### PR TITLE
Round-to-integer functions in math library

### DIFF
--- a/fpy2/math.py
+++ b/fpy2/math.py
@@ -233,21 +233,6 @@ def fma(x: Float, y: Float, z: Float, ctx: Context):
         raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_3ary(mpfr_fma, x, y, z, ctx)
 
-def fmod(x: Float, y: Float, ctx: Context):
-    """
-    Computes the remainder of `x / y` rounded under this context.
-
-    The remainder has the same sign as `x`; it is exactly `x - iquot * y`,
-    where `iquot` is the `x / y` with its fractional part truncated.
-    """
-    if not isinstance(x, Float):
-        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
-    if not isinstance(y, Float):
-        raise TypeError(f'Expected \'Float\', got \'{type(y)}\' for x={y}')
-    if not isinstance(ctx, Context):
-        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_2ary(mpfr_fmod, x, y, ctx)
-
 def fmax(x: Float, y: Float, ctx: Context):
     """Computes `max(x, y)` rounded under `ctx`."""
     if not isinstance(x, Float):
@@ -267,6 +252,21 @@ def fmin(x: Float, y: Float, ctx: Context):
     if not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_2ary(mpfr_fmin, x, y, ctx)
+
+def fmod(x: Float, y: Float, ctx: Context):
+    """
+    Computes the remainder of `x / y` rounded under this context.
+
+    The remainder has the same sign as `x`; it is exactly `x - iquot * y`,
+    where `iquot` is the `x / y` with its fractional part truncated.
+    """
+    if not isinstance(x, Float):
+        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
+    if not isinstance(y, Float):
+        raise TypeError(f'Expected \'Float\', got \'{type(y)}\' for x={y}')
+    if not isinstance(ctx, Context):
+        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
+    return _apply_2ary(mpfr_fmod, x, y, ctx)
 
 def hypot(x: Float, y: Float, ctx: Context):
     """Computes `sqrt(x * x + y * y)` rounded under `ctx`."""

--- a/fpy2/math.py
+++ b/fpy2/math.py
@@ -41,7 +41,7 @@ def _apply_3ary(func: MPFR_3ary, x: Float, y: Float, z: Float, ctx: Context):
 # General operations
 
 def acos(x: Float, ctx: Context):
-    """Computes `acos(x)` rounded under `ctx`."""
+    """Computes the inverse cosine of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -49,7 +49,7 @@ def acos(x: Float, ctx: Context):
     return _apply_1ary(mpfr_acos, x, ctx)
 
 def acosh(x: Float, ctx: Context):
-    """Computes `acosh(x)` rounded under `ctx`."""
+    """Computes the inverse hyperbolic cosine of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -67,7 +67,7 @@ def add(x: Float, y: Float, ctx: Context):
     return _apply_2ary(mpfr_add, x, y, ctx)
 
 def asin(x: Float, ctx: Context):
-    """Computes `asin(x)` rounded under `ctx`."""
+    """Computes the inverse sine of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -75,7 +75,7 @@ def asin(x: Float, ctx: Context):
     return _apply_1ary(mpfr_asin, x, ctx)
 
 def asinh(x: Float, ctx: Context):
-    """Computes `asinh(x)` rounded under `ctx`."""
+    """Computes the inverse hyperbolic sine of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -83,7 +83,7 @@ def asinh(x: Float, ctx: Context):
     return _apply_1ary(mpfr_asinh, x, ctx)
 
 def atan(x: Float, ctx: Context):
-    """Computes `atan(x)` rounded under `ctx`."""
+    """Computes the inverse tangent of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -91,7 +91,10 @@ def atan(x: Float, ctx: Context):
     return _apply_1ary(mpfr_atan, x, ctx)
 
 def atan2(y: Float, x: Float, ctx: Context):
-    """Computes `atan2(y, x)` rounded under `ctx`."""
+    """
+    Computes `atan(y / x)` taking into account the correct quadrant
+    that the point `(x, y)` resides in. The result is rounded under `ctx`.
+    """
     if not isinstance(y, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(y)}\' for x={y}')
     if not isinstance(x, Float):
@@ -101,7 +104,7 @@ def atan2(y: Float, x: Float, ctx: Context):
     return _apply_2ary(mpfr_atan2, y, x, ctx)
 
 def atanh(x: Float, ctx: Context):
-    """Computes `atanh(x)` rounded under `ctx`."""
+    """Computes the inverse hyperbolic tangent of `x` under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -109,7 +112,7 @@ def atanh(x: Float, ctx: Context):
     return _apply_1ary(mpfr_atanh, x, ctx)
 
 def cbrt(x: Float, ctx: Context):
-    """Computes `cbrt(x)` rounded under `ctx`."""
+    """Computes the cube root of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -117,7 +120,7 @@ def cbrt(x: Float, ctx: Context):
     return _apply_1ary(mpfr_cbrt, x, ctx)
 
 def copysign(x: Float, y: Float, ctx: Context):
-    """Computes `copysign(x, y)` rounded under `ctx`."""
+    """Returns `|x| * sign(y)` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(y, Float):
@@ -127,7 +130,7 @@ def copysign(x: Float, y: Float, ctx: Context):
     return _apply_2ary(mpfr_copysign, x, y, ctx)
 
 def cos(x: Float, ctx: Context):
-    """Computes `cos(x)` rounded under `ctx`."""
+    """Computes the cosine of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -135,7 +138,7 @@ def cos(x: Float, ctx: Context):
     return _apply_1ary(mpfr_cos, x, ctx)
 
 def cosh(x: Float, ctx: Context):
-    """Computes `cosh(x)` rounded under `ctx`."""
+    """Computes the hyperbolic cosine `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -153,7 +156,7 @@ def div(x: Float, y: Float, ctx: Context):
     return _apply_2ary(mpfr_div, x, y, ctx)
 
 def erf(x: Float, ctx: Context):
-    """Computes `erf(x)` rounded under `ctx`."""
+    """Computes the error function of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -161,7 +164,7 @@ def erf(x: Float, ctx: Context):
     return _apply_1ary(mpfr_erf, x, ctx)
 
 def erfc(x: Float, ctx: Context):
-    """Computes `erfc(x)` rounded under `ctx`."""
+    """Computes `1 - erf(x)` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -169,7 +172,7 @@ def erfc(x: Float, ctx: Context):
     return _apply_1ary(mpfr_erfc, x, ctx)
 
 def exp(x: Float, ctx: Context):
-    """Computes `exp(x)` rounded under `ctx`."""
+    """Computes `e ** x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -177,7 +180,7 @@ def exp(x: Float, ctx: Context):
     return _apply_1ary(mpfr_exp, x, ctx)
 
 def exp2(x: Float, ctx: Context):
-    """Computes `exp2(x)` rounded under `ctx`."""
+    """Computes `2 ** x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -185,7 +188,7 @@ def exp2(x: Float, ctx: Context):
     return _apply_1ary(mpfr_exp2, x, ctx)
 
 def exp10(x: Float, ctx: Context):
-    """Computes `exp10(x)` rounded under `ctx`."""
+    """Computes `10 *** x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -193,7 +196,7 @@ def exp10(x: Float, ctx: Context):
     return _apply_1ary(mpfr_exp10, x, ctx)
 
 def expm1(x: Float, ctx: Context):
-    """Computes `expm1(x)` rounded under `ctx`."""
+    """Computes `exp(x) - 1` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -201,7 +204,7 @@ def expm1(x: Float, ctx: Context):
     return _apply_1ary(mpfr_expm1, x, ctx)
 
 def fabs(x: Float, ctx: Context):
-    """Computes `fabs(x)` rounded under `ctx`."""
+    """Computes `|x|` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -209,7 +212,7 @@ def fabs(x: Float, ctx: Context):
     return _apply_1ary(mpfr_fabs, x, ctx)
 
 def fdim(x: Float, y: Float, ctx: Context):
-    """Computes `fdim(x, y)` rounded under `ctx`."""
+    """Computes `max(x - y, 0)` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(y, Float):
@@ -231,7 +234,12 @@ def fma(x: Float, y: Float, z: Float, ctx: Context):
     return _apply_3ary(mpfr_fma, x, y, z, ctx)
 
 def fmod(x: Float, y: Float, ctx: Context):
-    """Computes `fmod(x, y)` rounded under `ctx`."""
+    """
+    Computes the remainder of `x / y` rounded under this context.
+
+    The remainder has the same sign as `x`; it is exactly `x - iquot * y`,
+    where `iquot` is the `x / y` with its fractional part truncated.
+    """
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(y, Float):
@@ -241,7 +249,7 @@ def fmod(x: Float, y: Float, ctx: Context):
     return _apply_2ary(mpfr_fmod, x, y, ctx)
 
 def fmax(x: Float, y: Float, ctx: Context):
-    """Computes `fmax(x, y)` rounded under `ctx`."""
+    """Computes `max(x, y)` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(y, Float):
@@ -251,7 +259,7 @@ def fmax(x: Float, y: Float, ctx: Context):
     return _apply_2ary(mpfr_fmax, x, y, ctx)
 
 def fmin(x: Float, y: Float, ctx: Context):
-    """Computes `fmin(x, y)` rounded under `ctx`."""
+    """Computes `min(x, y)` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(y, Float):
@@ -271,7 +279,7 @@ def hypot(x: Float, y: Float, ctx: Context):
     return _apply_2ary(mpfr_hypot, x, y, ctx)
 
 def lgamma(x: Float, ctx: Context):
-    """Computes `lgamma(x)` rounded under `ctx`."""
+    """Computes the log-gamma of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -354,7 +362,7 @@ def remainder(x: Float, y: Float, ctx: Context):
     return _apply_2ary(mpfr_remainder, x, y, ctx)
 
 def sin(x: Float, ctx: Context):
-    """Computes `sin(x)` rounded under `ctx`."""
+    """Computes the sine of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -362,7 +370,7 @@ def sin(x: Float, ctx: Context):
     return _apply_1ary(mpfr_sin, x, ctx)
 
 def sinh(x: Float, ctx: Context):
-    """Computes `sinh(x)` rounded under `ctx`."""
+    """Computes the hyperbolic sine of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -370,7 +378,7 @@ def sinh(x: Float, ctx: Context):
     return _apply_1ary(mpfr_sinh, x, ctx)
 
 def sqrt(x: Float, ctx: Context):
-    """Computes `sqrt(x)` rounded under `ctx`."""
+    """Computes square-root of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -388,7 +396,7 @@ def sub(x: Float, y: Float, ctx: Context):
     return _apply_2ary(mpfr_sub, x, y, ctx)
 
 def tan(x: Float, ctx: Context):
-    """Computes `tan(x)` rounded under `ctx`."""
+    """Computes the tangent of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -396,7 +404,7 @@ def tan(x: Float, ctx: Context):
     return _apply_1ary(mpfr_tan, x, ctx)
 
 def tanh(x: Float, ctx: Context):
-    """Computes `tanh(x)` rounded under `ctx`."""
+    """Computes the hyperbolic tangent of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):
@@ -404,7 +412,7 @@ def tanh(x: Float, ctx: Context):
     return _apply_1ary(mpfr_tanh, x, ctx)
 
 def tgamma(x: Float, ctx: Context):
-    """Computes `tgamma(x)` rounded under `ctx`."""
+    """Computes gamma of `x` rounded under `ctx`."""
     if not isinstance(x, Float):
         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
     if not isinstance(ctx, Context):

--- a/fpy2/math.py
+++ b/fpy2/math.py
@@ -409,3 +409,27 @@ def tgamma(x: Float, ctx: Context):
     if not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_1ary(mpfr_tgamma, x, ctx)
+
+#############################################################################
+# Round-to-integer operations
+
+# def ceil(x: Float, ctx: Context):
+#     """
+#     Computes the nearest integer greater than or equal to `x`
+#     representable under `ctx`.
+#     """
+#     if not isinstance(x, Float):
+#         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
+#     if not isinstance(ctx, Context):
+#         raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
+#     return ctx.round_integer(x)
+
+# def floor(x: Float, ctx: Context):
+
+
+
+# # ceil
+# # floor
+# # trunc
+# # round
+# # nearbyint

--- a/fpy2/math.py
+++ b/fpy2/math.py
@@ -464,19 +464,6 @@ def trunc(x: Float, ctx: Context):
 
 def nearbyint(x: Float, ctx: Context):
     """
-    Computes the nearest integer to `x`, preferring the even
-    one in case of ties; the result is representable under `ctx`.
-
-    If the context supports overflow, the result may be infinite.
-    """
-    if not isinstance(x, Float):
-        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
-    if not isinstance(ctx, Context):
-        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
-    return ctx.with_rm(RoundingMode.RNE).round_integer(x)
-
-def round(x: Float, ctx: Context):
-    """
     Rounds `x` to a representable integer according to
     the rounding mode of this context.
 
@@ -487,3 +474,16 @@ def round(x: Float, ctx: Context):
     if not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
     return ctx.round_integer(x)
+
+def round(x: Float, ctx: Context):
+    """
+    Rounds `x` to the nearest representable integer,
+    rounding tiews away from zero in halfway cases.
+
+    If the context supports overflow, the result may be infinite.
+    """
+    if not isinstance(x, Float):
+        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
+    if not isinstance(ctx, Context):
+        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
+    return ctx.with_rm(RoundingMode.RNA).round_integer(x)

--- a/fpy2/math.py
+++ b/fpy2/math.py
@@ -8,12 +8,12 @@ from .number import Context, Float
 from .number.gmp import *
 from .number.round import RoundingMode
 
-MPFR_1ary: TypeAlias = Callable[[Float, int], Float]
-MPFR_2ary: TypeAlias = Callable[[Float, Float, int], Float]
-MPFR_3ary: TypeAlias = Callable[[Float, Float, Float, int], Float]
+_MPFR_1ary: TypeAlias = Callable[[Float, int], Float]
+_MPFR_2ary: TypeAlias = Callable[[Float, Float, int], Float]
+_MPFR_3ary: TypeAlias = Callable[[Float, Float, Float, int], Float]
 
 
-def _apply_1ary(func: MPFR_1ary, x: Float, ctx: Context):
+def _apply_1ary(func: _MPFR_1ary, x: Float, ctx: Context):
     p, n = ctx.round_params()
     if p is None:
         raise NotImplementedError(f'p={p}, n={n}')
@@ -21,7 +21,7 @@ def _apply_1ary(func: MPFR_1ary, x: Float, ctx: Context):
         r = func(x, p)       # compute with round-to-odd (safe at p digits)
         return ctx.round(r)  # re-round under desired rounding mode
 
-def _apply_2ary(func: MPFR_2ary, x: Float, y: Float, ctx: Context):
+def _apply_2ary(func: _MPFR_2ary, x: Float, y: Float, ctx: Context):
     p, n = ctx.round_params()
     if p is None:
         raise NotImplementedError(f'p={p}, n={n}')
@@ -29,7 +29,7 @@ def _apply_2ary(func: MPFR_2ary, x: Float, y: Float, ctx: Context):
         r = func(x, y, p)    # compute with round-to-odd (safe at p digits)
         return ctx.round(r)  # re-round under desired rounding mode
 
-def _apply_3ary(func: MPFR_3ary, x: Float, y: Float, z: Float, ctx: Context):
+def _apply_3ary(func: _MPFR_3ary, x: Float, y: Float, z: Float, ctx: Context):
     p, n = ctx.round_params()
     if p is None:
         raise NotImplementedError(f'p={p}, n={n}')

--- a/fpy2/math.py
+++ b/fpy2/math.py
@@ -6,6 +6,7 @@ from typing import Callable, TypeAlias
 
 from .number import Context, Float
 from .number.gmp import *
+from .number.round import RoundingMode
 
 MPFR_1ary: TypeAlias = Callable[[Float, int], Float]
 MPFR_2ary: TypeAlias = Callable[[Float, Float, int], Float]
@@ -413,23 +414,68 @@ def tgamma(x: Float, ctx: Context):
 #############################################################################
 # Round-to-integer operations
 
-# def ceil(x: Float, ctx: Context):
-#     """
-#     Computes the nearest integer greater than or equal to `x`
-#     representable under `ctx`.
-#     """
-#     if not isinstance(x, Float):
-#         raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
-#     if not isinstance(ctx, Context):
-#         raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
-#     return ctx.round_integer(x)
+def ceil(x: Float, ctx: Context):
+    """
+    Computes the smallest integer greater than or equal to `x`
+    that is representable under `ctx`.
 
-# def floor(x: Float, ctx: Context):
+    If the context supports overflow, the result may be infinite.
+    """
+    if not isinstance(x, Float):
+        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
+    if not isinstance(ctx, Context):
+        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
+    return ctx.with_rm(RoundingMode.RTP).round_integer(x)
 
+def floor(x: Float, ctx: Context):
+    """
+    Computes the largest integer less than or equal to `x`
+    that is representable under `ctx`.
 
+    If the context supports overflow, the result may be infinite.
+    """
+    if not isinstance(x, Float):
+        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
+    if not isinstance(ctx, Context):
+        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
+    return ctx.with_rm(RoundingMode.RTN).round_integer(x)
 
-# # ceil
-# # floor
-# # trunc
-# # round
-# # nearbyint
+def trunc(x: Float, ctx: Context):
+    """
+    Computes the integer with the largest magnitude whose
+    magnitude is less than or equal to the magntidue of `x`
+    that is representable under `ctx`.
+
+    If the context supports overflow, the result may be infinite.
+    """
+    if not isinstance(x, Float):
+        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
+    if not isinstance(ctx, Context):
+        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
+    return ctx.with_rm(RoundingMode.RTZ).round_integer(x)
+
+def nearbyint(x: Float, ctx: Context):
+    """
+    Computes the nearest integer to `x`, preferring the even
+    one in case of ties; the result is representable under `ctx`.
+
+    If the context supports overflow, the result may be infinite.
+    """
+    if not isinstance(x, Float):
+        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
+    if not isinstance(ctx, Context):
+        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
+    return ctx.with_rm(RoundingMode.RNE).round_integer(x)
+
+def round(x: Float, ctx: Context):
+    """
+    Rounds `x` to a representable integer according to
+    the rounding mode of this context.
+
+    If the context supports overflow, the result may be infinite.
+    """
+    if not isinstance(x, Float):
+        raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
+    if not isinstance(ctx, Context):
+        raise TypeError(f'Expected \'Context\', got \'{type(ctx)}\' for x={ctx}')
+    return ctx.round_integer(x)

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -69,6 +69,36 @@ class Context(ABC):
         """Rounds any digital number according to this context."""
         raise NotImplementedError('virtual method')
 
+    @abstractmethod
+    def round_at(self, x, n: int) -> Float:
+        """
+        Rounding any digital number of a representable value with
+        an unnormalized exponent of at minimum `n + 1`.
+
+        Rounding is done by the following rules:
+         - if `x` is representable and has an unnormalized exponent
+           of at minimum `n + 1`, then `self.round_n(x, n) == x`
+         - if `x` is between two representable values `i1 < x < i2`
+           where both `i1` and `i2` have unnormalized exponents of at
+           minimum `n + 1`,  then the context information determines
+           which value is returned.
+        """
+        raise NotImplementedError('virtual method')
+
+    def round_integer(self, x) -> Float:
+        """
+        Rounds any digital number to an integer according to this context.
+
+        Rounding is done by the following rules:
+         - if `x` is a representable integer, then `self.round_integer(x) == x`
+         - if `x` is between two representable integers `i1 < x < i2`,
+          then the context information determines which integer
+          is returned.
+
+        This is equivalent to `self.round_at(x, -1)`.
+        """
+        return self.round_at(x, -1)
+
 
 class OrdinalContext(Context):
     """

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -3,7 +3,9 @@ This module defines the rounding context type.
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional, TypeAlias, Union
+from typing import Optional, TypeAlias, Self, Union
+
+from .round import RoundingMode
 
 from . import number
 from . import real
@@ -29,6 +31,11 @@ class Context(ABC):
     when in isolation. The characteristics of the rounding operation are
     summarized by this type.
     """
+
+    @abstractmethod
+    def with_rm(self, rm: RoundingMode) -> Self:
+        """Returns `self` but with rounding mode `rm`."""
+        raise NotImplementedError('virtual method')
 
     @abstractmethod
     def is_representable(self, x: Union[Float, RealFloat]) -> bool:

--- a/fpy2/number/gmp.py
+++ b/fpy2/number/gmp.py
@@ -39,8 +39,16 @@ def _round_odd(x: gmp.mpfr, inexact: bool):
         return Float(s=s, c=c, exp=exp)
 
 def float_to_mpfr(x: RealFloat | Float):
-    fmt = f'{_bool_to_sign(x.s)}{hex(x.c)}p{x.exp}'
-    return gmp.mpfr(fmt, precision=x.p, base=16)
+    if isinstance(x, Float) and x.is_nar():
+        if x.isnan:
+            s = '-' if x.s else '+'
+            return gmp.mpfr(f'{s}nan')
+        else: # x.isinf
+            s = '-' if x.s else '+'
+            return gmp.mpfr(f'{s}inf')
+    else:
+        fmt = f'{_bool_to_sign(x.s)}{hex(x.c)}p{x.exp}'
+        return gmp.mpfr(fmt, precision=x.p, base=16)
 
 def mpfr_constant(x, prec: int):
     """

--- a/fpy2/number/ieee754.py
+++ b/fpy2/number/ieee754.py
@@ -115,6 +115,9 @@ class IEEEContext(EncodableContext):
         """The exponent "bias" as defined by the IEEE 754 standard."""
         return self.emax
 
+    def with_rm(self, rm: RoundingMode):
+        return IEEEContext(self.es, self.nbits, rm)
+
     def is_zero(self, x: Float):
         """Returns if `x` is a zero number."""
         return x.is_zero()

--- a/fpy2/number/ieee754.py
+++ b/fpy2/number/ieee754.py
@@ -160,6 +160,11 @@ class IEEEContext(EncodableContext):
         rounded.ctx = self
         return rounded
 
+    def round_at(self, x, n: int) -> Float:
+        rounded = self._mpb_ctx.round_at(x, n)
+        rounded.ctx = self
+        return rounded
+
     def to_ordinal(self, x: Float, infval = False) -> int:
         if not isinstance(x, Float) or not self.is_representable(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')

--- a/fpy2/number/mp.py
+++ b/fpy2/number/mp.py
@@ -41,6 +41,9 @@ class MPContext(Context):
         self.pmax = pmax
         self.rm = rm
 
+    def with_rm(self, rm: RoundingMode):
+        return MPContext(self.pmax, rm)
+
     def is_representable(self, x: RealFloat | Float) -> bool:
         if not isinstance(x, RealFloat | Float):
             raise TypeError(f'Expected \'RealFloat\' or \'Float\', got \'{type(x)}\' for x={x}')

--- a/fpy2/number/mpb.py
+++ b/fpy2/number/mpb.py
@@ -128,6 +128,9 @@ class MPBContext(SizedContext):
         """
         return self._mps_ctx.nmin
 
+    def with_rm(self, rm: RoundingMode):
+        return MPBContext(self.pmax, self.emin, self.pos_maxval, rm, neg_maxval=self.neg_maxval)
+
     def is_representable(self, x: RealFloat | Float) -> bool:
         if not isinstance(x, RealFloat | Float):
             raise TypeError(f'Expected \'RealFloat\' or \'Float\', got \'{type(x)}\' for x={x}')

--- a/fpy2/number/mpb.py
+++ b/fpy2/number/mpb.py
@@ -186,8 +186,13 @@ class MPBContext(SizedContext):
             case _:
                 raise RuntimeError(f'unrechable {direction}')
 
-    def _round_float(self, x: RealFloat | Float):
-        """Like `self.round()` but for only `RealFloat` and `Float` inputs"""
+    def _round_float_at(self, x: RealFloat | Float, n: Optional[int]) -> Float:
+        """
+        Like `self.round()` but for only `RealFloat` and `Float` inputs.
+
+        Optionally specify `n` as the least absolute digit position.
+        Only overrides rounding behavior when `n > self.nmin`.
+        """
         # step 1. handle special values
         if isinstance(x, Float):
             if x.isnan:
@@ -202,10 +207,15 @@ class MPBContext(SizedContext):
             # exactly zero
             return Float(ctx=self)
 
-        # step 3. round value based on rounding parameters
-        rounded = x.round(self.pmax, self.nmin, self.rm)
+        # step 3. select rounding parameter `n`
+        if n is None or n < self.nmin:
+            # no rounding parameter
+            n = self.nmin
 
-        # step 4. check for overflow
+        # step 4. round value based on rounding parameters
+        rounded = x.round(self.pmax, n, self.rm)
+
+        # step 5. check for overflow
         if self._is_overflowing(rounded):
             # overflowing => check which way to round
             if self._overflow_to_infinity(rounded):
@@ -216,10 +226,10 @@ class MPBContext(SizedContext):
                 max_val = self.maxval(rounded.s)
                 return Float(x=max_val, ctx=self)
 
-        # step 5. return rounded result
+        # step 6. return rounded result
         return Float(x=rounded, ctx=self)
 
-    def round(self, x):
+    def _round_at(self, x, n: Optional[int]) -> Float:
         match x:
             case Float() | RealFloat():
                 xr = x
@@ -235,7 +245,13 @@ class MPBContext(SizedContext):
             case _:
                 raise TypeError(f'not valid argument x={x}')
 
-        return self._round_float(xr)
+        return self._round_float_at(xr, n)
+
+    def round(self, x) -> Float:
+        return self._round_at(x, None)
+
+    def round_at(self, x, n: int) -> Float:
+        return self._round_at(x, n)
 
     def to_ordinal(self, x: Float, infval = False):
         if not isinstance(x, Float) or not self.is_representable(x):

--- a/fpy2/number/mps.py
+++ b/fpy2/number/mps.py
@@ -70,6 +70,9 @@ class MPSContext(OrdinalContext):
         """
         return self.expmin - 1
 
+    def with_rm(self, rm: RoundingMode):
+        return MPSContext(self.pmax, self.emin, rm)
+
     def is_representable(self, x: RealFloat | Float) -> bool:
         if not isinstance(x, RealFloat | Float):
             raise TypeError(f'Expected \'RealFloat\' or \'Float\', got \'{type(x)}\' for x={x}')

--- a/tests/math/test_mpfr.py
+++ b/tests/math/test_mpfr.py
@@ -1,0 +1,159 @@
+import gmpy2 as gmp
+import random
+import unittest
+
+from typing import Any, Callable
+
+from fpy2 import IEEEContext, RM
+from fpy2.math import *
+from fpy2.number.gmp import float_to_mpfr, mpfr_to_float
+
+def _gmp_neg(x):
+    return -x
+
+def _gmp_abs(x):
+    return abs(x)
+
+def _gmp_pow(x, y):
+    return x ** y
+
+def _gmp_lgamma(x):
+    y, _ = gmp.lgamma(x)
+    return y
+
+
+_unary_ops = {
+    acos : gmp.acos,
+    acosh: gmp.acosh,
+    asin: gmp.asin,
+    asinh: gmp.asinh,
+    atan: gmp.atan,
+    atanh : gmp.atanh,
+    cbrt : gmp.cbrt,
+    cos : gmp.cos,
+    cosh : gmp.cosh,
+    erf : gmp.erf,
+    erfc : gmp.erfc,
+    exp : gmp.exp,
+    exp2 : gmp.exp2,
+    exp10 : gmp.exp10,
+    expm1 : gmp.expm1,
+    fabs : _gmp_abs,
+    lgamma : _gmp_lgamma,
+    log : gmp.log,
+    log10 : gmp.log10,
+    log1p : gmp.log1p,
+    log2 : gmp.log2,
+    neg : _gmp_neg,
+    sin : gmp.sin,
+    sinh : gmp.sinh,
+    sqrt : gmp.sqrt,
+    tan : gmp.tan,
+    tanh : gmp.tanh,
+    tgamma : gmp.gamma,
+    ceil : gmp.ceil,
+    floor : gmp.floor,
+    trunc : gmp.trunc,
+    nearbyint : gmp.rint,
+    round : gmp.round_away
+}
+
+# _binary_ops = {
+#     add : gmp.add,
+#     atan2 : gmp.atan2,
+#     copysign : gmp.copysign,
+#     div : gmp.div,
+#     fdim : gmp.fdim,
+#     fmax,
+#     fmin,
+#     fmod,
+#     hypot,
+#     mul,
+#     pow,
+#     remainder
+# }
+
+# _ternary_ops = [
+#     fma
+# ]
+
+_rms = [
+    RM.RNE,
+    # RM.RNA,
+    RM.RTP,
+    RM.RTN,
+    RM.RTZ,
+    RM.RAZ
+]
+
+_ctxs = [
+    IEEEContext(11, 64, RM.RNE),
+    IEEEContext(8, 32, RM.RNE),
+    IEEEContext(5, 16, RM.RNE),
+    IEEEContext(5, 8, RM.RNE)
+]
+
+
+def _mpfr_rm(rm: RM):
+    match rm:
+        case RM.RNE:
+            return gmp.RoundToNearest
+        case RM.RTP:
+            return gmp.RoundUp
+        case RM.RTN:
+            return gmp.RoundDown
+        case RM.RTZ:
+            return gmp.RoundToZero
+        case RM.RAZ:
+            return gmp.RoundAwayZero
+        case _:
+            raise ValueError(f'Unsupported rounding mode: {rm}')
+
+def _mpfr_apply(
+    op: Callable,
+    xs: tuple[Float, ...],
+    ctx: IEEEContext
+):
+    with gmp.context(
+        precision=ctx.pmax,
+        emin=ctx.expmin + 1,
+        emax=ctx.emax + 1,
+        subnormalize=True,
+        round=_mpfr_rm(ctx.rm),
+        trap_underflow=False,
+        trap_overflow=False,
+        trap_inexact=False,
+        trap_divzero=False,
+    ):
+        y = op(*map(float_to_mpfr, xs))
+        return mpfr_to_float(y)
+
+
+class MPFREquivTestCase(unittest.TestCase):
+    """
+    Fuzz testing under `fpy2.math`.
+
+    Ensures that the operations in `fpy2.math` match those from MPFR.
+    """
+
+    def test_fuzz_unary(self, num_inputs: int = 256):
+        for op, mpfr in _unary_ops.items():
+            for ctx_base in _ctxs:
+                for rm in _rms:
+                    ctx = ctx_base.with_rm(rm)
+                    for _ in range(num_inputs):
+                        # sample point
+                        i = random.randint(0, 1 << ctx.nbits - 1)
+                        x = ctx.decode(i)
+                        # evaluate operation
+                        y = op(x, ctx)
+                        # evaluate equivalent operation
+                        r = _mpfr_apply(mpfr, (x,), ctx)
+                        ref = ctx.round(r)
+                        # sanity check: ref should be exact
+                        assert not ref.inexact
+                        # check that they are the same
+                        if y.isnan:
+                            self.assertTrue(y.isnan, f'op={op}, rm={rm}, x={x}, y={y}, ref={ref}')
+                        else:
+                            self.assertEqual(y, ref, f'op={op}, rm={rm}, x={x}, y={y}, ref={ref}')

--- a/tests/math/test_ops.py
+++ b/tests/math/test_ops.py
@@ -88,8 +88,39 @@ class MathNoExceptTestCase(unittest.TestCase):
                 for rm in _rms:
                     ctx = ctx_base.with_rm(rm)
                     for _ in range(num_inputs):
-                        # sample point and evaluate
+                        # sample point
                         i = random.randint(0, 1 << ctx.nbits - 1)
                         x = ctx.decode(i)
+                        # evaluate
                         op(x, ctx)
 
+
+    def test_fuzz_binary(self, num_inputs: int = 256):
+        for op in _binary_ops:
+            for ctx_base in _ctxs:
+                for rm in _rms:
+                    ctx = ctx_base.with_rm(rm)
+                    for _ in range(num_inputs):
+                        # sample point
+                        i = random.randint(0, 1 << ctx.nbits - 1)
+                        j = random.randint(0, 1 << ctx.nbits - 1)
+                        x = ctx.decode(i)
+                        y = ctx.decode(j)
+                        # evaluate
+                        op(x, y, ctx)
+
+    def test_fuzz_ternary(self, num_inputs: int = 256):
+        for op in _ternary_ops:
+            for ctx_base in _ctxs:
+                for rm in _rms:
+                    ctx = ctx_base.with_rm(rm)
+                    for _ in range(num_inputs):
+                        # sample point
+                        i = random.randint(0, 1 << ctx.nbits - 1)
+                        j = random.randint(0, 1 << ctx.nbits - 1)
+                        k = random.randint(0, 1 << ctx.nbits - 1)
+                        x = ctx.decode(i)
+                        y = ctx.decode(j)
+                        z = ctx.decode(k)
+                        # evaluate
+                        op(x, y, z, ctx)

--- a/tests/math/test_ops.py
+++ b/tests/math/test_ops.py
@@ -1,0 +1,95 @@
+import random
+import unittest
+
+from fpy2 import IEEEContext, RM
+from fpy2.math import *
+
+_unary_ops = [
+    acos,
+    acosh,
+    asin,
+    atan,
+    atanh,
+    cbrt,
+    cos,
+    cosh,
+    erf,
+    erfc,
+    exp,
+    exp2,
+    exp10,
+    expm1,
+    fabs,
+    lgamma,
+    log,
+    log10,
+    log1p,
+    log2,
+    neg,
+    sin,
+    sinh,
+    sqrt,
+    tan,
+    tanh,
+    tgamma,
+    ceil,
+    floor,
+    trunc,
+    nearbyint,
+    round
+]
+
+_binary_ops = [
+    add,
+    atan2,
+    copysign,
+    div,
+    fdim,
+    fmax,
+    fmin,
+    fmod,
+    hypot,
+    mul,
+    pow,
+    remainder
+]
+
+_ternary_ops = [
+    fma
+]
+
+_rms = [
+    RM.RNE,
+    RM.RNA,
+    RM.RTP,
+    RM.RTN,
+    RM.RTZ,
+    RM.RAZ
+]
+
+_ctxs = [
+    IEEEContext(11, 64, RM.RNE),
+    IEEEContext(8, 32, RM.RNE),
+    IEEEContext(5, 16, RM.RNE),
+    IEEEContext(5, 8, RM.RNE)
+]
+
+class MathNoExceptTestCase(unittest.TestCase):
+    """
+    Fuzz testing for each operation under `fpy2.math`.
+
+    Ensures that the operations in `fpy2.math` don't
+    throw an exception for randomly sampled inputs.
+    """
+
+    def test_fuzz_unary(self, num_inputs: int = 256):
+        for op in _unary_ops:
+            for ctx_base in _ctxs:
+                for rm in _rms:
+                    ctx = ctx_base.with_rm(rm)
+                    for _ in range(num_inputs):
+                        # sample point and evaluate
+                        i = random.randint(0, 1 << ctx.nbits - 1)
+                        x = ctx.decode(i)
+                        op(x, ctx)
+

--- a/tests/math/test_ops.py
+++ b/tests/math/test_ops.py
@@ -8,6 +8,7 @@ _unary_ops = [
     acos,
     acosh,
     asin,
+    asinh,
     atan,
     atanh,
     cbrt,

--- a/tests/numbers/test_round.py
+++ b/tests/numbers/test_round.py
@@ -18,7 +18,6 @@ class RoundTestCase(unittest.TestCase):
             (0, 0b101010, 3, 2, 3, 2), # 0b101010 * 2 ** 0, max_p=3, min_n=2 => p=3, n=2
             (0, 0b101010, 3, 5, 3, 5), # 0b101010 * 2 ** 0, max_p=3, min_n=5 => p=3, n=5
             (0, 0b10, 3, 3, 3, 3), # 0b10 * 2 ** 0, max_p=3, min_n=3 => p=3, n=3
-            
         ]
 
         for exp, c, max_p, min_n, expect_p, expect_n in inputs:


### PR DESCRIPTION
This PR adds round-to-integer functions under `fpy2.math` including `ceil`, `floor`,  `nearestint`, `round`, and `trunc`. These functions are supported by new `round_integer` and `round_at` functions for the `Context` interface. Also adds tests for `fpy2.math` including fuzzing for crashes and comparison against MPFR.