### PR TITLE
Exact rounding / static constructors for `Float`

### DIFF
--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -163,6 +163,54 @@ class Float:
         fn = get_current_float_converter()
         return fn(self)
 
+    @staticmethod
+    def from_real(x: RealFloat, ctx: Optional[Context] = None) -> 'Float':
+        """
+        Converts a `RealFloat` number to a `Float` number.
+
+        Optionally specify a rounding context under which to
+        construct this value. If a rounding context is specified,
+        `x` must be representable under `ctx`.
+        """
+        if not isinstance(x, RealFloat):
+            raise TypeError(f'expected RealFloat, got {type(x)}')
+
+        f = Float(x=x, ctx=ctx)
+        if ctx is None:
+            return f
+        else:
+            if not f.is_representable():
+                raise ValueError(f'{x} is not representable under {ctx}')
+            return f.normalize()
+
+    @staticmethod
+    def from_int(x: int, ctx: Optional[Context] = None) -> 'Float':
+        """
+        Converts an integer to a `Float` number.
+
+        Optionally specify a rounding context under which to
+        construct this value. If a rounding context is specified,
+        `x` must be representable under `ctx`.
+        """
+        if not isinstance(x, int):
+            raise TypeError(f'expected int, got {type(x)}')
+
+        return Float.from_real(RealFloat.from_int(x), ctx)
+
+    @staticmethod
+    def from_float(x: float, ctx: Optional[Context] = None) -> 'Float':
+        """
+        Converts a native Python float to a `Float` number.
+
+        Optionally specify a rounding context under which to
+        construct this value. If a rounding context is specified,
+        `x` must be representable under `ctx`.
+        """
+        if not isinstance(x, float):
+            raise TypeError(f'expected int, got {type(x)}')
+
+        return Float.from_real(RealFloat.from_float(x), ctx)
+
     @property
     def base(self):
         """Integer base of this number. Always 2."""

--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -352,6 +352,36 @@ class Float:
             raise ValueError(f'cannot normalize without a context: self={self}')
         return self.ctx.normalize(self)
 
+    def round(self, ctx: Context):
+        """
+        Rounds this number under the given context.
+
+        This method is equivalent to `ctx.round(self)`.
+        """
+        if not isinstance(ctx, Context):
+            raise TypeError(f'expected Context, got {type(ctx)}')
+        return ctx.round(self)
+
+    def round_at(self, ctx: Context, n: int) -> 'Float':
+        """
+        Rounds this number at the given position.
+
+        This method is equivalent to `self.ctx.round_at(self, n)`.
+        """
+        if not isinstance(ctx, Context):
+            raise TypeError(f'expected Context, got {type(ctx)}')
+        return ctx.round_at(self, n)
+
+    def round_integer(self, ctx: Context) -> 'Float':
+        """
+        Rounds this number to the nearest integer.
+
+        This method is equivalent to `self.ctx.round_integer(self)`.
+        """
+        if not isinstance(ctx, Context):
+            raise TypeError(f'expected Context, got {type(ctx)}')
+        return ctx.round_integer(self)
+
     def compare(self, other: Self | RealFloat) -> Optional[Ordering]:
         """
         Compare `self` and `other` values returning an `Optional[Ordering]`.

--- a/fpy2/number/real.py
+++ b/fpy2/number/real.py
@@ -919,6 +919,19 @@ class RealFloat(numbers.Rational):
 
         return kept, half_bit, lower_bits
 
+    def round_at_exact(self, n: int):
+        """
+        Like `self.round_at()` except that the result must be exact.
+        Raises a `ValueError` if the result is not exact.
+
+        See `self.round_at()` for more information.
+        """
+
+        kept, lost = self.split(n)
+        if not lost.is_zero():
+            raise ValueError(f'rounding off digits: n={n}, x={self}')
+        return kept
+
 
     def round(
         self,
@@ -957,3 +970,22 @@ class RealFloat(numbers.Rational):
         # step 3. finalize the rounding operation
         return self._round_finalize(kept, half_bit, lower_bits, p, rm)
 
+    def round_exact(
+        self,
+        max_p: Optional[int] = None,
+        min_n: Optional[int] = None
+    ):
+        """
+        Like `self.round()` except the result must be exact.
+        Raises a `ValueError` if the result is not exact.
+
+        See `self.round()` for more information.
+        """
+        if max_p is None and min_n is None:
+            raise ValueError(f'must specify {max_p} or {min_n}')
+
+        # step 1. compute rounding parameters
+        _, n = self._round_params(max_p, min_n)
+
+        # step 2. split the number at the rounding position
+        return self.round_at_exact(n)


### PR DESCRIPTION
This PR adds:
 - exact rounding methods for `RealFloat`: methods that produce values as if rounded but asserts that no digits were lost
 - static constructors for `Float`: exact construction from `int`, `float`, etc.
 - rounding methods on `Float`: equivalent to `round` for contexts