### PR TITLE
New context syntax

### DIFF
--- a/docs/notes/TODO.md
+++ b/docs/notes/TODO.md
@@ -9,6 +9,8 @@ Frontend:
  - language:
    - support for zip()
    - support for vector addition/multiplication
+ - formatter:
+   - use IndentCtx
 
 Middle-end:
  - do we really need a separate AST / IR?

--- a/docs/notes/TODO.md
+++ b/docs/notes/TODO.md
@@ -29,8 +29,11 @@ Backend:
     - detect multi-variable for loops
 
 Misc:
-  - Rational contains a Fraction
-  - decnum and hexnum conversion to Fraction
+ - Rational contains a Fraction
+ - decnum and hexnum conversion to Fraction
+
+Interpreters:
+ - integrate FPCoreContext into other interpreters
 
 Numbers:
   - hashing by numerical equality (except NaN!)

--- a/fpy2/__init__.py
+++ b/fpy2/__init__.py
@@ -44,7 +44,7 @@ from .number import (
     FP8P1, FP8P2, FP8P3, FP8P4, FP8P5, FP8P6, FP8P7
 )
 
-from .frontend import FPCoreContext
+from .fpc_context import FPCoreContext, NoSuchContextError
 
 from .decorator import fpy, pattern
 

--- a/fpy2/__init__.py
+++ b/fpy2/__init__.py
@@ -44,6 +44,8 @@ from .number import (
     FP8P1, FP8P2, FP8P3, FP8P4, FP8P5, FP8P6, FP8P7
 )
 
+from .frontend import FPCoreContext
+
 from .decorator import fpy, pattern
 
 from .backend import (

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -33,6 +33,9 @@ class _LiveVars(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: None) -> _RetType:
         return set()
 
+    def _visit_context_val(self, e: ContextVal, ctx: None) -> _RetType:
+        return set()
+
     def _visit_decnum(self, e: Decnum, ctx: None) -> _RetType:
         return set()
 

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -199,9 +199,8 @@ class _FormatterInstance(AstVisitor):
         self._visit_block(stmt.body, ctx + 1)
 
     def _visit_context(self, stmt: ContextStmt, ctx: _Ctx):
-        # TODO: format data
         context = self._visit_expr(stmt.ctx, ctx)
-        self._add_line(f'with {context}:', ctx)
+        self._add_line(f'with {context} as {str(stmt.name)}:', ctx)
         self._visit_block(stmt.body, ctx + 1)
 
     def _visit_assert(self, stmt: AssertStmt, ctx: _Ctx):

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -41,6 +41,9 @@ class _FormatterInstance(AstVisitor):
     def _visit_bool(self, e: BoolVal, ctx: _Ctx):
         return str(e.val)
 
+    def _visit_context_val(self, e: ContextVal, ctx):
+        return repr(e.val)
+
     def _visit_decnum(self, e: Decnum, ctx: _Ctx):
         return e.val
 

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -6,7 +6,7 @@ import ast as pyast
 
 from abc import ABC, abstractmethod
 from enum import IntEnum
-from typing import Any, Optional, Self, Sequence
+from typing import Any, Optional, Self, Sequence, Mapping
 from ..utils import CompareOp, Id, NamedId, UnderscoreId, Location, default_repr
 
 
@@ -601,24 +601,27 @@ class ContextExpr(Expr):
     """FPy AST: context constructor"""
     ctor: Var | ForeignAttribute
     args: list[Expr | ForeignAttribute]
+    kwargs: list[tuple[str, Expr | ForeignAttribute]]
 
     def __init__(
         self,
         ctor: Var | ForeignAttribute,
         args: Sequence[Expr | ForeignAttribute],
+        kwargs: Sequence[tuple[str, Expr | ForeignAttribute]],
         loc: Optional[Location]
     ):
         super().__init__(loc)
         self.ctor = ctor
         self.args = list(args)
+        self.kwargs = list(kwargs)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ContextExpr):
             return False
-        return self.ctor == other.ctor and self.args == other.args
+        return self.ctor == other.ctor and self.args == other.args and self.kwargs == other.kwargs
 
     def __hash__(self) -> int:
-        return hash((self.ctor, tuple(self.args)))
+        return hash((self.ctor, tuple(self.args), tuple(self.kwargs)))
 
 
 class ContextAttribute(Ast):

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -895,13 +895,13 @@ class ForStmt(Stmt):
 
 class ContextStmt(Stmt):
     """FPy AST: with statement"""
-    name: Optional[Id]
+    name: Id
     ctx: ContextExpr | Var
     body: StmtBlock
 
     def __init__(
         self,
-        name: Optional[Id],
+        name: Id,
         ctx: ContextExpr | Var,
         body: StmtBlock,
         loc: Optional[Location]

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -592,7 +592,7 @@ class IfExpr(Expr):
         return hash((self.cond, self.ift, self.iff))
 
 
-class ContextExpr(Ast):
+class ContextExpr(Expr):
     """FPy AST: context constructor"""
     ctor: pyast.expr
     args: list[Expr]

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -197,27 +197,6 @@ class Var(ValueExpr):
     def __hash__(self) -> int:
         return hash(self.name)
 
-class ForeignAttribute(ValueExpr):
-    """
-    FPy AST: attribute of a foreign object, e.g., `x.y`
-    Attributes may be nested, e.g., `x.y.z`.
-    """
-    name: NamedId
-    attrs: list[NamedId]
-
-    def __init__(self, name: NamedId, attrs: Sequence[NamedId], loc: Optional[Location]):
-        super().__init__(loc)
-        self.name = name
-        self.attrs = list(attrs)
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ForeignAttribute):
-            return False
-        return self.name == other.name and self.attrs == other.attrs
-
-    def __hash__(self) -> int:
-        return hash((self.name, tuple(self.attrs)))
-
 class BoolVal(ValueExpr):
     """FPy AST: boolean value"""
     val: bool
@@ -596,16 +575,37 @@ class IfExpr(Expr):
     def __hash__(self) -> int:
         return hash((self.cond, self.ift, self.iff))
 
+class ForeignAttribute(Ast):
+    """
+    FPy AST: attribute of a foreign object, e.g., `x.y`
+    Attributes may be nested, e.g., `x.y.z`.
+    """
+    name: NamedId
+    attrs: list[NamedId]
+
+    def __init__(self, name: NamedId, attrs: Sequence[NamedId], loc: Optional[Location]):
+        super().__init__(loc)
+        self.name = name
+        self.attrs = list(attrs)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ForeignAttribute):
+            return False
+        return self.name == other.name and self.attrs == other.attrs
+
+    def __hash__(self) -> int:
+        return hash((self.name, tuple(self.attrs)))
+
 
 class ContextExpr(Expr):
     """FPy AST: context constructor"""
     ctor: Var | ForeignAttribute
-    args: list[Expr]
+    args: list[Expr | ForeignAttribute]
 
     def __init__(
         self,
         ctor: Var | ForeignAttribute,
-        args: Sequence[Expr],
+        args: Sequence[Expr | ForeignAttribute],
         loc: Optional[Location]
     ):
         super().__init__(loc)
@@ -619,6 +619,7 @@ class ContextExpr(Expr):
 
     def __hash__(self) -> int:
         return hash((self.ctor, tuple(self.args)))
+
 
 class ContextAttribute(Ast):
     """FPy AST: context attribute"""

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -2,11 +2,12 @@
 This module contains the AST for FPy programs.
 """
 
-import ast as pyast
-
 from abc import ABC, abstractmethod
 from enum import IntEnum
-from typing import Any, Optional, Self, Sequence, Mapping
+from typing import Any, Optional, Self, Sequence
+
+from ..fpc_context import FPCoreContext
+from ..number import Context
 from ..utils import CompareOp, Id, NamedId, UnderscoreId, Location, default_repr
 
 
@@ -229,6 +230,22 @@ class StringVal(ValueExpr):
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, StringVal):
+            return False
+        return self.val == other.val
+
+    def __hash__(self) -> int:
+        return hash(self.val)
+
+class ContextVal(ValueExpr):
+    """FPy AST: context value"""
+    val: Context | FPCoreContext
+
+    def __init__(self, val: Context | FPCoreContext, loc: Optional[Location]):
+        super().__init__(loc)
+        self.val = val
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ContextVal):
             return False
         return self.val == other.val
 
@@ -905,13 +922,13 @@ class ForStmt(Stmt):
 class ContextStmt(Stmt):
     """FPy AST: with statement"""
     name: Id
-    ctx: ContextExpr | Var
+    ctx: ContextExpr | ContextVal | Var
     body: StmtBlock
 
     def __init__(
         self,
         name: Id,
-        ctx: ContextExpr | Var,
+        ctx: ContextExpr | ContextVal | Var,
         body: StmtBlock,
         loc: Optional[Location]
     ):

--- a/fpy2/ast/live_vars.py
+++ b/fpy2/ast/live_vars.py
@@ -101,6 +101,13 @@ class LiveVarsInstance(AstVisitor):
         iff_live = self._visit_expr(e.iff, ctx)
         return cond_live | ift_live | iff_live
 
+    def _visit_context_expr(self, e: ContextExpr, ctx: None) -> _LiveSet:
+        live: set[NamedId] = set()
+        for arg in e.args:
+            if isinstance(arg, NamedId):
+                live.add(arg)
+        return live
+
     def _visit_simple_assign(self, stmt: SimpleAssign, live: _LiveSet) -> _LiveSet:
         live = set(live)
         if isinstance(stmt.var, NamedId):
@@ -154,6 +161,7 @@ class LiveVarsInstance(AstVisitor):
         live = self._visit_block(stmt.body, live)
         if stmt.name is not None and isinstance(stmt.name, NamedId):
             live -= { stmt.name }
+        live |= self._visit_expr(stmt.ctx, None)
         return live
 
     def _visit_assert(self, stmt: AssertStmt, live: _LiveSet) -> _LiveSet:

--- a/fpy2/ast/live_vars.py
+++ b/fpy2/ast/live_vars.py
@@ -159,7 +159,7 @@ class LiveVarsInstance(AstVisitor):
     def _visit_context(self, stmt: ContextStmt, live: _LiveSet) -> _LiveSet:
         live = set(live)
         live = self._visit_block(stmt.body, live)
-        if stmt.name is not None and isinstance(stmt.name, NamedId):
+        if isinstance(stmt.name, NamedId):
             live -= { stmt.name }
         live |= self._visit_expr(stmt.ctx, None)
         return live

--- a/fpy2/ast/live_vars.py
+++ b/fpy2/ast/live_vars.py
@@ -28,6 +28,9 @@ class LiveVarsInstance(AstVisitor):
     def _visit_bool(self, e: BoolVal, ctx: None) -> _LiveSet:
         return set()
 
+    def _visit_context_val(self, e: ContextVal, ctx: None):
+        return set()
+
     def _visit_decnum(self, e: Decnum, ctx: None) -> _LiveSet:
         return set()
 

--- a/fpy2/ast/syntax_check.py
+++ b/fpy2/ast/syntax_check.py
@@ -271,7 +271,7 @@ class SyntaxCheckInstance(AstVisitor):
     def _visit_context(self, stmt: ContextStmt, ctx: _Ctx):
         env, is_top = ctx
         self._visit_expr(stmt.ctx, ctx)
-        if stmt.name is not None and isinstance(stmt.name, NamedId):
+        if isinstance(stmt.name, NamedId):
             env = env.extend(stmt.name)
         return self._visit_block(stmt.body, (env, is_top))
 

--- a/fpy2/ast/syntax_check.py
+++ b/fpy2/ast/syntax_check.py
@@ -109,6 +109,10 @@ class SyntaxCheckInstance(AstVisitor):
         env, _ = ctx
         return env
 
+    def _visit_context_val(self, e, ctx):
+        env, _ = ctx
+        return env
+
     def _visit_decnum(self, e: Decnum, ctx: _Ctx):
         env, _ = ctx
         return env

--- a/fpy2/ast/syntax_check.py
+++ b/fpy2/ast/syntax_check.py
@@ -261,6 +261,7 @@ class SyntaxCheckInstance(AstVisitor):
 
     def _visit_context(self, stmt: ContextStmt, ctx: _Ctx):
         env, is_top = ctx
+        print(stmt.ctx)
         for _, v in stmt.props.items():
             if isinstance(v, NamedId):
                 self._mark_use(v, env)

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -430,7 +430,7 @@ class DefaultAstTransformVisitor(AstVisitor):
         return IfExpr(cond, ift, iff, e.loc)
 
     def _visit_context_expr(self, e: ContextExpr, ctx: Any):
-        args: list[Expr] = []
+        args: list[Expr | ForeignAttribute] = []
         for arg in e.args:
             match arg:
                 case ForeignAttribute():

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -446,7 +446,15 @@ class DefaultAstTransformVisitor(AstVisitor):
                 case _:
                     args.append(self._visit_expr(arg, ctx))
 
-        return ContextExpr(ctor, args, e.loc)
+        kwargs: list[tuple[str, Expr | ForeignAttribute]] = []
+        for name, arg in e.kwargs:
+            match arg:
+                case ForeignAttribute():
+                    kwargs.append((name, ForeignAttribute(arg.name, arg.attrs, arg.loc)))
+                case _:
+                    kwargs.append((name, self._visit_expr(arg, ctx)))
+
+        return ContextExpr(ctor, args, kwargs, e.loc)
 
     def _visit_simple_assign(self, stmt: SimpleAssign, ctx: Any):
         expr = self._visit_expr(stmt.expr, ctx)

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -22,6 +22,10 @@ class AstVisitor(ABC):
         ...
 
     @abstractmethod
+    def _visit_context_val(self, e: ContextVal, ctx: Any) -> Any:
+        ...
+
+    @abstractmethod
     def _visit_decnum(self, e: Decnum, ctx: Any) -> Any:
         ...
 
@@ -161,6 +165,8 @@ class AstVisitor(ABC):
                 return self._visit_var(e, ctx)
             case BoolVal():
                 return self._visit_bool(e, ctx)
+            case ContextVal():
+                return self._visit_context_val(e, ctx)
             case Decnum():
                 return self._visit_decnum(e, ctx)
             case Hexnum():
@@ -236,6 +242,9 @@ class DefaultAstVisitor(AstVisitor):
         pass
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
+        pass
+
+    def _visit_context_val(self, e: ContextVal, ctx: Any):
         pass
 
     def _visit_decnum(self, e: Decnum, ctx: Any):
@@ -363,6 +372,9 @@ class DefaultAstTransformVisitor(AstVisitor):
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return BoolVal(e.val, e.loc)
+
+    def _visit_context_val(self, e: ContextVal, ctx: Any):
+        return ContextVal(e.val, e.loc)
 
     def _visit_decnum(self, e: Decnum, ctx: Any):
         return Decnum(e.val, e.loc)

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -301,7 +301,7 @@ class DefaultAstVisitor(AstVisitor):
 
     def _visit_context_expr(self, e: ContextExpr, ctx: Any):
         for arg in e.args:
-            if not isinstance(arg, ForeignVal):
+            if not isinstance(arg, ForeignAttribute):
                 self._visit_expr(arg, ctx)
 
     def _visit_simple_assign(self, stmt: SimpleAssign, ctx: Any):
@@ -433,8 +433,8 @@ class DefaultAstTransformVisitor(AstVisitor):
         args: list[Expr] = []
         for arg in e.args:
             match arg:
-                case ForeignVal():
-                    args.append(ForeignVal(arg.val, arg.loc))
+                case ForeignAttribute():
+                    args.append(ForeignAttribute(arg.name, arg.attrs, arg.loc))
                 case _:
                     args.append(self._visit_expr(arg, ctx))
         return ContextExpr(e.ctor, args, e.loc)

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -447,6 +447,9 @@ class FPCoreCompileInstance(ReduceVisitor):
         while_binding = (name, fpc.Var(init), body)
         return fpc.Let([(tuple_id, iterable)], fpc.For([dim_binding], [while_binding], ctx))
 
+    def _visit_context_expr(self, e: ContextExpr, ctx):
+        raise NotImplementedError(e)
+
     def _visit_context(self, stmt, ctx):
         body = self._visit_block(stmt.body, ctx)
         return fpc.Ctx(stmt.props, body)

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -5,8 +5,9 @@ from typing import Optional
 import titanfp.fpbench.fpcast as fpc 
 
 from ..analysis import DefineUse
-from ..runtime import Function
+from ..fpc_context import FPCoreContext
 from ..ir import *
+from ..number import Context
 from ..transform import ForBundling, FuncUpdate, SimplifyIf, WhileBundling
 from ..utils import Gensym
 
@@ -146,6 +147,15 @@ class FPCoreCompileInstance(ReduceVisitor):
 
     def _visit_bool(self, e: BoolVal, ctx: None):
         return fpc.Constant('TRUE' if e.val else 'FALSE')
+
+    def _visit_context_val(self, e: ContextVal, ctx) -> fpc.Expr:
+        match e.val:
+            case FPCoreContext():
+                return e.val
+            case Context():
+                FPCoreContext.from_context(e.val)
+            case _:
+                raise FPCoreCompileError('unsupported context value', e.val)
 
     def _visit_decnum(self, e, ctx) -> fpc.Expr:
         return fpc.Decnum(e.val)

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -452,7 +452,8 @@ class FPCoreCompileInstance(ReduceVisitor):
 
     def _visit_context(self, stmt, ctx):
         body = self._visit_block(stmt.body, ctx)
-        return fpc.Ctx(stmt.props, body)
+        # TODO: fix
+        return fpc.Ctx({}, body)
 
     def _visit_assert(self, stmt, ctx):
         # strip the assertion

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -43,6 +43,9 @@ class _FPyCompilerInstance(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: None):
         return ast.BoolVal(e.val, None)
 
+    def _visit_context_val(self, e: ContextVal, ctx: None):
+        return ast.ContextVal(e.val, None)
+
     def _visit_decnum(self, e: Decnum, ctx: None):
         return ast.Decnum(e.val, None)
 

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -219,8 +219,18 @@ class _FPyCompilerInstance(ReduceVisitor):
                 case _:
                     args.append(self._visit_expr(arg, ctx))
 
+        kwargs: list[tuple[str, ast.Expr | ast.ForeignAttribute]] = []
+        for k, v in e.kwargs:
+            match v:
+                case ForeignAttribute():
+                    kwargs.append((k, ast.ForeignAttribute(v.name, v.attrs, None)))
+                case StringVal():
+                    kwargs.append((k, ast.StringVal(v.val, None)))
+                case _:
+                    kwargs.append((k, self._visit_expr(v, ctx)))
+
         # TODO: kwargs
-        return ast.ContextExpr(ctor, args, dict(), None)
+        return ast.ContextExpr(ctor, args, kwargs, None)
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
         match stmt.ctx:

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -219,7 +219,8 @@ class _FPyCompilerInstance(ReduceVisitor):
                 case _:
                     args.append(self._visit_expr(arg, ctx))
 
-        return ast.ContextExpr(ctor, args, None)
+        # TODO: kwargs
+        return ast.ContextExpr(ctor, args, dict(), None)
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
         match stmt.ctx:
@@ -286,6 +287,7 @@ class FPYCompiler(Backend):
 
         func = UnSSA.apply(func)
         ast = _FPyCompilerInstance(func).compile()
-        SyntaxCheck.analyze(ast)
+        free_vars = set([str(v) for v in func.free_vars])
+        SyntaxCheck.analyze(ast, free_vars=free_vars)
         return ast
 

--- a/fpy2/decorator.py
+++ b/fpy2/decorator.py
@@ -27,17 +27,17 @@ R = TypeVar('R')
 # @fpy decorator
 
 @overload
-def fpy(func: Callable[P, R]) -> Callable[P, R]:
+def fpy(func: Callable[P, R]) -> Function:
     ...
 
 @overload
-def fpy(**kwargs) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def fpy(**kwargs) -> Callable[[Callable[P, R]], Function]:
     ...
 
 def fpy(
     func: Optional[Callable[P, R]] = None,
     **kwargs
-) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
+):
     """
     Decorator to parse a Python function into FPy.
 

--- a/fpy2/fpc_context.py
+++ b/fpy2/fpc_context.py
@@ -4,8 +4,8 @@ Runtime utilities for integrating with FPCore from Titanic.
 
 from typing import Any
 
-from ..number import Context, IEEEContext, RM
-from ..utils import default_repr
+from .number import Context, IEEEContext, RM
+from .utils import default_repr
 
 
 def _cvt_round_mode(mode: str):

--- a/fpy2/frontend/__init__.py
+++ b/fpy2/frontend/__init__.py
@@ -6,5 +6,4 @@ for the FPy language.
 """
 
 from .fpc import fpcore_to_fpy
-from .fpc_context import FPCoreContext
 from .parser import Parser

--- a/fpy2/frontend/__init__.py
+++ b/fpy2/frontend/__init__.py
@@ -6,4 +6,5 @@ for the FPy language.
 """
 
 from .fpc import fpcore_to_fpy
+from .fpc_context import FPCoreContext
 from .parser import Parser

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -574,7 +574,7 @@ class _FPCore2FPy:
         # bind value to temporary
         t = self.gensym.fresh('t')
         block = StmtBlock(val_ctx.stmts + [SimpleAssign(t, val, None, None)])
-        stmt = ContextStmt(None, props, block, None)
+        stmt = ContextStmt(UnderscoreId, props, block, None)
         ctx.stmts.append(stmt)
         return Var(t, None)
 

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -9,8 +9,10 @@ from titanfp.fpbench.fpcparser import data_as_expr
 
 from ..ast.fpyast import *
 from ..ast.syntax_check import SyntaxCheck
-
 from ..utils import Gensym, pythonize_id
+
+from .fpc_context import FPCoreContext, NoSuchContextError
+
 
 DataElt: TypeAlias = tuple['DataElt'] | fpc.ValueExpr
 
@@ -83,19 +85,27 @@ def _zeros(ns: list[Expr]) -> Expr:
     args = [UnaryOp(UnaryOpKind.RANGE, n, None) for n in ns]
     return CompExpr(vars, args, Integer(0, None), None)
 
+# TODO: clean this up
 class _Ctx:
     env: dict[str, NamedId]
+    props: dict[str, Any]
     stmts: list[Stmt]
 
     def __init__(
         self,
         env: Optional[dict[str, NamedId]] = None,
+        props: Optional[dict[str, Any]] = None,
         stmts: Optional[list[Stmt]] = None
     ):
         if env is None:
             self.env = {}
         else:
             self.env = env
+
+        if props is None:
+            self.props = {}
+        else:
+            self.props = props
 
         if stmts is None:
             self.stmts = []
@@ -269,7 +279,7 @@ class _FPCore2FPy:
 
         for var, val in e.let_bindings:
             # compile value
-            val_ctx = _Ctx(env=env, stmts=ctx.stmts) if is_star else ctx
+            val_ctx = _Ctx(env=env, props=ctx.props, stmts=ctx.stmts) if is_star else ctx
             v_e = self._visit(val, val_ctx)
             # bind value to variable
             t = self.gensym.fresh(var)
@@ -277,13 +287,13 @@ class _FPCore2FPy:
             stmt = SimpleAssign(t, v_e, None, None)
             ctx.stmts.append(stmt)
 
-        return self._visit(e.body, _Ctx(env=env, stmts=ctx.stmts))
+        return self._visit(e.body, _Ctx(env=env, props=ctx.props, stmts=ctx.stmts))
 
     def _visit_whilestar(self, e: fpc.WhileStar, ctx: _Ctx) -> Expr:
         env = ctx.env
         for var, init, _ in e.while_bindings:
             # compile value
-            init_ctx = _Ctx(env=env, stmts=ctx.stmts)
+            init_ctx = _Ctx(env=env, props=ctx.props, stmts=ctx.stmts)
             init_e = self._visit(init, init_ctx)
             # bind value to variable
             t = self.gensym.fresh(var)
@@ -292,12 +302,12 @@ class _FPCore2FPy:
             ctx.stmts.append(stmt)
 
         # compile condition
-        cond_ctx = _Ctx(env=env, stmts=ctx.stmts)
+        cond_ctx = _Ctx(env=env, props=ctx.props, stmts=ctx.stmts)
         cond_e = self._visit(e.cond, cond_ctx)
 
         # create loop body
         stmts: list[Stmt] = []
-        update_ctx = _Ctx(env=env, stmts=stmts)
+        update_ctx = _Ctx(env=env, props=ctx.props, stmts=stmts)
         for var, _, update in e.while_bindings:
             # compile value and update loop variable
             update_e = self._visit(update, update_ctx)
@@ -309,7 +319,7 @@ class _FPCore2FPy:
         ctx.stmts.append(while_stmt)
 
         # compile body
-        body_ctx = _Ctx(env=env, stmts=ctx.stmts)
+        body_ctx = _Ctx(env=env, props=ctx.props, stmts=ctx.stmts)
         return self._visit(e.body, body_ctx)
 
     def _visit_while(self, e: fpc.While, ctx: _Ctx) -> Expr:
@@ -325,7 +335,7 @@ class _FPCore2FPy:
             ctx.stmts.append(stmt)
 
         # compile condition
-        cond_ctx = _Ctx(env=env, stmts=ctx.stmts)
+        cond_ctx = _Ctx(env=env, props=ctx.props, stmts=ctx.stmts)
         cond_e = self._visit(e.cond, cond_ctx)
 
         # create loop body
@@ -353,7 +363,7 @@ class _FPCore2FPy:
         ctx.stmts.append(while_stmt)
 
         # compile body
-        body_ctx = _Ctx(env=env, stmts=ctx.stmts)
+        body_ctx = _Ctx(env=env, props=ctx.props, stmts=ctx.stmts)
         return self._visit(e.body, body_ctx)
 
     def _make_tensor_body(
@@ -398,7 +408,7 @@ class _FPCore2FPy:
 
         # initialize loop variables
         init_env = ctx.env.copy()
-        init_ctx = _Ctx(env=ctx.env, stmts=ctx.stmts)
+        init_ctx = _Ctx(env=ctx.env, props=ctx.props, stmts=ctx.stmts)
         for var, init, _ in e.while_bindings:
             # compile value
             init_e = self._visit(init, init_ctx)
@@ -424,7 +434,7 @@ class _FPCore2FPy:
 
         # generate for loops
         loop_stmts = self._make_tensor_body(iter_vars, bound_vars, ctx.stmts)
-        loop_ctx = _Ctx(env=loop_env, stmts=loop_stmts)
+        loop_ctx = _Ctx(env=loop_env, props=ctx.props, stmts=loop_stmts)
 
         # set tensor element
         body_e = self._visit(e.body, loop_ctx)
@@ -477,7 +487,7 @@ class _FPCore2FPy:
 
         # generate for loops
         loop_stmts = self._make_tensor_body(iter_vars, bound_vars, ctx.stmts)
-        loop_ctx = _Ctx(env=loop_env, stmts=loop_stmts)
+        loop_ctx = _Ctx(env=loop_env, props=ctx.props, stmts=loop_stmts)
 
         # set tensor element
         body_e = self._visit(e.body, loop_ctx)
@@ -516,7 +526,7 @@ class _FPCore2FPy:
         init_env = ctx.env.copy()
         for var, init, _ in e.while_bindings:
             # compile value
-            init_ctx = _Ctx(init_env if is_star else ctx.env, ctx.stmts)
+            init_ctx = _Ctx(init_env if is_star else ctx.env, props=ctx.props, stmts=ctx.stmts)
             init_e = self._visit(init, init_ctx)
             # bind value to variable
             t = self.gensym.fresh(var)
@@ -534,7 +544,7 @@ class _FPCore2FPy:
         # generate for loops
         loop_env = init_env.copy()
         loop_stmts = self._make_tensor_body(iter_vars, bound_vars, ctx.stmts)
-        loop_ctx = _Ctx(env=loop_env, stmts=loop_stmts)
+        loop_ctx = _Ctx(env=loop_env, props=ctx.props, stmts=loop_stmts)
 
         if is_star:
             # update loop variables
@@ -560,7 +570,7 @@ class _FPCore2FPy:
                 stmt = SimpleAssign(x, Var(t, None), None, None)
                 loop_stmts.append(stmt)
 
-        body_ctx = _Ctx(env=init_env, stmts=ctx.stmts)
+        body_ctx = _Ctx(env=init_env, props=ctx.props, stmts=ctx.stmts)
         return self._visit(e.body, body_ctx)
 
     def _visit_ctx(self, e: fpc.Ctx, ctx: _Ctx) -> Expr:
@@ -568,8 +578,16 @@ class _FPCore2FPy:
         val_ctx = ctx.without_stmts()
         val = self._visit(e.body, val_ctx)
 
-        # compile properties
-        props = self._visit_props(e.props, _Ctx(env=ctx.env))
+        # compile properties to a context
+        props = self._visit_props(e.props, ctx)
+        fpc_ctx = FPCoreContext(**props)
+
+        try:
+            fpy_ctx = fpc_ctx.to_context()
+            print(fpy_ctx)
+        except NoSuchContextError:
+            print(f'{fpc_ctx!r}')
+
 
         # bind value to temporary
         t = self.gensym.fresh('t')
@@ -638,7 +656,7 @@ class _FPCore2FPy:
                 raise NotImplementedError(repr(data))
 
     def _visit_props(self, props: dict[str, fpc.Data], ctx: _Ctx):
-        new_props: dict[str, Any] = {}
+        new_props = dict(ctx.props)
         for k, v in props.items():
             match k:
                 case 'pre' | 'spec' | 'alt':
@@ -679,7 +697,8 @@ class _FPCore2FPy:
                         ctx.env[dim] = dim_id
 
         # compile 
-        props = self._visit_props(f.props, _Ctx(env=ctx.env))
+        props = self._visit_props(f.props, ctx)
+        ctx.props = props
 
         # compile function body
         e = self._visit(f.e, ctx)

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -7,11 +7,10 @@ from typing import TypeAlias
 import titanfp.fpbench.fpcast as fpc
 from titanfp.fpbench.fpcparser import data_as_expr
 
+from ..fpc_context import FPCoreContext, NoSuchContextError
 from ..ast.fpyast import *
 from ..ast.syntax_check import SyntaxCheck
 from ..utils import Gensym, pythonize_id
-
-from .fpc_context import FPCoreContext, NoSuchContextError
 
 
 DataElt: TypeAlias = tuple['DataElt'] | fpc.ValueExpr

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -574,7 +574,8 @@ class _FPCore2FPy:
         # bind value to temporary
         t = self.gensym.fresh('t')
         block = StmtBlock(val_ctx.stmts + [SimpleAssign(t, val, None, None)])
-        stmt = ContextStmt(UnderscoreId, props, block, None)
+        # TODO: need to generate an FPy context
+        stmt = ContextStmt(UnderscoreId(), props, block, None)
         ctx.stmts.append(stmt)
         return Var(t, None)
 

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -581,18 +581,17 @@ class _FPCore2FPy:
         props = self._visit_props(e.props, ctx)
         fpc_ctx = FPCoreContext(**props)
 
+        # try to convert to a native FPy context
         try:
-            fpy_ctx = fpc_ctx.to_context()
-            print(fpy_ctx)
+            ctx_val = ContextVal(fpc_ctx.to_context(), None)
         except NoSuchContextError:
-            print(f'{fpc_ctx!r}')
-
+            ctx_val = ContextVal(fpc_ctx, None)
 
         # bind value to temporary
         t = self.gensym.fresh('t')
         block = StmtBlock(val_ctx.stmts + [SimpleAssign(t, val, None, None)])
         # TODO: need to generate an FPy context
-        stmt = ContextStmt(UnderscoreId(), props, block, None)
+        stmt = ContextStmt(UnderscoreId(), ctx_val, block, None)
         ctx.stmts.append(stmt)
         return Var(t, None)
 

--- a/fpy2/frontend/fpc_context.py
+++ b/fpy2/frontend/fpc_context.py
@@ -1,0 +1,64 @@
+"""
+Runtime utilities for integrating with FPCore from Titanic.
+"""
+
+from typing import Any
+
+from ..number import Context
+from ..utils import default_repr
+
+@default_repr
+class FPCoreContext:
+    """
+    FPCore rounding context.
+
+    FPCore defines a rounding context to be a dictionary of properties.
+    Each property consists of an arbitrary string key and an arbitrary value.
+
+    The FPCore standard defines a set of standard properties:
+    - `precision`: the precision of the floating-point numbers
+    - `round`: the rounding mode to use
+    - `overflow`: overflow behavior for fixed-point numbers
+
+    This class provides a way to define an FPCore-style rounding context
+    and convert to and from rounding contexts in this library.
+    """
+
+    props: dict[str, Any]
+
+
+    def __init__(self, props: dict[str, Any]):
+        """
+        Initialize the FPCore context with the given properties.
+
+        :param props: A dictionary of properties.
+        """
+        self.props = dict(props)
+
+    def with_prop(self, key: str, value: Any) -> 'FPCoreContext':
+        """
+        Create a new FPCore context with the given property.
+
+        :param key: The property key.
+        :param value: The property value.
+        :return: A new FPCore context with the given property.
+        """
+        new_props = self.props.copy()
+        new_props[key] = value
+        return FPCoreContext(new_props)
+
+    @staticmethod
+    def from_context(ctx: Context) -> 'FPCoreContext':
+        """
+        Create an FPCore context from a given context.
+
+        :param ctx: The context to convert.
+        :return: An FPCore context with the properties of the given context.
+        """
+        if not isinstance(ctx, Context):
+            raise TypeError(f'Expected \'Context\' for ctx={ctx}, got {type(ctx)}')
+        raise NotImplementedError
+
+
+    def to_context(self) -> Context:
+        raise NotImplementedError

--- a/fpy2/frontend/fpc_context.py
+++ b/fpy2/frontend/fpc_context.py
@@ -4,8 +4,43 @@ Runtime utilities for integrating with FPCore from Titanic.
 
 from typing import Any
 
-from ..number import Context
+from ..number import Context, IEEEContext, RM
 from ..utils import default_repr
+
+
+def _cvt_round_mode(mode: str):
+    match mode:
+        case 'nearestEven':
+            return RM.RNE
+        case 'nearestAway':
+            return RM.RNA
+        case 'toPositive':
+            return RM.RTP
+        case 'toNegative':
+            return RM.RTN
+        case 'toZero':
+            return RM.RTZ
+        case 'awayZero':
+            return RM.RAZ
+        case _:
+            raise ValueError(f'Unknown rounding mode: {mode}')
+
+class NoSuchContextError(Exception):
+    """
+    Exception raised when a context is not found.
+    """
+
+    def __init__(self, ctx: 'FPCoreContext'):
+        """
+        Initialize the exception with the given context.
+
+        :param ctx: The context that was not found.
+        """
+        self.ctx = ctx
+
+    def __str__(self):
+        return f'No such context: {self.ctx}'
+
 
 @default_repr
 class FPCoreContext:
@@ -26,14 +61,20 @@ class FPCoreContext:
 
     props: dict[str, Any]
 
-
-    def __init__(self, props: dict[str, Any]):
+    def __init__(self, **kwargs):
         """
         Initialize the FPCore context with the given properties.
 
         :param props: A dictionary of properties.
         """
-        self.props = dict(props)
+        self.props = kwargs
+
+
+    def __enter__(self) -> 'FPCoreContext':
+        raise RuntimeError('do not call')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        raise RuntimeError('do not call')
 
     def with_prop(self, key: str, value: Any) -> 'FPCoreContext':
         """
@@ -45,7 +86,7 @@ class FPCoreContext:
         """
         new_props = self.props.copy()
         new_props[key] = value
-        return FPCoreContext(new_props)
+        return FPCoreContext(**new_props)
 
     @staticmethod
     def from_context(ctx: Context) -> 'FPCoreContext':
@@ -61,4 +102,23 @@ class FPCoreContext:
 
 
     def to_context(self) -> Context:
-        raise NotImplementedError
+        """
+        Converts the FPCore context to a context in this library.
+        """
+        prec_str = self.props.get('precision', 'binary64')
+        rnd_str = self.props.get('round', 'nearestEven')
+        try:
+            match prec_str:
+                # IEEE 754 shorthands
+                case 'binary128':
+                    return IEEEContext(15, 128, _cvt_round_mode(rnd_str))
+                case 'binary64':
+                    return IEEEContext(11, 64, _cvt_round_mode(rnd_str))
+                case 'binary32':
+                    return IEEEContext(8, 32, _cvt_round_mode(rnd_str))
+                case 'binary16':
+                    return IEEEContext(5, 16, _cvt_round_mode(rnd_str))
+                case _:
+                    raise NoSuchContextError(self)
+        except ValueError:
+            raise NoSuchContextError(self) from None

--- a/fpy2/frontend/fpc_context.py
+++ b/fpy2/frontend/fpc_context.py
@@ -105,19 +105,19 @@ class FPCoreContext:
         """
         Converts the FPCore context to a context in this library.
         """
-        prec_str = self.props.get('precision', 'binary64')
-        rnd_str = self.props.get('round', 'nearestEven')
+        prec = self.props.get('precision', 'binary64')
+        rnd = self.props.get('round', 'nearestEven')
         try:
-            match prec_str:
+            match prec:
                 # IEEE 754 shorthands
                 case 'binary128':
-                    return IEEEContext(15, 128, _cvt_round_mode(rnd_str))
+                    return IEEEContext(15, 128, _cvt_round_mode(rnd))
                 case 'binary64':
-                    return IEEEContext(11, 64, _cvt_round_mode(rnd_str))
+                    return IEEEContext(11, 64, _cvt_round_mode(rnd))
                 case 'binary32':
-                    return IEEEContext(8, 32, _cvt_round_mode(rnd_str))
+                    return IEEEContext(8, 32, _cvt_round_mode(rnd))
                 case 'binary16':
-                    return IEEEContext(5, 16, _cvt_round_mode(rnd_str))
+                    return IEEEContext(5, 16, _cvt_round_mode(rnd))
                 case _:
                     raise NoSuchContextError(self)
         except ValueError:

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -570,9 +570,13 @@ class Parser:
                         case _:
                             pos_args.append(self._parse_expr(arg, allow_foreign=True))
                 # parse keyword arguments
-                if e.keywords != []:
-                    raise FPyParserError(loc, 'FPy does not support keyword arguments', e)
-                return ContextExpr(ctor, pos_args, loc)
+                kw_args: list[tuple[str, Expr]] = []
+                for kwd in e.keywords:
+                    if kwd.arg is None:
+                        raise FPyParserError(loc, 'FPy does not support unnamed keyword arguments', kwd, e)
+                    v = self._parse_expr(kwd.value, allow_foreign=True)
+                    kw_args.append((kwd.arg, v))
+                return ContextExpr(ctor, pos_args, kw_args, loc)
             case _:
                 raise FPyParserError(loc, 'FPy expects a valid context expression', e, item)
         # match e:

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -519,7 +519,7 @@ class Parser:
         var = item.optional_vars
         match var:
             case None:
-                return None
+                return UnderscoreId()
             case ast.Name():
                 return var.id
             case _:

--- a/fpy2/interpret/interpreter.py
+++ b/fpy2/interpret/interpreter.py
@@ -5,9 +5,8 @@ Defines the abstract base class for FPy interpreters.
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
-from titanfp.arithmetic.evalctx import EvalCtx
-
 from ..ir import Expr
+from ..number import Context
 from ..runtime import Function, set_default_function_call
 from ..runtime.trace import ExprTraceEntry
 
@@ -16,15 +15,15 @@ class Interpreter(ABC):
     """Abstract base class for FPy interpreters."""
 
     @abstractmethod
-    def eval(self, func: Function, args, ctx: Optional[EvalCtx] = None):
+    def eval(self, func: Function, args, ctx: Optional[Context] = None):
         ...
 
     @abstractmethod
-    def eval_with_trace(self, func: Function, args, ctx: Optional[EvalCtx] = None) -> tuple[Any, list[ExprTraceEntry]]:
+    def eval_with_trace(self, func: Function, args, ctx: Optional[Context] = None) -> tuple[Any, list[ExprTraceEntry]]:
         ...
 
     @abstractmethod
-    def eval_expr(self, expr: Expr, env: dict, ctx: EvalCtx):
+    def eval_expr(self, expr: Expr, env: dict, ctx: Context):
         ...
 
 class FunctionReturnException(Exception):
@@ -55,7 +54,7 @@ def set_default_interpreter(rt: Interpreter):
 ###########################################################
 # Default function call
 
-def _default_function_call(fn: Function, *args, ctx: Optional[EvalCtx] = None):
+def _default_function_call(fn: Function, *args, ctx: Optional[Context] = None):
     """Default function call."""
     if fn.runtime is None:
         rt = get_default_interpreter()

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -179,6 +179,9 @@ class _Interpreter(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: Context):
         return e.val
 
+    def _visit_context_val(self, e: ContextVal, ctx: Context):
+        return e.val
+
     def _visit_decnum(self, e: Decnum, ctx: Context):
         return float(e.val)
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -7,17 +7,19 @@ import titanfp.titanic.gmpmath as gmpmath
 
 from typing import Any, Callable, Optional, Sequence, TypeAlias
 
-from titanfp.arithmetic.evalctx import EvalCtx, determine_ctx
-from titanfp.arithmetic.ieee754 import Float, IEEECtx, ieee_ctx
-from titanfp.titanic.digital import Digital
-from titanfp.titanic.ops import RM
-
+from ..number import Context, Float, IEEEContext, RM
+from ..number.gmp import mpfr_constant
 from ..runtime.function import Function
 from ..runtime.env import ForeignEnv
 from ..ir import *
+from ..utils import digits_to_fraction
 
 from .interpreter import Interpreter, FunctionReturnException
 
+ScalarVal: TypeAlias = bool | float
+"""Type of scalar values."""
+TensorVal: TypeAlias = tuple
+"""Type of tensor values."""
 
 def _safe_div(x: float, y: float):
     if y == 0:
@@ -28,10 +30,7 @@ def _safe_div(x: float, y: float):
     else:
         return x / y
 
-ScalarVal: TypeAlias = bool | float
-"""Type of scalar values."""
-TensorVal: TypeAlias = tuple
-"""Type of tensor values."""
+
 _method_table: dict[str, Callable[..., Any]] = {
     '+': lambda x, y: x + y,
     '-': lambda x, y: x - y,
@@ -89,6 +88,10 @@ _method_table: dict[str, Callable[..., Any]] = {
 
 _Env: TypeAlias = dict[NamedId, ScalarVal | TensorVal]
 
+_PY_CTX = IEEEContext(11, 64, RM.RNE)
+"""the native Python floating-point context"""
+
+
 class _Interpreter(ReduceVisitor):
     """Single-use interpreter for a function."""
 
@@ -104,23 +107,19 @@ class _Interpreter(ReduceVisitor):
         self.foreign = foreign
         self.env = env
 
-    def _is_python_ctx(self, ctx: EvalCtx):
-        return (
-            isinstance(ctx, IEEECtx)
-            and ctx.es == 11
-            and ctx.nbits == 64
-            or ctx.rm == RM.RNE
-        )
+    def _is_python_ctx(self, ctx: Context):
+        return ctx == _PY_CTX
 
     def _arg_to_float(self, arg: Any):
-        if isinstance(arg, str | int | float):
-            return float(arg)
-        elif isinstance(arg, Digital):
-            return float(arg)
-        elif isinstance(arg, tuple | list):
-            raise NotImplementedError()
-        else:
-            return arg
+        match arg:
+            case int() | float():
+                return arg
+            case str() | Float():
+                return float(arg)
+            case tuple() | list():
+                raise NotImplementedError('cannot convert tuple or list to float')
+            case _:
+                return arg
 
     def _lookup(self, name: NamedId):
         if name not in self.env:
@@ -131,20 +130,20 @@ class _Interpreter(ReduceVisitor):
         self,
         func: FuncDef,
         args: Sequence[Any],
-        ctx: Optional[EvalCtx] = None
+        ctx: Optional[Context] = None
     ):
         args = tuple(args)
         if len(args) != len(func.args):
             raise TypeError(f'Expected {len(func.args)} arguments, got {len(args)}')
 
-        # determine context
+        # TODO: what context is set when entering the FPy runtime?
+        # determine context when specified
         if ctx is None:
-            ctx = ieee_ctx(11, 64)
-        ctx = determine_ctx(ctx, func.ctx)
+            ctx = _PY_CTX
 
         # Python only has doubles
         if not self._is_python_ctx(ctx):
-            raise ValueError(f'Unsupported context {ctx}; Python only has doubles')
+            raise RuntimeError(f'Unsupported context {ctx}, expected {_PY_CTX}')
 
         # bind arguments
         for val, arg in zip(args, func.args):
@@ -174,40 +173,38 @@ class _Interpreter(ReduceVisitor):
         except FunctionReturnException as e:
             return e.value
 
-    def _visit_var(self, e: Var, ctx: EvalCtx):
+    def _visit_var(self, e: Var, ctx: Context):
         return self._lookup(e.name)
 
-    def _visit_bool(self, e: BoolVal, ctx: EvalCtx):
+    def _visit_bool(self, e: BoolVal, ctx: Context):
         return e.val
 
-    def _visit_decnum(self, e: Decnum, ctx: EvalCtx):
+    def _visit_decnum(self, e: Decnum, ctx: Context):
         return float(e.val)
 
-    def _visit_hexnum(self, e: Hexnum, ctx: EvalCtx):
+    def _visit_hexnum(self, e: Hexnum, ctx: Context):
         return float.fromhex(e.val)
 
-    def _visit_integer(self, e: Integer, ctx: EvalCtx):
+    def _visit_integer(self, e: Integer, ctx: Context):
         return float(e.val)
 
-    def _visit_rational(self, e: Rational, ctx: EvalCtx):
+    def _visit_rational(self, e: Rational, ctx: Context):
         return e.p / e.q
 
-    def _visit_constant(self, e: Constant, ctx: EvalCtx):
-        # rely on Titanic for this
-        x = gmpmath.compute_constant(e.val, prec=ctx.p)
-        d = Float._round_to_context(x, ctx=ctx)
-        return float(d)
+    def _visit_constant(self, e: Constant, ctx: Context):
+        prec, _ = ctx.round_params()
+        assert isinstance(prec, int)
+        x = mpfr_constant(e.val, prec=prec)
+        return float(_PY_CTX.round(x))
 
-    def _visit_digits(self, e: Digits, ctx: EvalCtx):
+    def _visit_digits(self, e: Digits, ctx: Context):
         # rely on Titanic for this
-        x = gmpmath.compute_digits(e.m, e.e, e.b, prec=ctx.p)
-        d = Float._round_to_context(x, ctx)
-        return float(d)
+        return float(digits_to_fraction(e.m, e.e, e.b))
 
-    def _visit_unknown(self, e: UnknownCall, ctx: EvalCtx):
+    def _visit_unknown(self, e: UnknownCall, ctx: Context):
         raise NotImplementedError('unknown call', e)
 
-    def _apply_method(self, e: NaryExpr, ctx: EvalCtx):
+    def _apply_method(self, e: NaryExpr, ctx: Context):
         fn = _method_table[e.name]
         args: list[float] = []
         for arg in e.children:
@@ -226,19 +223,19 @@ class _Interpreter(ReduceVisitor):
 
         return result
 
-    def _apply_cast(self, e: Cast, ctx: EvalCtx):
+    def _apply_cast(self, e: Cast, ctx: Context):
         x = self._visit_expr(e.children[0], ctx)
         if not isinstance(x, float):
             raise TypeError(f'expected a float, got {x}')
         return x
 
-    def _apply_not(self, e: Not, ctx: EvalCtx):
+    def _apply_not(self, e: Not, ctx: Context):
         arg = self._visit_expr(e.children[0], ctx)
         if not isinstance(arg, bool):
             raise TypeError(f'expected a boolean argument, got {arg}')
         return not arg
 
-    def _apply_and(self, e: And, ctx: EvalCtx):
+    def _apply_and(self, e: And, ctx: Context):
         args: list[bool] = []
         for arg in e.children:
             val = self._visit_expr(arg, ctx)
@@ -247,7 +244,7 @@ class _Interpreter(ReduceVisitor):
             args.append(val)
         return all(args)
 
-    def _apply_or(self, e: Or, ctx: EvalCtx):
+    def _apply_or(self, e: Or, ctx: Context):
         args: list[bool] = []
         for arg in e.children:
             val = self._visit_expr(arg, ctx)
@@ -256,7 +253,7 @@ class _Interpreter(ReduceVisitor):
             args.append(val)
         return any(args)
 
-    def _apply_range(self, e: Range, ctx: EvalCtx):
+    def _apply_range(self, e: Range, ctx: Context):
         stop = self._visit_expr(e.children[0], ctx)
         if not isinstance(stop, float):
             raise TypeError(f'expected a real number argument, got {stop}')
@@ -264,7 +261,7 @@ class _Interpreter(ReduceVisitor):
             raise TypeError(f'expected an integer argument, got {stop}')
         return tuple([float(i) for i in range(int(stop))])
 
-    def _visit_nary_expr(self, e: NaryExpr, ctx: EvalCtx):
+    def _visit_nary_expr(self, e: NaryExpr, ctx: Context):
         if e.name in _method_table:
             return self._apply_method(e, ctx)
         elif e.name == 'fma':
@@ -299,7 +296,7 @@ class _Interpreter(ReduceVisitor):
             case _:
                 raise NotImplementedError('unknown comparison operator', op)
 
-    def _visit_compare(self, e: Compare, ctx: EvalCtx):
+    def _visit_compare(self, e: Compare, ctx: Context):
         lhs = self._visit_expr(e.children[0], ctx)
         for op, arg in zip(e.ops, e.children[1:]):
             rhs = self._visit_expr(arg, ctx)
@@ -308,10 +305,10 @@ class _Interpreter(ReduceVisitor):
             lhs = rhs
         return True
 
-    def _visit_tuple_expr(self, e: TupleExpr, ctx: EvalCtx):
+    def _visit_tuple_expr(self, e: TupleExpr, ctx: Context):
         return tuple([self._visit_expr(x, ctx) for x in e.children])
 
-    def _visit_tuple_ref(self, e: TupleRef, ctx: EvalCtx):
+    def _visit_tuple_ref(self, e: TupleRef, ctx: Context):
         value = self._visit_expr(e.value, ctx)
         if not isinstance(value, tuple):
             raise TypeError(f'expected a tensor, got {value}')
@@ -319,7 +316,7 @@ class _Interpreter(ReduceVisitor):
         elt = value
         for s in e.slices:
             val = self._visit_expr(s, ctx)
-            if not isinstance(val, Digital):
+            if not isinstance(val, float):
                 raise TypeError(f'expected a real number slice, got {val}')
             if not val.is_integer():
                 raise TypeError(f'expected an integer slice, got {val}')
@@ -327,14 +324,14 @@ class _Interpreter(ReduceVisitor):
 
         return elt
 
-    def _visit_tuple_set(self, e: TupleSet, ctx: EvalCtx):
+    def _visit_tuple_set(self, e: TupleSet, ctx: Context):
         raise NotImplementedError
 
     def _apply_comp(
         self,
         bindings: list[tuple[Id, Expr]],
         elt: Expr,
-        ctx: EvalCtx,
+        ctx: Context,
         elts: list[Any]
     ):
         if bindings == []:
@@ -349,7 +346,7 @@ class _Interpreter(ReduceVisitor):
                     self.env[var] = val
                 self._apply_comp(bindings[1:], elt, ctx, elts)
 
-    def _visit_comp_expr(self, e: CompExpr, ctx: EvalCtx):
+    def _visit_comp_expr(self, e: CompExpr, ctx: Context):
         # evaluate comprehension
         elts: list[Any] = []
         bindings = [(var, iterable) for var, iterable in zip(e.vars, e.iterables)]
@@ -363,13 +360,13 @@ class _Interpreter(ReduceVisitor):
         # the result
         return tuple(elts)
 
-    def _visit_if_expr(self, e: IfExpr, ctx: EvalCtx):
+    def _visit_if_expr(self, e: IfExpr, ctx: Context):
         cond = self._visit_expr(e.cond, ctx)
         if not isinstance(cond, bool):
             raise TypeError(f'expected a boolean, got {cond}')
         return self._visit_expr(e.ift if cond else e.iff, ctx)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: EvalCtx):
+    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: Context):
         val = self._visit_expr(stmt.expr, ctx)
         match stmt.var:
             case NamedId():
@@ -379,7 +376,7 @@ class _Interpreter(ReduceVisitor):
             case _:
                 raise NotImplementedError('unknown variable', stmt.var)
 
-    def _unpack_tuple(self, binding: TupleBinding, val: tuple, ctx: EvalCtx) -> None:
+    def _unpack_tuple(self, binding: TupleBinding, val: tuple, ctx: Context) -> None:
         if len(binding.elts) != len(val):
             raise NotImplementedError(f'unpacking {len(val)} values into {len(binding.elts)}')
         for elt, v in zip(binding.elts, val):
@@ -393,16 +390,16 @@ class _Interpreter(ReduceVisitor):
                 case _:
                     raise NotImplementedError('unknown tuple element', elt)
 
-    def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: EvalCtx):
+    def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: Context):
         val = self._visit_expr(stmt.expr, ctx)
         if not isinstance(val, tuple):
             raise TypeError(f'expected a tuple, got {val}')
         self._unpack_tuple(stmt.binding, val, ctx)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: EvalCtx):
+    def _visit_index_assign(self, stmt: IndexAssign, ctx: Context):
         raise NotImplementedError
 
-    def _visit_if1(self, stmt: If1Stmt, ctx: EvalCtx):
+    def _visit_if1(self, stmt: If1Stmt, ctx: Context):
         cond = self._visit_expr(stmt.cond, ctx)
         if not isinstance(cond, bool):
             raise TypeError(f'expected a boolean, got {cond}')
@@ -416,7 +413,7 @@ class _Interpreter(ReduceVisitor):
                 self.env[phi.name] = self.env[phi.lhs]
                 del self.env[phi.lhs]
 
-    def _visit_if(self, stmt: IfStmt, ctx: EvalCtx):
+    def _visit_if(self, stmt: IfStmt, ctx: Context):
         cond = self._visit_expr(stmt.cond, ctx)
         if not isinstance(cond, bool):
             raise TypeError(f'expected a boolean, got {cond}')
@@ -431,7 +428,7 @@ class _Interpreter(ReduceVisitor):
                 self.env[phi.name] = self.env[phi.rhs]
                 del self.env[phi.rhs]
 
-    def _visit_while(self, stmt: WhileStmt, ctx: EvalCtx):
+    def _visit_while(self, stmt: WhileStmt, ctx: Context):
         for phi in stmt.phis:
             self.env[phi.name] = self.env[phi.lhs]
             del self.env[phi.lhs]
@@ -450,7 +447,7 @@ class _Interpreter(ReduceVisitor):
             if not isinstance(cond, bool):
                 raise TypeError(f'expected a boolean, got {cond}')
 
-    def _visit_for(self, stmt: ForStmt, ctx: EvalCtx):
+    def _visit_for(self, stmt: ForStmt, ctx: Context):
         for phi in stmt.phis:
             self.env[phi.name] = self.env[phi.lhs]
             del self.env[phi.lhs]
@@ -467,19 +464,51 @@ class _Interpreter(ReduceVisitor):
                 self.env[phi.name] = self.env[phi.rhs]
                 del self.env[phi.rhs]
 
-    def _visit_context(self, stmt: ContextStmt, ctx: EvalCtx):
-        props = {}
-        for k, v in stmt.props.items():
-            if isinstance(v, NamedId):
-                props[k] = self._lookup(v)
+    def _visit_foreign_attr(self, e: ForeignAttribute):
+        # lookup the root value (should be captured)
+        val = self._lookup(e.name)
+        # walk the attribute chain
+        for attr_id in e.attrs:
+            # need to manually lookup the attribute
+            attr = str(attr_id)
+            if isinstance(val, dict):
+                if attr not in val:
+                    raise RuntimeError(f'unknown attribute {attr} for {val}')
+                val = val[attr]
+            elif hasattr(val, attr):
+                val = getattr(val, attr)
             else:
-                props[k] = v
-        ctx = determine_ctx(ctx, stmt.props)
+                raise RuntimeError(f'unknown attribute {attr} for {val}')
+        return val
+
+    def _visit_context_expr(self, e: ContextExpr, ctx: Context):
+        match e.ctor:
+            case ForeignAttribute():
+                ctor = self._visit_foreign_attr(e.ctor)
+            case Var():
+                ctor = self._visit_var(e.ctor, ctx)
+
+        args: list[Any] = []
+        for arg in e.args:
+            match arg:
+                case ForeignAttribute():
+                    args.append(self._visit_foreign_attr(arg))
+                case _:
+                    v = self._visit_expr(arg, ctx)
+                    if isinstance(v, float) and v.is_integer():
+                        # HACK: keeps things as specific as possible
+                        args.append(int(v))
+                    else:
+                        args.append(v)
+        return ctor(*args)
+
+    def _visit_context(self, stmt: ContextStmt, ctx: Context):
+        ctx = self._visit_expr(stmt.ctx, ctx)
         if not self._is_python_ctx(ctx):
-            raise NotImplementedError(f'unsupported context {ctx}')
+            raise RuntimeError(f'Unsupported context {ctx}, expected {_PY_CTX}')
         return self._visit_block(stmt.body, ctx)
 
-    def _visit_assert(self, stmt: AssertStmt, ctx: EvalCtx):
+    def _visit_assert(self, stmt: AssertStmt, ctx: Context):
         test = self._visit_expr(stmt.test, ctx)
         if not isinstance(test, bool):
             raise TypeError(f'expected a boolean, got {test}')
@@ -491,19 +520,18 @@ class _Interpreter(ReduceVisitor):
         self._visit_expr(stmt.expr, ctx)
         return ctx
 
-    def _visit_return(self, stmt: ReturnStmt, ctx: EvalCtx):
+    def _visit_return(self, stmt: ReturnStmt, ctx: Context):
         return self._visit_expr(stmt.expr, ctx)
 
-    def _visit_block(self, block: StmtBlock, ctx: EvalCtx):
+    def _visit_block(self, block: StmtBlock, ctx: Context):
         for stmt in block.stmts:
             if isinstance(stmt, ReturnStmt):
                 x = self._visit_return(stmt, ctx)
                 raise FunctionReturnException(x)
             self._visit_statement(stmt, ctx)
 
-    def _visit_function(self, func: FuncDef, ctx: EvalCtx):
+    def _visit_function(self, func: FuncDef, ctx: Context):
         raise NotImplementedError('do not call directly')
-
 
 
 class PythonInterpreter(Interpreter):
@@ -519,15 +547,15 @@ class PythonInterpreter(Interpreter):
         self,
         func: Function,
         args: Sequence[Any],
-        ctx: Optional[EvalCtx] = None
+        ctx: Optional[Context] = None
     ):
         if not isinstance(func, Function):
             raise TypeError(f'Expected Function, got {func}')
         rt = _Interpreter(func.env)
         return rt.eval(func.to_ir(), args, ctx)
 
-    def eval_with_trace(self, func: Function, args: Sequence[Any], ctx = None):
+    def eval_with_trace(self, func: Function, args: Sequence[Any], ctx: Optional[Context] = None):
         raise NotImplementedError('not implemented')
 
-    def eval_expr(self, expr: Expr, env: _Env, ctx: EvalCtx):
+    def eval_expr(self, expr: Expr, env: _Env, ctx: Context):
         raise NotImplementedError('not implemented')

--- a/fpy2/interpret/real.py
+++ b/fpy2/interpret/real.py
@@ -7,14 +7,12 @@ from fractions import Fraction
 
 from typing import Any, Optional, Sequence, TypeAlias
 
-from titanfp.arithmetic.evalctx import EvalCtx, determine_ctx
-from titanfp.arithmetic.ieee754 import Float, IEEECtx, ieee_ctx
 from titanfp.titanic.ndarray import NDArray
-from titanfp.titanic.digital import Digital
 
 from ..runtime.real.interval import RealInterval
 from ..runtime.real.rival_manager import RivalManager, InsufficientPrecisionError, PrecisionLimitExceeded
 
+from ..number import Context, Float, IEEEContext, RM
 from ..runtime.trace import ExprTraceEntry
 from ..runtime.function import Function
 from ..ir import *
@@ -33,6 +31,10 @@ TensorArg: TypeAlias = NDArray | tuple | list
 """Type of tensor arguments in FPy programs; includes native Python types"""
 
 MAX_ITERS = 50
+"""maximum number of iterations for the interpreter"""
+
+_PY_CTX = IEEEContext(11, 64, RM.RNE)
+"""the native Python floating-point context"""
 
 """Maps python operator to the corresponding operator in Rival"""
 _method_table: dict[str, str] = {
@@ -89,18 +91,18 @@ _method_table: dict[str, str] = {
     'signbit': 'signbit',
 }
 
-def _interval_to_real(val: RealInterval, ctx: EvalCtx):
+def _interval_to_real(val: RealInterval, ctx: Context):
     # rounding contexts
-    assert isinstance(ctx, IEEECtx)
+    assert isinstance(ctx, IEEEContext)
     # compute the midpoint
     # TODO: not entirely sound, should be inside the rounding envelope
     lo = Fraction(val.lo)
     hi = Fraction(val.hi)
     mid = (lo + hi) / 2
-    return Float(x=mid, ctx=ctx)
+    return ctx.round(mid)
 
-def _digital_to_str(x: Digital) -> str:
-    m = (-1 if x.negative else 1) * x.c
+def _digital_to_str(x: Float) -> str:
+    m = (-1 if x.s else 1) * x.c
     pow2 = Fraction(2) ** x.exp
     return str(m * pow2)
 
@@ -142,7 +144,7 @@ class _Interpreter(ReduceVisitor):
             return arg
         elif isinstance(arg, int | float):
             return str(arg)
-        elif isinstance(arg, Digital):
+        elif isinstance(arg, Float):
             return _digital_to_str(arg)
         elif isinstance(arg, tuple | list):
             raise NotImplementedError()
@@ -152,7 +154,7 @@ class _Interpreter(ReduceVisitor):
     def eval(self,
         func: FuncDef,
         args: Sequence[Any],
-        ctx: Optional[EvalCtx] = None,
+        ctx: Optional[Context] = None,
     ):
         if not isinstance(func, FuncDef):
             raise TypeError(f'Expected Function, got {type(func)}')
@@ -163,10 +165,14 @@ class _Interpreter(ReduceVisitor):
             raise TypeError(f'Expected {len(func.args)} arguments, got {len(args)}')
 
         # default context if none is specified
+        # determine context if `None` is specified
         if ctx is None:
-            ctx = ieee_ctx(11, 64)
-        ctx = determine_ctx(ctx, func.ctx)
-        self.rival.set_precision(ctx.p)
+            ctx = _PY_CTX
+
+        prec, _ = ctx.round_params()
+        if not isinstance(prec, int):
+            raise RuntimeError(f'could not determine required precision for {ctx}')
+        self.rival.set_precision(prec)
 
         for val, arg in zip(args, func.args):
             match arg.ty:
@@ -208,29 +214,29 @@ class _Interpreter(ReduceVisitor):
             raise RuntimeError(f'unbound variable {name}')
         return name.base # We return the name rather than the value in expression
 
-    def _visit_var(self, e: Var, ctx: EvalCtx):
+    def _visit_var(self, e: Var, ctx: Context):
         return e.name
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return e.val
 
-    def _visit_decnum(self, e: Decnum, ctx: EvalCtx):
+    def _visit_decnum(self, e: Decnum, ctx: Context):
         return str(e.val)
 
-    def _visit_hexnum(self, e: Hexnum, ctx: EvalCtx):
+    def _visit_hexnum(self, e: Hexnum, ctx: Context):
         return str(e.val)
 
-    def _visit_integer(self, e: Integer, ctx: EvalCtx):
+    def _visit_integer(self, e: Integer, ctx: Context):
         return str(e.val)
 
-    def _visit_rational(self, e: Rational, ctx: EvalCtx):
+    def _visit_rational(self, e: Rational, ctx: Context):
         return f'{e.p}/{e.q}'
 
-    def _visit_digits(self, e: Digits, ctx: EvalCtx):
+    def _visit_digits(self, e: Digits, ctx: Context):
         x = Fraction(e.b) ** e.e
         return str(e.m * x)
 
-    def _visit_nary_expr(self, e: NaryExpr, ctx: EvalCtx):
+    def _visit_nary_expr(self, e: NaryExpr, ctx: Context):
         if e.name in _method_table:
             return self._apply_method(e, ctx)
         elif isinstance(e, Cast):
@@ -246,13 +252,13 @@ class _Interpreter(ReduceVisitor):
         else:
             raise NotImplementedError('unknown n-ary expression', e)
 
-    def _apply_method(self, e: NaryExpr, ctx: EvalCtx):
+    def _apply_method(self, e: NaryExpr, ctx: Context):
         fn = _method_table[e.name]
         args = [self._visit_expr(arg, ctx) for arg in e.children]
         arg_values_str = " ".join(map(str, args))
         return f"({fn} {arg_values_str})"
 
-    def _apply_not(self, e: Not, ctx: EvalCtx):
+    def _apply_not(self, e: Not, ctx: Context):
         arg = self._visit_expr(e.children[0], ctx)
         return f'(not {arg})'
 
@@ -264,15 +270,15 @@ class _Interpreter(ReduceVisitor):
         else:
             return f'({op} {self._nary_to_2ary(op, args[:-1])} {args[-1]})'
 
-    def _apply_and(self, e: And, ctx: EvalCtx):
+    def _apply_and(self, e: And, ctx: Context):
         args = [self._visit_expr(arg, ctx) for arg in e.children]
         return self._nary_to_2ary('and', args)
 
-    def _apply_or(self, e: Or, ctx: EvalCtx):
+    def _apply_or(self, e: Or, ctx: Context):
         args = [self._visit_expr(arg, ctx) for arg in e.children]
         return self._nary_to_2ary('or', args)
 
-    def _apply_range(self, e: Range, ctx: EvalCtx):
+    def _apply_range(self, e: Range, ctx: Context):
         stop = self._force_value(self._eval_rival(e.children[0], ctx), ctx)
         if not isinstance(stop, Float):
             raise TypeError(f'expected a real number argument, got {stop}')
@@ -280,23 +286,23 @@ class _Interpreter(ReduceVisitor):
             raise TypeError(f'expected an integer argument, got {stop}')
         return NDArray([str(i) for i in range(int(stop))])
 
-    def _visit_comp_expr(self, e: CompExpr, ctx: EvalCtx):
+    def _visit_comp_expr(self, e: CompExpr, ctx: Context):
         raise NotImplementedError
 
-    def _visit_unknown(self, e: UnknownCall, ctx: EvalCtx):
+    def _visit_unknown(self, e: UnknownCall, ctx: Context):
         raise NotImplementedError
 
-    def _visit_constant(self, e: Constant, ctx: EvalCtx):
+    def _visit_constant(self, e: Constant, ctx: Context):
         raise NotImplementedError
 
-    def _visit_tuple_expr(self, e: TupleExpr, ctx: EvalCtx):
+    def _visit_tuple_expr(self, e: TupleExpr, ctx: Context):
         elts = [self._eval_rival(elt, ctx) for elt in e.children]
         return NDArray(elts)
 
-    def _visit_tuple_ref(self, e: TupleRef, ctx: EvalCtx):
+    def _visit_tuple_ref(self, e: TupleRef, ctx: Context):
         raise NotImplementedError
 
-    def _visit_tuple_set(self, e: TupleSet, ctx: EvalCtx):
+    def _visit_tuple_set(self, e: TupleSet, ctx: Context):
         raise NotImplementedError
 
     def _apply_cmp2(self, op: CompareOp, lhs, rhs):
@@ -316,7 +322,7 @@ class _Interpreter(ReduceVisitor):
             case _:
                 raise NotImplementedError('unknown comparison operator', op)
 
-    def _visit_compare(self, e: Compare, ctx: EvalCtx):
+    def _visit_compare(self, e: Compare, ctx: Context):
         args: list[str] = []
         lhs = self._visit_expr(e.children[0], ctx)
         for op, arg in zip(e.ops, e.children[1:]):
@@ -325,7 +331,7 @@ class _Interpreter(ReduceVisitor):
             lhs = rhs
         return self._nary_to_2ary('and', args)
 
-    def _visit_if_expr(self, e: IfExpr, ctx: EvalCtx):
+    def _visit_if_expr(self, e: IfExpr, ctx: Context):
         cond = self._visit_expr(e.cond, ctx)
         ift = self._visit_expr(e.ift, ctx)
         iff = self._visit_expr(e.iff, ctx)
@@ -349,7 +355,7 @@ class _Interpreter(ReduceVisitor):
             case _:
                 raise NotImplementedError(f'unknown type {arg} {type(arg)}')
 
-    def _eval_rival_inner(self, expr: Expr, ctx: EvalCtx):
+    def _eval_rival_inner(self, expr: Expr, ctx: Context):
         match self._visit_expr(expr, ctx):
             case bool() as b:
                 return b
@@ -368,7 +374,7 @@ class _Interpreter(ReduceVisitor):
                     # numerical constant
                     return s
 
-    def _eval_rival(self, expr: Expr, ctx: EvalCtx):
+    def _eval_rival(self, expr: Expr, ctx: Context):
         """
         Applies Rival to an expression.
         If the expression is exact, returns its value as a string.
@@ -380,7 +386,7 @@ class _Interpreter(ReduceVisitor):
             self.expr_trace.append(trace)
         return val
 
-    def _force_value(self, val: ScalarVal, ctx: EvalCtx):
+    def _force_value(self, val: ScalarVal, ctx: Context):
         """
         Not every expression is evaluated to a concrete value.
         This function ensures that the result is a concrete value.
@@ -393,13 +399,13 @@ class _Interpreter(ReduceVisitor):
                     case bool() as b:
                         return b
                     case str() as s:
-                        assert isinstance(ctx, IEEECtx), 'expected an IEEECtx'
+                        assert isinstance(ctx, IEEEContext), 'expected an IEEEContext'
                         if s == 'nan':
                             return Float(isnan=True, ctx=ctx)
                         elif s == '+inf':
-                            return Float(isinf=True, negative=False, ctx=ctx)
+                            return Float(isinf=True, s=False, ctx=ctx)
                         elif s == '-inf':
-                            return Float(isinf=True, negative=True, ctx=ctx)
+                            return Float(isinf=True, s=True, ctx=ctx)
                         else:
                             raise NotImplementedError(f'unknown string value {s}')
                     case RealInterval() as ival:
@@ -413,7 +419,7 @@ class _Interpreter(ReduceVisitor):
             case _:
                 raise NotImplementedError(f'unreachable {val}')
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: EvalCtx):
+    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: Context):
         match stmt.var:
             case NamedId():
                 # only `SourceId` comes from the parser
@@ -421,8 +427,12 @@ class _Interpreter(ReduceVisitor):
                 #   <do something>
                 if stmt.var not in self.req_prec:
                     # first time visiting this assignment
-                    self.req_prec[stmt.var] = ctx.p
-                    self.curr_prec[stmt.var] = ctx.p
+                    prec, _ = ctx.round_params()
+                    if not isinstance(prec, int):
+                        raise RuntimeError(f'could not determine required precision for {ctx}')
+
+                    self.req_prec[stmt.var] = prec
+                    self.curr_prec[stmt.var] = prec
                 else:
                     # revisiting this assignment
                     if stmt.var not in self.visited:
@@ -438,7 +448,7 @@ class _Interpreter(ReduceVisitor):
             case _:
                 raise NotImplementedError('unknown variable', stmt.var)
 
-    def _visit_cond(self, cond: Expr, ctx: EvalCtx):
+    def _visit_cond(self, cond: Expr, ctx: Context):
         v = self._eval_rival(cond, ctx)
         if v == 'nan':
             # Rival instance returns +nan.0 even if the expression is a boolean
@@ -449,7 +459,7 @@ class _Interpreter(ReduceVisitor):
                 raise TypeError(f'expected a boolean, got {val}')
             return val
 
-    def _visit_if1(self, stmt: If1Stmt, ctx: EvalCtx):
+    def _visit_if1(self, stmt: If1Stmt, ctx: Context):
         if self._visit_cond(stmt.cond, ctx):
             self._visit_block(stmt.body, ctx)
             for phi in stmt.phis:
@@ -458,7 +468,7 @@ class _Interpreter(ReduceVisitor):
             for phi in stmt.phis:
                 self.env[phi.name] = self.env[phi.lhs]
 
-    def _visit_if(self, stmt: IfStmt, ctx: EvalCtx):
+    def _visit_if(self, stmt: IfStmt, ctx: Context):
         if self._visit_cond(stmt.cond, ctx):
             self._visit_block(stmt.ift, ctx)
             for phi in stmt.phis:
@@ -468,11 +478,58 @@ class _Interpreter(ReduceVisitor):
             for phi in stmt.phis:
                 self.env[phi.name] = self.env[phi.rhs]
 
-    def _visit_context(self, stmt: ContextStmt, ctx: EvalCtx):
-        ctx = determine_ctx(ctx, stmt.props)
+    def _visit_foreign_attr(self, e: ForeignAttribute):
+        # lookup the root value (should be captured)
+        val = self._lookup(e.name)
+        # walk the attribute chain
+        for attr_id in e.attrs:
+            # need to manually lookup the attribute
+            attr = str(attr_id)
+            if isinstance(val, dict):
+                if attr not in val:
+                    raise RuntimeError(f'unknown attribute {attr} for {val}')
+                val = val[attr]
+            elif hasattr(val, attr):
+                val = getattr(val, attr)
+            else:
+                raise RuntimeError(f'unknown attribute {attr} for {val}')
+        return val
+
+    def _visit_context_expr(self, e: ContextExpr, ctx: Context):
+        match e.ctor:
+            case ForeignAttribute():
+                ctor = self._visit_foreign_attr(e.ctor)
+            case Var():
+                ctor = self._visit_var(e.ctor, ctx)
+
+        args: list[Any] = []
+        for arg in e.args:
+            match arg:
+                case ForeignAttribute():
+                    args.append(self._visit_foreign_attr(arg))
+                case _:
+                    v = self._visit_expr(arg, ctx)
+                    if isinstance(v, Float) and v.is_integer():
+                        # HACK: keeps things as specific as possible
+                        args.append(int(v))
+                    else:
+                        args.append(v)
+        return ctor(*args)
+
+    def _visit_context(self, stmt: ContextStmt, ctx: Context):
+        match stmt.ctx:
+            case ContextExpr():
+                ctx = self._visit_context_expr(stmt.ctx, ctx)
+            case Var():
+                ctx = self._lookup(stmt.ctx.name)
+            case _:
+                raise RuntimeError(f'unknown context {stmt.ctx}')
+
+        if not isinstance(ctx, Context):
+            raise RuntimeError(f'Expected a \'Context\', got {ctx}')
         return self._visit_block(stmt.body, ctx)
 
-    def _visit_assert(self, stmt: AssertStmt, ctx: EvalCtx):
+    def _visit_assert(self, stmt: AssertStmt, ctx: Context):
         test = self._visit_cond(stmt.test, ctx)
         if not test:
             raise AssertionError(stmt.msg)
@@ -481,13 +538,17 @@ class _Interpreter(ReduceVisitor):
     def _visit_effect(self, stmt, ctx):
         raise NotImplementedError
 
-    def _visit_return(self, stmt: ReturnStmt, ctx: EvalCtx) -> bool | float:
+    def _visit_return(self, stmt: ReturnStmt, ctx: Context) -> bool | float:
         # since we are returning we actually want a value
-        self.rival.set_precision(ctx.p)
+        prec, _ = ctx.round_params()
+        if not isinstance(prec, int):
+            raise RuntimeError(f'could not determine required precision for {ctx}')
+
+        self.rival.set_precision(prec)
         val = self._eval_rival(stmt.expr, ctx)
         return self._force_value(val, ctx)
 
-    def _visit_block(self, block: StmtBlock, ctx: EvalCtx):
+    def _visit_block(self, block: StmtBlock, ctx: Context):
         for stmt in block.stmts:
             if isinstance(stmt, ReturnStmt):
                 v = self._visit_return(stmt, ctx)
@@ -495,7 +556,7 @@ class _Interpreter(ReduceVisitor):
             else:
                 self._visit_statement(stmt, ctx)
 
-    def _visit_while(self, stmt: WhileStmt, ctx: EvalCtx) -> None:
+    def _visit_while(self, stmt: WhileStmt, ctx: Context) -> None:
         for phi in stmt.phis:
             self.env[phi.name] = self.env[phi.lhs]
             del self.env[phi.lhs]
@@ -506,13 +567,13 @@ class _Interpreter(ReduceVisitor):
                 self.env[phi.name] = self.env[phi.rhs]
                 del self.env[phi.rhs]
 
-    def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: EvalCtx):
+    def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: Context):
         raise NotImplementedError
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: EvalCtx):
+    def _visit_index_assign(self, stmt: IndexAssign, ctx: Context):
         raise NotImplementedError
 
-    def _visit_for(self, stmt: ForStmt, ctx: EvalCtx):
+    def _visit_for(self, stmt: ForStmt, ctx: Context):
         for phi in stmt.phis:
             self.env[phi.name] = self.env[phi.lhs]
             del self.env[phi.lhs]
@@ -529,11 +590,11 @@ class _Interpreter(ReduceVisitor):
                 self.env[phi.name] = self.env[phi.rhs]
                 del self.env[phi.rhs]
 
-    def _visit_function(self, func: FuncDef, ctx: EvalCtx):
+    def _visit_function(self, func: FuncDef, ctx: Context):
         raise NotImplementedError('do not call directly')
     
     # override for typing
-    def _visit_expr(self, e: Expr, ctx: EvalCtx) -> NDArray | NamedId | str | bool:
+    def _visit_expr(self, e: Expr, ctx: Context) -> NDArray | NamedId | str | bool:
         return super()._visit_expr(e, ctx)
 
 
@@ -559,7 +620,7 @@ class RealInterpreter(Interpreter):
         self,
         func: Function,
         args: Sequence[Any],
-        ctx: Optional[EvalCtx] = None
+        ctx: Optional[Context] = None
     ):
         if not isinstance(func, Function):
             raise TypeError(f'Expected Function, got {func}')
@@ -573,7 +634,7 @@ class RealInterpreter(Interpreter):
         self,
         func: Function,
         args: Sequence[Any],
-        ctx: Optional[EvalCtx] = None
+        ctx: Optional[Context] = None
     ):
         if not isinstance(func, Function):
             raise TypeError(f'Expected Function, got {func}')

--- a/fpy2/interpret/real.py
+++ b/fpy2/interpret/real.py
@@ -220,6 +220,9 @@ class _Interpreter(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return e.val
 
+    def _visit_context_val(self, e: ContextVal, ctx: Any):
+        return e.val
+
     def _visit_decnum(self, e: Decnum, ctx: Context):
         return str(e.val)
 

--- a/fpy2/interpret/titanic.py
+++ b/fpy2/interpret/titanic.py
@@ -2,25 +2,24 @@
 FPy runtime backed by the Titanic library.
 """
 
+from fractions import Fraction
 from typing import Any, Callable, Optional, Sequence, TypeAlias
 
-from titanfp.arithmetic.evalctx import EvalCtx, determine_ctx
-from titanfp.arithmetic.ieee754 import ieee_ctx
-from titanfp.arithmetic.mpmf import MPMF
-from titanfp.titanic.digital import Digital
 from titanfp.titanic.ndarray import NDArray
-from titanfp.titanic.ops import OP
-import titanfp.titanic.gmpmath as gmpmath
 
+from .. import math
+
+from ..number import Context, Float, IEEEContext, RM
+from ..number.gmp import mpfr_constant
 from ..runtime.trace import ExprTraceEntry
 from ..runtime.env import ForeignEnv
 from ..runtime.function import Function
 from ..ir import *
+from ..utils import decnum_to_fraction, hexnum_to_fraction, digits_to_fraction
 
 from .interpreter import Interpreter, FunctionReturnException
 
-
-ScalarVal: TypeAlias = bool | Digital
+ScalarVal: TypeAlias = bool | Float
 """Type of scalar values in FPy programs."""
 TensorVal: TypeAlias = NDArray
 """Type of tensor values in FPy programs."""
@@ -30,74 +29,89 @@ ScalarArg: TypeAlias = ScalarVal | str | int | float
 TensorArg: TypeAlias = NDArray | tuple | list
 """Type of tensor arguments in FPy programs; includes native Python types"""
 
-def _isinf(x: MPMF) -> bool:
+def _isfinite(x: Float, _: Context) -> bool:
+    return x.is_finite()
+
+def _isinf(x: Float, _: Context) -> bool:
     return x.isinf
 
-def _isnan(x: MPMF) -> bool:
+def _isnan(x: Float, _: Context) -> bool:
     return x.isnan
 
+def _isnormal(x: Float, _: Context) -> bool:
+    # TODO: should all Floats have this property?
+    return True
+
+def _signbit(x: Float, _: Context) -> bool:
+    # TODO: should all Floats have this property?
+    return x.s
+
 _method_table: dict[str, Callable[..., Any]] = {
-    '+': MPMF.add,
-    '-': MPMF.sub,
-    '*': MPMF.mul,
-    '/': MPMF.div,
-    'fabs': MPMF.fabs,
-    'sqrt': MPMF.sqrt,
-    'fma': MPMF.fma,
-    'neg': MPMF.neg,
-    'copysign': MPMF.copysign,
-    'fdim': MPMF.fdim,
-    'fmax': MPMF.fmax,
-    'fmin': MPMF.fmin,
-    'fmod': MPMF.fmod,
-    'remainder': MPMF.remainder,
-    'hypot': MPMF.hypot,
-    'cbrt': MPMF.cbrt,
-    'ceil': MPMF.ceil,
-    'floor': MPMF.floor,
-    'nearbyint': MPMF.nearbyint,
-    'round': MPMF.round,
-    'trunc': MPMF.trunc,
-    'acos': MPMF.acos,
-    'asin': MPMF.asin,
-    'atan': MPMF.atan,
-    'atan2': MPMF.atan2,
-    'cos': MPMF.cos,
-    'sin': MPMF.sin,
-    'tan': MPMF.tan,
-    'acosh': MPMF.acosh,
-    'asinh': MPMF.asinh,
-    'atanh': MPMF.atanh,
-    'cosh': MPMF.cosh,
-    'sinh': MPMF.sinh,
-    'tanh': MPMF.tanh,
-    'exp': MPMF.exp_,
-    'exp2': MPMF.exp2,
-    'expm1': MPMF.expm1,
-    'log': MPMF.log,
-    'log10': MPMF.log10,
-    'log1p': MPMF.log1p,
-    'log2': MPMF.log2,
-    'pow': MPMF.pow,
-    'erf': MPMF.erf,
-    'erfc': MPMF.erfc,
-    'lgamma': MPMF.lgamma,
-    'tgamma': MPMF.tgamma,
-    'isfinite': MPMF.isfinite,
+    '+': math.add,
+    '-': math.sub,
+    '*': math.mul,
+    '/': math.div,
+    'fabs': math.fabs,
+    'sqrt': math.sqrt,
+    'fma': math.fma,
+    'neg': math.neg,
+    'copysign': math.copysign,
+    'fdim': math.fdim,
+    'fmax': math.fmax,
+    'fmin': math.fmin,
+    'fmod': math.fmod,
+    'remainder': math.remainder,
+    'hypot': math.hypot,
+    'cbrt': math.cbrt,
+    'ceil': math.ceil,
+    'floor': math.floor,
+    'nearbyint': math.nearbyint,
+    'round': math.round,
+    'trunc': math.trunc,
+    'acos': math.acos,
+    'asin': math.asin,
+    'atan': math.atan,
+    'atan2': math.atan2,
+    'cos': math.cos,
+    'sin': math.sin,
+    'tan': math.tan,
+    'acosh': math.acosh,
+    'asinh': math.asinh,
+    'atanh': math.atanh,
+    'cosh': math.cosh,
+    'sinh': math.sinh,
+    'tanh': math.tanh,
+    'exp': math.exp,
+    'exp2': math.exp2,
+    'expm1': math.expm1,
+    'log': math.log,
+    'log10': math.log10,
+    'log1p': math.log1p,
+    'log2': math.log2,
+    'pow': math.pow,
+    'erf': math.erf,
+    'erfc': math.erfc,
+    'lgamma': math.lgamma,
+    'tgamma': math.tgamma,
+    'isfinite': _isfinite,
     'isinf': _isinf,
     'isnan': _isnan,
-    'isnormal': MPMF.isnormal,
-    'signbit': MPMF.signbit,
+    'isnormal': _isnormal,
+    'signbit': _signbit,
 }
 
 _Env: TypeAlias = dict[NamedId, ScalarVal | TensorVal]
+
+_PY_CTX = IEEEContext(11, 64, RM.RNE)
+"""the native Python floating-point context"""
+
 
 class _Interpreter(ReduceVisitor):
     """Single-use interpreter for a function"""
 
     foreign: ForeignEnv
     """foreign environment"""
-    override_ctx: Optional[EvalCtx]
+    override_ctx: Optional[Context]
     """optional overriding context"""
     env: _Env
     """Environment mapping variable names to values"""
@@ -110,7 +124,7 @@ class _Interpreter(ReduceVisitor):
         self, 
         foreign: ForeignEnv,
         *,
-        override_ctx: Optional[EvalCtx] = None,
+        override_ctx: Optional[Context] = None,
         env: Optional[_Env] = None,
         enable_trace: bool = False
     ):
@@ -123,28 +137,31 @@ class _Interpreter(ReduceVisitor):
         self.trace = []
         self.enable_trace = enable_trace
 
-    def _eval_ctx(self, ctx: EvalCtx):
+    def _eval_ctx(self, ctx: Context):
         if self.override_ctx is None:
             return ctx
         else:
             return self.override_ctx
 
     # TODO: what are the semantics of arguments
-    def _arg_to_mpmf(self, arg: Any, ctx: EvalCtx):
-        if isinstance(arg, int | float):
-            return MPMF(x=arg, ctx=ctx)
-        elif isinstance(arg, Digital):
-            return MPMF(x=arg, ctx=ctx)
-        elif isinstance(arg, tuple | list):
-            return NDArray([self._arg_to_mpmf(x, ctx) for x in arg])
-        else:
-            return arg
+    def _arg_to_mpmf(self, arg: Any, ctx: Context):
+        match arg:
+            case int():
+                return Float.from_int(arg, ctx=ctx)
+            case float():
+                return Float.from_float(arg, ctx=ctx)
+            case Float():
+                return arg.round(ctx)
+            case tuple() | list():
+                return NDArray([self._arg_to_mpmf(x, ctx) for x in arg])
+            case _:
+                return arg
 
     def eval(
         self,
         func: FuncDef,
         args: Sequence[Any],
-        ctx: Optional[EvalCtx] = None
+        ctx: Optional[Context] = None
     ):
         # check arity
         args = tuple(args)
@@ -153,8 +170,11 @@ class _Interpreter(ReduceVisitor):
 
         # determine context if `None` is specified
         if ctx is None:
-            ctx = ieee_ctx(11, 64)
-        ctx = determine_ctx(ctx, func.ctx)
+            ctx = _PY_CTX
+
+        # possibly override the context
+        ctx = self._eval_ctx(ctx)
+        assert isinstance(ctx, Context)
 
         # process arguments and add to environment
         for val, arg in zip(args, func.args):
@@ -165,7 +185,7 @@ class _Interpreter(ReduceVisitor):
                         self.env[arg.name] = x
                 case RealType():
                     x = self._arg_to_mpmf(val, ctx)
-                    if not isinstance(x, Digital):
+                    if not isinstance(x, Float):
                         raise NotImplementedError(f'argument is a scalar, got data {val}')
                     if isinstance(arg.name, NamedId):
                         self.env[arg.name] = x
@@ -189,82 +209,62 @@ class _Interpreter(ReduceVisitor):
             raise RuntimeError(f'unbound variable {name}')
         return self.env[name]
 
-    def _visit_var(self, e: Var, ctx: EvalCtx):
+    def _visit_var(self, e: Var, ctx: Context):
         return self._lookup(e.name)
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return e.val
 
-    def _visit_decnum(self, e: Decnum, ctx: EvalCtx):
-        ctx = self._eval_ctx(ctx)
-        return MPMF(x=e.val, ctx=ctx)
+    def _visit_decnum(self, e: Decnum, ctx: Context):
+        x = decnum_to_fraction(e.val)
+        return ctx.round(x)
 
-    def _visit_integer(self, e: Integer, ctx: EvalCtx):
-        ctx = self._eval_ctx(ctx)
-        x = Digital(m=e.val, exp=0, inexact=False)
-        return MPMF._round_to_context(x, ctx=ctx)
+    def _visit_integer(self, e: Integer, ctx: Context):
+        return ctx.round(e.val)
 
-    def _visit_hexnum(self, e: Hexnum, ctx: EvalCtx):
-        return MPMF(x=e.val, ctx=ctx)
+    def _visit_hexnum(self, e: Hexnum, ctx: Context):
+        x = hexnum_to_fraction(e.val)
+        return ctx.round(x)
 
-    def _visit_rational(self, e: Rational, ctx: EvalCtx):
-        ctx = self._eval_ctx(ctx)
-        p = Digital(m=e.p, exp=0, inexact=False)
-        q = Digital(m=e.q, exp=0, inexact=False)
-        x = gmpmath.compute(OP.div, p, q, prec=ctx.p)
-        return MPMF._round_to_context(x, ctx=ctx)
+    def _visit_rational(self, e: Rational, ctx: Context):
+        x = Fraction(e.p, e.q)
+        return ctx.round(x)
 
-    def _visit_constant(self, e: Constant, ctx: EvalCtx):
-        ctx = self._eval_ctx(ctx)
-        x = gmpmath.compute_constant(e.val, prec=ctx.p)
-        return MPMF._round_to_context(x, ctx=ctx)
+    def _visit_constant(self, e: Constant, ctx: Context):
+        prec, _ = ctx.round_params()
+        assert isinstance(prec, int) # TODO: not every context produces has a known precision
+        x = mpfr_constant(e.val, prec=prec)
+        return ctx.round(x)
 
-    def _visit_digits(self, e: Digits, ctx: EvalCtx):
-        ctx = self._eval_ctx(ctx)
-        x = gmpmath.compute_digits(e.m, e.e, e.b, prec=ctx.p)
-        return MPMF._round_to_context(x, ctx)
+    def _visit_digits(self, e: Digits, ctx: Context):
+        x = digits_to_fraction(e.m, e.e, e.b)
+        return ctx.round(x)
 
-    def _apply_method(self, e: NaryExpr, ctx: EvalCtx):
+    def _apply_method(self, e: NaryExpr, ctx: Context):
         fn = _method_table[e.name]
-        args: list[Digital] = []
+        args: list[Float] = []
         for arg in e.children:
             val = self._visit_expr(arg, ctx)
-            if not isinstance(val, Digital):
+            if not isinstance(val, Float):
                 raise TypeError(f'expected a real number argument for {e.name}, got {val}')
             args.append(val)
 
         # compute the result
-        ctx = self._eval_ctx(ctx)
-        try:
-            result = fn(*args, ctx=ctx)
-        except gmpmath.SignedOverflow as err:
-            # we overflowed beyond MPFR's limits, generate a large value and round it
-            exp = ctx.emax + 1
-            x = Digital(negative=err.sign, c=1, exp=exp)
-            result = MPMF._round_to_context(x, ctx=ctx)
-        except gmpmath.SignedUnderflow as e:
-            # we underflowed beyond MPFR's limits, generate a small value and round it
-            ctx = self._eval_ctx(ctx)
-            exp = ctx.emin - ctx.p - 1
-            x = Digital(negative=e.sign, c=1, exp=exp)
-            result = MPMF._round_to_context(x, ctx=ctx)
+        return fn(*args, ctx=ctx)
 
-        return result
-
-    def _apply_cast(self, e: Cast, ctx: EvalCtx):
+    def _apply_cast(self, e: Cast, ctx: Context):
         x = self._visit_expr(e.children[0], ctx)
-        if not isinstance(x, Digital):
+        if not isinstance(x, Float):
             raise TypeError(f'expected a real number argument, got {x}')
-        ctx = self._eval_ctx(ctx)
-        return MPMF._round_to_context(x, ctx)
+        return ctx.round(x)
 
-    def _apply_not(self, e: Not, ctx: EvalCtx):
+    def _apply_not(self, e: Not, ctx: Context):
         arg = self._visit_expr(e.children[0], ctx)
         if not isinstance(arg, bool):
             raise TypeError(f'expected a boolean argument, got {arg}')
         return not arg
 
-    def _apply_and(self, e: And, ctx: EvalCtx):
+    def _apply_and(self, e: And, ctx: Context):
         args: list[bool] = []
         for arg in e.children:
             val = self._visit_expr(arg, ctx)
@@ -273,7 +273,7 @@ class _Interpreter(ReduceVisitor):
             args.append(val)
         return all(args)
 
-    def _apply_or(self, e: Or, ctx: EvalCtx):
+    def _apply_or(self, e: Or, ctx: Context):
         args: list[bool] = []
         for arg in e.children:
             val = self._visit_expr(arg, ctx)
@@ -282,40 +282,42 @@ class _Interpreter(ReduceVisitor):
             args.append(val)
         return any(args)
 
-    def _apply_shape(self, e: Shape, ctx: EvalCtx):
+    def _apply_shape(self, e: Shape, ctx: Context):
         v = self._visit_expr(e.children[0], ctx)
         if not isinstance(v, NDArray):
             raise TypeError(f'expected a tensor, got {v}')
-        return NDArray([MPMF(x, ctx) for x in v.shape])
+        return NDArray([ctx.round(x) for x in v.shape])
 
-    def _apply_range(self, e: Range, ctx: EvalCtx):
+    def _apply_range(self, e: Range, ctx: Context):
         stop = self._visit_expr(e.children[0], ctx)
-        if not isinstance(stop, Digital):
+        if not isinstance(stop, Float):
             raise TypeError(f'expected a real number argument, got {stop}')
         if not stop.is_integer():
             raise TypeError(f'expected an integer argument, got {stop}')
-        return NDArray([MPMF._round_to_context(Digital(negative=i < 0, c=abs(i)), ctx) for i in range(int(stop))])
 
-    def _apply_dim(self, e: Dim, ctx: EvalCtx):
+        elts: list[Float] = []
+        for i in range(int(stop)):
+            elts.append(Float.from_int(i, ctx=ctx))
+        return NDArray(elts)
+
+    def _apply_dim(self, e: Dim, ctx: Context):
         v = self._visit_expr(e.children[0], ctx)
         if not isinstance(v, NDArray):
             raise TypeError(f'expected a tensor, got {v}')
-        x = Digital(c=len(v.shape))
-        return MPMF._round_to_context(x, ctx)
+        return Float.from_int(len(v.shape), ctx=ctx)
 
-    def _apply_size(self, e: Size, ctx: EvalCtx):
+    def _apply_size(self, e: Size, ctx: Context):
         v = self._visit_expr(e.children[0], ctx)
         if not isinstance(v, NDArray):
             raise TypeError(f'expected a tensor, got {v}')
         dim = self._visit_expr(e.children[1], ctx)
-        if not isinstance(dim, Digital):
+        if not isinstance(dim, Float):
             raise TypeError(f'expected a real number argument, got {dim}')
         if not dim.is_integer():
             raise TypeError(f'expected an integer argument, got {dim}')
-        x = Digital(c=v.shape[int(dim)])
-        return MPMF._round_to_context(x, ctx)
+        return Float.from_int(v.shape[int(dim)], ctx=ctx)
 
-    def _visit_nary_expr(self, e: NaryExpr, ctx: EvalCtx):
+    def _visit_nary_expr(self, e: NaryExpr, ctx: Context):
         if e.name in _method_table:
             return self._apply_method(e, ctx)
         elif isinstance(e, Cast):
@@ -337,7 +339,7 @@ class _Interpreter(ReduceVisitor):
         else:
             raise NotImplementedError('unknown n-ary expression', e)
 
-    def _visit_unknown(self, e: UnknownCall, ctx: EvalCtx):
+    def _visit_unknown(self, e: UnknownCall, ctx: Context):
         args = [self._visit_expr(arg, ctx) for arg in e.children]
         fn = self.foreign[e.name]
         if isinstance(fn, Function):
@@ -367,7 +369,7 @@ class _Interpreter(ReduceVisitor):
             case _:
                 raise NotImplementedError('unknown comparison operator', op)
 
-    def _visit_compare(self, e: Compare, ctx: EvalCtx):
+    def _visit_compare(self, e: Compare, ctx: Context):
         lhs = self._visit_expr(e.children[0], ctx)
         for op, arg in zip(e.ops, e.children[1:]):
             rhs = self._visit_expr(arg, ctx)
@@ -376,10 +378,10 @@ class _Interpreter(ReduceVisitor):
             lhs = rhs
         return True
 
-    def _visit_tuple_expr(self, e: TupleExpr, ctx: EvalCtx):
+    def _visit_tuple_expr(self, e: TupleExpr, ctx: Context):
         return NDArray([self._visit_expr(x, ctx) for x in e.children])
 
-    def _visit_tuple_ref(self, e: TupleRef, ctx: EvalCtx):
+    def _visit_tuple_ref(self, e: TupleRef, ctx: Context):
         value = self._visit_expr(e.value, ctx)
         if not isinstance(value, NDArray):
             raise TypeError(f'expected a tensor, got {value}')
@@ -387,7 +389,7 @@ class _Interpreter(ReduceVisitor):
         slices: list[int] = []
         for s in e.slices:
             val = self._visit_expr(s, ctx)
-            if not isinstance(val, Digital):
+            if not isinstance(val, Float):
                 raise TypeError(f'expected a real number slice, got {val}')
             if not val.is_integer():
                 raise TypeError(f'expected an integer slice, got {val}')
@@ -395,7 +397,7 @@ class _Interpreter(ReduceVisitor):
 
         return value[slices]
 
-    def _visit_tuple_set(self, e: TupleSet, ctx: EvalCtx):
+    def _visit_tuple_set(self, e: TupleSet, ctx: Context):
         value = self._visit_expr(e.array, ctx)
         if not isinstance(value, NDArray):
             raise TypeError(f'expected a tensor, got {value}')
@@ -404,7 +406,7 @@ class _Interpreter(ReduceVisitor):
         slices: list[int] = []
         for s in e.slices:
             val = self._visit_expr(s, ctx)
-            if not isinstance(val, Digital):
+            if not isinstance(val, Float):
                 raise TypeError(f'expected a real number slice, got {val}')
             if not val.is_integer():
                 raise TypeError(f'expected an integer slice, got {val}')
@@ -418,7 +420,7 @@ class _Interpreter(ReduceVisitor):
         self,
         bindings: list[tuple[Id, Expr]],
         elt: Expr,
-        ctx: EvalCtx,
+        ctx: Context,
         elts: list[Any]
     ):
         if bindings == []:
@@ -433,7 +435,7 @@ class _Interpreter(ReduceVisitor):
                     self.env[var] = val
                 self._apply_comp(bindings[1:], elt, ctx, elts)
 
-    def _visit_comp_expr(self, e: CompExpr, ctx: EvalCtx):
+    def _visit_comp_expr(self, e: CompExpr, ctx: Context):
         # evaluate comprehension
         elts: list[Any] = []
         bindings = [(var, iterable) for var, iterable in zip(e.vars, e.iterables)]
@@ -446,16 +448,16 @@ class _Interpreter(ReduceVisitor):
 
         return NDArray(elts)
 
-    def _visit_if_expr(self, e: IfExpr, ctx: EvalCtx):
+    def _visit_if_expr(self, e: IfExpr, ctx: Context):
         cond = self._visit_expr(e.cond, ctx)
         if not isinstance(cond, bool):
             raise TypeError(f'expected a boolean, got {cond}')
         return self._visit_expr(e.ift if cond else e.iff, ctx)
 
-    def _visit_context_expr(self, e: ContextExpr, ctx: EvalCtx):
+    def _visit_context_expr(self, e: ContextExpr, ctx: Context):
         raise RuntimeError('do not call directly')
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: EvalCtx) -> None:
+    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: Context) -> None:
         val = self._visit_expr(stmt.expr, ctx)
         if self.enable_trace:
             entry = ExprTraceEntry(stmt.expr, val, dict(self.env), ctx)
@@ -469,7 +471,7 @@ class _Interpreter(ReduceVisitor):
             case _:
                 raise NotImplementedError('unknown variable', stmt.var)
 
-    def _unpack_tuple(self, binding: TupleBinding, val: NDArray, ctx: EvalCtx) -> None:
+    def _unpack_tuple(self, binding: TupleBinding, val: NDArray, ctx: Context) -> None:
         if len(binding.elts) != len(val):
             raise NotImplementedError(f'unpacking {len(val)} values into {len(binding.elts)}')
         for elt, v in zip(binding.elts, val):
@@ -483,7 +485,7 @@ class _Interpreter(ReduceVisitor):
                 case _:
                     raise NotImplementedError('unknown tuple element', elt)
 
-    def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: EvalCtx) -> None:
+    def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: Context) -> None:
         val = self._visit_expr(stmt.expr, ctx)
         if not isinstance(val, NDArray):
             raise TypeError(f'expected a tuple, got {val}')
@@ -494,7 +496,7 @@ class _Interpreter(ReduceVisitor):
 
         self._unpack_tuple(stmt.binding, val, ctx)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: EvalCtx) -> None:
+    def _visit_index_assign(self, stmt: IndexAssign, ctx: Context) -> None:
         # lookup array
         array = self._lookup(stmt.var)
 
@@ -512,7 +514,7 @@ class _Interpreter(ReduceVisitor):
         val = self._visit_expr(stmt.expr, ctx)
         array[slices] = val
 
-    def _visit_if1(self, stmt: If1Stmt, ctx: EvalCtx):
+    def _visit_if1(self, stmt: If1Stmt, ctx: Context):
         cond = self._visit_expr(stmt.cond, ctx)
         if not isinstance(cond, bool):
             raise TypeError(f'expected a boolean, got {cond}')
@@ -524,7 +526,7 @@ class _Interpreter(ReduceVisitor):
             for phi in stmt.phis:
                 self.env[phi.name] = self.env[phi.lhs]
 
-    def _visit_if(self, stmt: IfStmt, ctx: EvalCtx) -> None:
+    def _visit_if(self, stmt: IfStmt, ctx: Context) -> None:
         cond = self._visit_expr(stmt.cond, ctx)
         if not isinstance(cond, bool):
             raise TypeError(f'expected a boolean, got {cond}')
@@ -542,7 +544,7 @@ class _Interpreter(ReduceVisitor):
             for phi in stmt.phis:
                 self.env[phi.name] = self.env[phi.rhs]
 
-    def _visit_while(self, stmt: WhileStmt, ctx: EvalCtx) -> None:
+    def _visit_while(self, stmt: WhileStmt, ctx: Context) -> None:
         for phi in stmt.phis:
             self.env[phi.name] = self.env[phi.lhs]
             del self.env[phi.lhs]
@@ -570,7 +572,7 @@ class _Interpreter(ReduceVisitor):
                 self.trace.append(entry)
 
 
-    def _visit_for(self, stmt: ForStmt, ctx: EvalCtx) -> None:
+    def _visit_for(self, stmt: ForStmt, ctx: Context) -> None:
         for phi in stmt.phis:
             self.env[phi.name] = self.env[phi.lhs]
             del self.env[phi.lhs]
@@ -587,7 +589,7 @@ class _Interpreter(ReduceVisitor):
                 self.env[phi.name] = self.env[phi.rhs]
                 del self.env[phi.rhs]
 
-    def _visit_context(self, stmt: ContextStmt, ctx: EvalCtx):
+    def _visit_context(self, stmt: ContextStmt, ctx: Context):
         props = {}
         for k, v in stmt.props.items():
             if isinstance(v, NamedId):
@@ -598,7 +600,7 @@ class _Interpreter(ReduceVisitor):
         ctx = determine_ctx(ctx, props)
         return self._visit_block(stmt.body, ctx)
 
-    def _visit_assert(self, stmt: AssertStmt, ctx: EvalCtx):
+    def _visit_assert(self, stmt: AssertStmt, ctx: Context):
         test = self._visit_expr(stmt.test, ctx)
         if not isinstance(test, bool):
             raise TypeError(f'expected a boolean, got {test}')
@@ -606,29 +608,29 @@ class _Interpreter(ReduceVisitor):
             raise AssertionError(stmt.msg)
         return ctx
 
-    def _visit_effect(self, stmt: EffectStmt, ctx: EvalCtx):
+    def _visit_effect(self, stmt: EffectStmt, ctx: Context):
         self._visit_expr(stmt.expr, ctx)
         return ctx
 
-    def _visit_return(self, stmt: ReturnStmt, ctx: EvalCtx):
+    def _visit_return(self, stmt: ReturnStmt, ctx: Context):
         val = self._visit_expr(stmt.expr, ctx)
         if self.enable_trace:
             entry = ExprTraceEntry(stmt.expr, val, dict(self.env), ctx)
             self.trace.append(entry)
         return val
 
-    def _visit_block(self, block: StmtBlock, ctx: EvalCtx):
+    def _visit_block(self, block: StmtBlock, ctx: Context):
         for stmt in block.stmts:
             if isinstance(stmt, ReturnStmt):
                 x = self._visit_return(stmt, ctx)
                 raise FunctionReturnException(x)
             self._visit_statement(stmt, ctx)
 
-    def _visit_function(self, func: FuncDef, ctx: EvalCtx):
+    def _visit_function(self, func: FuncDef, ctx: Context):
         raise NotImplementedError('do not call directly')
 
     # override typing hint
-    def _visit_statement(self, stmt, ctx: EvalCtx) -> None:
+    def _visit_statement(self, stmt, ctx: Context) -> None:
         return super()._visit_statement(stmt, ctx)
 
 
@@ -637,23 +639,23 @@ class TitanicInterpreter(Interpreter):
     Standard interpreter for FPy programs.
 
     Programs are evaluated using the Titanic backend (`titanfp`).
-    Booleans are Python `bool` values, real numbers are Titanic `MPMF` values,
+    Booleans are Python `bool` values, real numbers are Titanic `Float` values,
     and tensors are Titanic `NDArray` values.
 
     All operations are correctly-rounded.
     """
 
-    ctx: Optional[EvalCtx] = None
+    ctx: Optional[Context] = None
     """optionaly overriding context"""
 
-    def __init__(self, ctx: Optional[EvalCtx] = None):
+    def __init__(self, ctx: Optional[Context] = None):
         self.ctx = ctx
 
     def eval(
         self,
         func: Function,
         args: Sequence[Any],
-        ctx: Optional[EvalCtx] = None
+        ctx: Optional[Context] = None
     ):
         if not isinstance(func, Function):
             raise TypeError(f'Expected Function, got {func}')
@@ -665,6 +667,6 @@ class TitanicInterpreter(Interpreter):
         result = rt.eval(func.to_ir(), args, ctx)
         return result, rt.trace
 
-    def eval_expr(self, expr: Expr, env: _Env, ctx: EvalCtx):
+    def eval_expr(self, expr: Expr, env: _Env, ctx: Context):
         rt = _Interpreter(ForeignEnv.empty(), override_ctx=self.ctx, env=env)
         return rt._visit_expr(expr, ctx)

--- a/fpy2/interpret/titanic.py
+++ b/fpy2/interpret/titanic.py
@@ -9,7 +9,7 @@ from titanfp.titanic.ndarray import NDArray
 
 from .. import math
 
-from ..frontend import FPCoreContext
+from ..fpc_context import FPCoreContext
 from ..number import Context, Float, IEEEContext, RM
 from ..number.gmp import mpfr_constant
 from ..runtime.trace import ExprTraceEntry

--- a/fpy2/interpret/titanic.py
+++ b/fpy2/interpret/titanic.py
@@ -234,11 +234,9 @@ class _Interpreter(ReduceVisitor):
             args.append(val)
 
         # compute the result
-        print(list(map(float, args)))
         ctx = self._eval_ctx(ctx)
         try:
             result = fn(*args, ctx=ctx)
-            print(result)
         except gmpmath.SignedOverflow as e:
             # we overflowed beyond MPFR's limits, generate a large value and round it
             exp = ctx.emax + 1

--- a/fpy2/interpret/titanic.py
+++ b/fpy2/interpret/titanic.py
@@ -628,6 +628,7 @@ class _Interpreter(ReduceVisitor):
         ctx = self._visit_expr(stmt.ctx, ctx)
         if not isinstance(ctx, Context):
             raise RuntimeError(f'Expected a \'Context\', got {ctx}')
+        ctx = self._eval_ctx(ctx)
         return self._visit_block(stmt.body, ctx)
 
     def _visit_assert(self, stmt: AssertStmt, ctx: Context):

--- a/fpy2/interpret/titanic.py
+++ b/fpy2/interpret/titanic.py
@@ -237,10 +237,10 @@ class _Interpreter(ReduceVisitor):
         ctx = self._eval_ctx(ctx)
         try:
             result = fn(*args, ctx=ctx)
-        except gmpmath.SignedOverflow as e:
+        except gmpmath.SignedOverflow as err:
             # we overflowed beyond MPFR's limits, generate a large value and round it
             exp = ctx.emax + 1
-            x = Digital(negative=e.sign, c=1, exp=exp)
+            x = Digital(negative=err.sign, c=1, exp=exp)
             result = MPMF._round_to_context(x, ctx=ctx)
         except gmpmath.SignedUnderflow as e:
             # we underflowed beyond MPFR's limits, generate a small value and round it
@@ -451,6 +451,9 @@ class _Interpreter(ReduceVisitor):
         if not isinstance(cond, bool):
             raise TypeError(f'expected a boolean, got {cond}')
         return self._visit_expr(e.ift if cond else e.iff, ctx)
+
+    def _visit_context_expr(self, e: ContextExpr, ctx: EvalCtx):
+        raise RuntimeError('do not call directly')
 
     def _visit_simple_assign(self, stmt: SimpleAssign, ctx: EvalCtx) -> None:
         val = self._visit_expr(stmt.expr, ctx)

--- a/fpy2/interpret/titanic.py
+++ b/fpy2/interpret/titanic.py
@@ -222,6 +222,9 @@ class _Interpreter(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return e.val
 
+    def _visit_context_val(self, e: ContextVal, ctx: Any):
+        return e.val
+
     def _visit_decnum(self, e: Decnum, ctx: Context):
         x = decnum_to_fraction(e.val)
         return ctx.round(x)

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -219,6 +219,9 @@ class _IRCodegenInstance(AstVisitor):
         body = self._visit_block(stmt.body, ctx)
         return ir.ForStmt(stmt.var, AnyType(), iterable, body, [])
 
+    def _visit_context_expr(self, e: ContextExpr, ctx: None):
+        raise NotImplementedError('do not call')
+
     def _visit_context(self, stmt: ContextStmt, ctx: None):
         props = self._visit_props(stmt.props)
         block = self._visit_block(stmt.body, ctx)

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -95,9 +95,9 @@ class _IRCodegenInstance(AstVisitor):
 
     def _visit_bool(self, e: BoolVal, ctx: None):
         return ir.BoolVal(e.val)
-    
+
     def _visit_context_val(self, e: ContextVal, ctx: None):
-        raise NotImplementedError(e)
+        return ir.ContextVal(e.val)
 
     def _visit_decnum(self, e: Decnum, ctx: None):
         return ir.Decnum(e.val)

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -95,6 +95,9 @@ class _IRCodegenInstance(AstVisitor):
 
     def _visit_bool(self, e: BoolVal, ctx: None):
         return ir.BoolVal(e.val)
+    
+    def _visit_context_val(self, e: ContextVal, ctx: None):
+        raise NotImplementedError(e)
 
     def _visit_decnum(self, e: Decnum, ctx: None):
         return ir.Decnum(e.val)

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -233,7 +233,18 @@ class _IRCodegenInstance(AstVisitor):
                     args.append(ir.ForeignAttribute(arg.name, arg.attrs))
                 case _:
                     args.append(self._visit_expr(arg, ctx))
-        return ir.ContextExpr(ctor, args)
+
+        kwargs: list[tuple[str, ir.Expr | ir.ForeignAttribute]] = []
+        for k, v in e.kwargs:
+            match v:
+                case ForeignAttribute():
+                    kwargs.append((k, ir.ForeignAttribute(v.name, v.attrs)))
+                case StringVal():
+                    kwargs.append((k, ir.StringVal(v.val)))
+                case _:
+                    kwargs.append((k, self._visit_expr(v, ctx)))
+
+        return ir.ContextExpr(ctor, args, kwargs)
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
         match stmt.ctx:

--- a/fpy2/ir/formatter.py
+++ b/fpy2/ir/formatter.py
@@ -62,6 +62,9 @@ class _FormatterInstance(BaseVisitor):
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return str(e.val)
 
+    def _visit_context_val(self, e: ContextVal, ctx: Any):
+        return repr(e.val)
+
     def _visit_decnum(self, e: Decnum, ctx: _IndentCtx):
         return e.val
 

--- a/fpy2/ir/ir.py
+++ b/fpy2/ir/ir.py
@@ -693,13 +693,13 @@ class ForStmt(Stmt):
 class ContextStmt(Stmt):
     """FPy IR: context statement"""
     name: Id
-    ctx: ContextExpr
+    ctx: Var | ContextExpr
     body: StmtBlock
 
-    def __init__(self, name: Id, props: dict[str, Any], body: StmtBlock):
+    def __init__(self, name: Id, ctx: Var | ContextExpr, body: StmtBlock):
         super().__init__()
         self.name = name
-        self.props = props.copy()
+        self.ctx = ctx
         self.body = body
 
 class AssertStmt(Stmt):

--- a/fpy2/ir/ir.py
+++ b/fpy2/ir/ir.py
@@ -5,9 +5,11 @@ This module contains the intermediate representation (IR).
 from abc import abstractmethod
 from typing import Any, Optional, Self, Sequence
 
-from .types import IRType
+from ..fpc_context import FPCoreContext
+from ..number import Context
 from ..utils import CompareOp, Id, NamedId, UnderscoreId, default_repr
 
+from .types import IRType
 
 @default_repr
 class IR(object):
@@ -57,6 +59,14 @@ class BoolVal(ValueExpr):
     val: bool
 
     def __init__(self, val: bool):
+        super().__init__()
+        self.val = val
+
+class ContextVal(ValueExpr):
+    """FPy node: context value"""
+    val: Context | FPCoreContext
+
+    def __init__(self, val: Context | FPCoreContext):
         super().__init__()
         self.val = val
 
@@ -708,10 +718,10 @@ class ForStmt(Stmt):
 class ContextStmt(Stmt):
     """FPy IR: context statement"""
     name: Id
-    ctx: Var | ContextExpr
+    ctx: ContextExpr | ContextVal | Var
     body: StmtBlock
 
-    def __init__(self, name: Id, ctx: Var | ContextExpr, body: StmtBlock):
+    def __init__(self, name: Id, ctx: ContextExpr | ContextVal | Var, body: StmtBlock):
         super().__init__()
         self.name = name
         self.ctx = ctx

--- a/fpy2/ir/ir.py
+++ b/fpy2/ir/ir.py
@@ -60,6 +60,14 @@ class BoolVal(ValueExpr):
         super().__init__()
         self.val = val
 
+class StringVal(ValueExpr):
+    """FPy node: string value"""
+    val: str
+
+    def __init__(self, val: str):
+        super().__init__()
+        self.val = val
+
 class RealVal(ValueExpr):
     """FPy node: abstract real number"""
 
@@ -518,19 +526,26 @@ class ContextExpr(Expr):
     """FPy AST: context constructor"""
     ctor: Var | ForeignAttribute
     args: list[Expr | ForeignAttribute]
+    kwargs: list[tuple[str, Expr | ForeignAttribute]]
 
-    def __init__(self, ctor: Var | ForeignAttribute, args: Sequence[Expr | ForeignAttribute]):
+    def __init__(
+        self,
+        ctor: Var | ForeignAttribute,
+        args: Sequence[Expr | ForeignAttribute],
+        kwargs: Sequence[tuple[str, Expr | ForeignAttribute]],
+    ):
         super().__init__()
         self.ctor = ctor
         self.args = list(args)
+        self.kwargs = list(kwargs)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ContextExpr):
             return False
-        return self.ctor == other.ctor and self.args == other.args
+        return self.ctor == other.ctor and self.args == other.args and self.kwargs == other.kwargs
 
     def __hash__(self) -> int:
-        return hash((self.ctor, tuple(self.args)))
+        return hash((self.ctor, tuple(self.args), tuple(self.kwargs)))
 
 
 class SimpleAssign(Stmt):

--- a/fpy2/ir/visitor.py
+++ b/fpy2/ir/visitor.py
@@ -21,6 +21,11 @@ class BaseVisitor(ABC):
         ...
 
     @abstractmethod
+    def _visit_context_val(self, e: ContextVal, ctx: Any):
+        """Visitor method for `ContextVal` nodes."""
+        ...
+
+    @abstractmethod
     def _visit_decnum(self, e: Decnum, ctx: Any):
         """Visitor method for `Decnum` nodes."""
         ...
@@ -205,6 +210,8 @@ class BaseVisitor(ABC):
                 return self._visit_var(e, ctx)
             case BoolVal():
                 return self._visit_bool(e, ctx)
+            case ContextVal():
+                return self._visit_context_val(e, ctx)
             case Decnum():
                 return self._visit_decnum(e, ctx)
             case Hexnum():
@@ -285,6 +292,9 @@ class DefaultVisitor(Visitor):
         pass
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
+        pass
+
+    def _visit_context_val(self, e: ContextVal, ctx: Any):
         pass
 
     def _visit_decnum(self, e: Decnum, ctx: Any):
@@ -407,6 +417,9 @@ class DefaultTransformVisitor(TransformVisitor):
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return BoolVal(e.val)
+
+    def _visit_context_val(self, e: ContextVal, ctx: Any):
+        return ContextVal(e.val)
 
     def _visit_decnum(self, e: Decnum, ctx: Any):
         return Decnum(e.val)

--- a/fpy2/ir/visitor.py
+++ b/fpy2/ir/visitor.py
@@ -90,6 +90,11 @@ class BaseVisitor(ABC):
         """Visitor method for `IfExpr` nodes."""
         ...
 
+    @abstractmethod
+    def _visit_context_expr(self, e: ContextExpr, ctx: Any):
+        """Visitor method for `ContextExpr` nodes."""
+        ...
+
     #######################################################
     # Statements
 
@@ -228,6 +233,8 @@ class BaseVisitor(ABC):
                 return self._visit_comp_expr(e, ctx)
             case IfExpr():
                 return self._visit_if_expr(e, ctx)
+            case ContextExpr():
+                return self._visit_context_expr(e, ctx)
             case _:
                 raise NotImplementedError('no visitor method for', e)
 

--- a/fpy2/ir/visitor.py
+++ b/fpy2/ir/visitor.py
@@ -495,7 +495,18 @@ class DefaultTransformVisitor(TransformVisitor):
                     args.append(ForeignAttribute(arg.name, arg.attrs))
                 case _:
                     args.append(self._visit_expr(arg, ctx))
-        return ContextExpr(ctor, args)
+
+        kwargs: list[tuple[str, Expr | ForeignAttribute]] = []
+        for k, v in e.kwargs:
+            match v:
+                case ForeignAttribute():
+                    kwargs.append((k, ForeignAttribute(v.name, v.attrs)))
+                case StringVal():
+                    kwargs.append((k, StringVal(v.val)))
+                case _:
+                    kwargs.append((k, self._visit_expr(v, ctx)))
+
+        return ContextExpr(ctor, args, kwargs)
 
     #######################################################
     # Statements

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -33,6 +33,12 @@ class Context(ABC):
     summarized by this type.
     """
 
+    def __enter__(self) -> None:
+        raise RuntimeError('do not call directly')
+
+    def __exit__(self, *args) -> None:
+        raise RuntimeError('do not call directly')
+
     @abstractmethod
     def with_rm(self, rm: RoundingMode) -> Self:
         """Returns `self` but with rounding mode `rm`."""

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -33,7 +33,7 @@ class Context(ABC):
     summarized by this type.
     """
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> Self:
         raise RuntimeError('do not call directly')
 
     def __exit__(self, *args) -> None:

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -46,7 +46,12 @@ class Context(ABC):
 
     @abstractmethod
     def is_representable(self, x: Union[Float, RealFloat]) -> bool:
-        """Returns if `x` is representable under this context."""
+        """
+        Returns if `x` is representable under this context.
+
+        Representable is not the same as canonical,
+        but every canonical value must be representable.
+        """
         ...
 
     @abstractmethod

--- a/fpy2/number/gmp.py
+++ b/fpy2/number/gmp.py
@@ -94,7 +94,7 @@ def mpfr_to_float(x):
     return _round_odd(x, False)
 
 
-def mpfr_constant(x, prec: int):
+def mpfr_value(x, prec: int):
     """
     Converts `x` into an MPFR type such that it may be safely re-rounded
     accurately to `prec` digits of precision.
@@ -111,6 +111,51 @@ def mpfr_constant(x, prec: int):
     ):
         y = gmp.mpfr(x)
         return _round_odd(y, y.rc != 0)
+
+# From `titanfp` package
+# TODO: some of these are unsafe
+# TODO: should these be indexed by string or enum?
+_constant_exprs = {
+    'E' : lambda : gmp.exp(1),
+    'LOG2E' : lambda: gmp.log2(gmp.exp(1)), # TODO: may be inaccurate
+    'LOG10E' : lambda: gmp.log10(gmp.exp(1)), # TODO: may be inaccurate
+    'LN2' : gmp.const_log2,
+    'LN10' : lambda: gmp.log(10),
+    'PI' : gmp.const_pi,
+    'PI_2' : lambda: gmp.const_pi() / 2, # division by 2 is exact
+    'PI_4' : lambda: gmp.const_pi() / 4, # division by 4 is exact
+    'M_1_PI' : lambda: 1 / gmp.const_pi(), # TODO: may be inaccurate
+    'M_2_PI' : lambda: 2 / gmp.const_pi(), # TODO: may be inaccurate
+    'M_2_SQRTPI' : lambda: 2 / gmp.sqrt(gmp.const_pi()), # TODO: may be inaccurate
+    'SQRT2': lambda: gmp.sqrt(2),
+    'SQRT1_2': lambda: gmp.sqrt(gmp.div(gmp.mpfr(1), gmp.mpfr(2))),
+    'INFINITY': gmp.inf,
+    'NAN': gmp.nan,
+}
+
+def mpfr_constant(x: str, prec: int):
+    """
+    Converts `x` into an MPFR type such that it may be safely re-rounded
+    accurately to `prec` digits of precision.
+    """
+    if not isinstance(x, str):
+        raise TypeError(f'Expected a string, got {type(x)}')
+
+    with gmp.context(
+        precision=prec+2,
+        emin=gmp.get_emin_min(),
+        emax=gmp.get_emax_max(),
+        trap_underflow=False,
+        trap_overflow=False,
+        trap_inexact=False,
+        trap_divzero=False,
+        round=gmp.RoundToZero,
+    ):
+        try:
+            y = _constant_exprs[x]()
+            return _round_odd(y, y.rc != 0)
+        except KeyError as e:
+            raise ValueError('unknown constant {}'.format(repr(e.args[0])))
 
 def _mpfr_1ary(gmp_fn: Callable[[Any], Any], x: Float, prec: int):
     xf = float_to_mpfr(x)

--- a/fpy2/number/gmp.py
+++ b/fpy2/number/gmp.py
@@ -155,7 +155,7 @@ def mpfr_constant(x: str, prec: int):
             y = _constant_exprs[x]()
             return _round_odd(y, y.rc != 0)
         except KeyError as e:
-            raise ValueError('unknown constant {}'.format(repr(e.args[0])))
+            raise ValueError(f'unknown constant {e.args[0]!r}') from None
 
 def _mpfr_1ary(gmp_fn: Callable[[Any], Any], x: Float, prec: int):
     xf = float_to_mpfr(x)

--- a/fpy2/number/mp.py
+++ b/fpy2/number/mp.py
@@ -12,7 +12,7 @@ from .context import Context
 from .number import Float
 from .real import RealFloat
 from .round import RoundingMode
-from .gmp import mpfr_constant
+from .gmp import mpfr_value
 
 @default_repr
 class MPContext(Context):
@@ -126,12 +126,12 @@ class MPContext(Context):
             case int():
                 xr = RealFloat(c=x)
             case float() | str():
-                xr = mpfr_constant(x, self.pmax)
+                xr = mpfr_value(x, self.pmax)
             case Fraction():
                 if x.denominator == 1:
                     xr = RealFloat(c=int(x))
                 else:
-                    xr = mpfr_constant(x, self.pmax)
+                    xr = mpfr_value(x, self.pmax)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mpb.py
+++ b/fpy2/number/mpb.py
@@ -237,12 +237,12 @@ class MPBContext(SizedContext):
             case Float() | RealFloat():
                 xr = x
             case int():
-                xr = RealFloat(c=x)
+                xr = RealFloat.from_int(x)
             case float() | str():
                 xr = mpfr_value(x, self.pmax)
             case Fraction():
                 if x.denominator == 1:
-                    xr = RealFloat(c=int(x))
+                    xr = RealFloat.from_int(int(x))
                 else:
                     xr = mpfr_value(x, self.pmax)
             case _:

--- a/fpy2/number/mpb.py
+++ b/fpy2/number/mpb.py
@@ -14,7 +14,7 @@ from .number import Float
 from .mps import MPSContext
 from .real import RealFloat
 from .round import RoundingMode, RoundingDirection
-from .gmp import mpfr_constant
+from .gmp import mpfr_value
 
 
 @default_repr
@@ -239,12 +239,12 @@ class MPBContext(SizedContext):
             case int():
                 xr = RealFloat(c=x)
             case float() | str():
-                xr = mpfr_constant(x, self.pmax)
+                xr = mpfr_value(x, self.pmax)
             case Fraction():
                 if x.denominator == 1:
                     xr = RealFloat(c=int(x))
                 else:
-                    xr = mpfr_constant(x, self.pmax)
+                    xr = mpfr_value(x, self.pmax)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mps.py
+++ b/fpy2/number/mps.py
@@ -14,7 +14,7 @@ from .number import Float
 from .mp import MPContext
 from .real import RealFloat
 from .round import RoundingMode
-from .gmp import mpfr_constant
+from .gmp import mpfr_value
 
 @default_repr
 class MPSContext(OrdinalContext):
@@ -166,12 +166,12 @@ class MPSContext(OrdinalContext):
             case int():
                 xr = RealFloat(c=x)
             case float() | str():
-                xr = mpfr_constant(x, self.pmax)
+                xr = mpfr_value(x, self.pmax)
             case Fraction():
                 if x.denominator == 1:
                     xr = RealFloat(c=int(x))
                 else:
-                    xr = mpfr_constant(x, self.pmax)
+                    xr = mpfr_value(x, self.pmax)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mps.py
+++ b/fpy2/number/mps.py
@@ -197,12 +197,37 @@ class MPSContext(OrdinalContext):
             # zero
             return 0
         elif x.e <= self.emin:
-            # subnormal
+            # subnormal: sgn(x) * [ 0 | m ]
+            # need to ensure that exp=self.expmin
+            offset = x.exp - self.expmin
+            if offset > 0:
+                # need to increase precision of `c`
+                c = x.c << offset
+            elif offset < 0:
+                # need to decrease precision of `c`
+                c = x.c >> -offset
+            else:
+                # no change
+                c = x.c
+
+            # ordinal components
             eord = 0
-            mord = x.c << (x.exp - self.expmin)  # normalize so that exp=self.expmin
+            mord = c
         else:
-            # normal
-            c = x.c << (self.pmax - x.p) # normalize so that p=self.pmax
+            # normal: sgn(x) * [ eord | m ]
+            # normalize so that p=self.pmax
+            offset = x.p - self.pmax
+            if offset > 0:
+                # too much precision
+                c = x.c >> offset
+            elif offset < 0:
+                # too little precision
+                c = x.c << -offset
+            else:
+                # no change
+                c = x.c
+
+            # ordinal components
             eord = x.e - self.emin + 1
             mord = c & bitmask(self.pmax - 1)
 

--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -156,12 +156,22 @@ class Float:
 
     def __float__(self):
         """
-        Casts this value to a native Python float.
+        Casts this value exactly to a native Python float.
 
         If the value is not representable, a `ValueError` is raised.
         """
         fn = get_current_float_converter()
         return fn(self)
+
+    def __int__(self):
+        """
+        Casts this value exactly to a native Python integer.
+
+        If the value is not representable, a `ValueError` is raised.
+        """
+        if not self.is_integer():
+            raise ValueError(f'{self} is not an integer')
+        return int(self._real)
 
     @staticmethod
     def from_real(x: RealFloat, ctx: Optional[Context] = None) -> 'Float':

--- a/fpy2/number/real.py
+++ b/fpy2/number/real.py
@@ -340,12 +340,33 @@ class RealFloat(numbers.Rational):
 
     def __float__(self):
         """
-        Casts this value to a native Python float.
+        Casts this value exactly to a native Python float.
 
         If the value is not representable, a `ValueError` is raised.
         """
         fn = get_current_float_converter()
         return fn(self)
+
+    def __int__(self):
+        """
+        Casts this value exactly to a native Python int.
+
+        If the value is not representable, a `ValueError` is raised.
+        """
+        if not self.is_integer():
+            raise ValueError(f'cannot convert to int: {self}')
+
+        # special case: 0
+        if self.c == 0:
+            return 0
+
+        if self.exp >= 0:
+            # `self.c` consists of integer digits
+            return self.c << self.exp
+        else:
+            # `self.c` consists of fractional digits
+            # but safe to just shift them off
+            return self.c >> -self.exp
 
     @staticmethod
     def from_int(x: int):

--- a/fpy2/number/real.py
+++ b/fpy2/number/real.py
@@ -89,6 +89,8 @@ class RealFloat(numbers.Rational):
         if c is not None:
             if m is not None:
                 raise ValueError(f'cannot specify both c={c} and m={m}')
+            if c < 0:
+                raise ValueError(f'c={c} must be non-negative')
             self.c = c
             if s is not None:
                 self.s = s

--- a/fpy2/rewrite/applier.py
+++ b/fpy2/rewrite/applier.py
@@ -161,12 +161,19 @@ class _StmtApplierInst(DefaultAstTransformVisitor):
         return s, None
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
+        match stmt.ctx:
+            case ContextExpr():
+                context = self._visit_context_expr(stmt.ctx, None)
+            case Var():
+                context = self._visit_var(stmt.ctx, None)
+            case _:
+                raise RuntimeError(f'unreachable case: {stmt.ctx}')
         body, _ = self._visit_block(stmt.body, None)
         if stmt.name is None:
-            s = ContextStmt(None, stmt.props, body, None)
+            s = ContextStmt(None, context, body, None)
         else:
             name = self._visit_id(stmt.name)
-            s = ContextStmt(name, stmt.props, body, None)
+            s = ContextStmt(name, context, body, None)
             return s, None
 
     def _visit_assert(self, stmt: AssertStmt, ctx: None):

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -233,11 +233,13 @@ class _MatcherInst(AstVisitor):
                 case ForeignAttribute(), ForeignAttribute():
                     if c1 != c2:
                         raise _MatchFailure(f'matching {ctx} against {e}')
+                case Expr(), Expr():
+                    # check if args are the same
+                    self._visit_expr(c1, c2)
                 case (ForeignAttribute(), _) | (_, ForeignAttribute()):
                     raise _MatchFailure(f'matching {ctx} against {e}')
                 case _, _:
-                    # check if args are the same
-                    self._visit_expr(c1, c2)
+                    raise RuntimeError(f'unreachable case: {c1} vs {c2}')
 
     def _visit_simple_assign(self, stmt: SimpleAssign, pat: SimpleAssign):
         self._visit_target(stmt.var, pat.var)

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -230,10 +230,10 @@ class _MatcherInst(AstVisitor):
             raise _MatchFailure(f'matching {ctx} against {e}')
         for c1, c2 in zip(e.args, ctx.args):
             match c1, c2:
-                case ForeignVal(), ForeignVal():
+                case ForeignAttribute(), ForeignAttribute():
                     if c1 != c2:
                         raise _MatchFailure(f'matching {ctx} against {e}')
-                case (ForeignVal(), _) | (_, ForeignVal()):
+                case (ForeignAttribute(), _) | (_, ForeignAttribute()):
                     raise _MatchFailure(f'matching {ctx} against {e}')
                 case _, _:
                     # check if args are the same

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -127,6 +127,10 @@ class _MatcherInst(AstVisitor):
         if e.val != pat.val:
             raise _MatchFailure(f'matching {pat} against {e}')
 
+    def _visit_context_val(self, e: ContextVal, pat: ContextVal):
+        # TODO: does this even make sense?
+        raise _MatchFailure(f'matching {pat} against {e}')
+
     def _visit_decnum(self, e: Decnum, pat: Decnum):
         # this is a semantic match, not a syntactic match!
         if decnum_to_fraction(e.val) != decnum_to_fraction(pat.val):

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -225,6 +225,20 @@ class _MatcherInst(AstVisitor):
         self._visit_expr(e.ift, pat.ift)
         self._visit_expr(e.iff, pat.iff)
 
+    def _visit_context_expr(self, e: ContextExpr, ctx: ContextExpr):
+        if len(e.args) != len(ctx.args):
+            raise _MatchFailure(f'matching {ctx} against {e}')
+        for c1, c2 in zip(e.args, ctx.args):
+            match c1, c2:
+                case ForeignVal(), ForeignVal():
+                    if c1 != c2:
+                        raise _MatchFailure(f'matching {ctx} against {e}')
+                case (ForeignVal(), _) | (_, ForeignVal()):
+                    raise _MatchFailure(f'matching {ctx} against {e}')
+                case _, _:
+                    # check if args are the same
+                    self._visit_expr(c1, c2)
+
     def _visit_simple_assign(self, stmt: SimpleAssign, pat: SimpleAssign):
         self._visit_target(stmt.var, pat.var)
         self._visit_expr(stmt.expr, pat.expr)
@@ -275,9 +289,7 @@ class _MatcherInst(AstVisitor):
         self._visit_block(stmt.body, pat.body)
 
     def _visit_context(self, stmt: ContextStmt, pat: ContextStmt):
-        # TODO: match context names
-        if stmt.props != pat.props:
-            raise _MatchFailure(f'matching {pat} against {stmt}')
+        self._visit_expr(stmt.ctx, pat.ctx)
         self._visit_block(stmt.body, pat.body)
 
     def _visit_assert(self, stmt: AssertStmt, pat: AssertStmt):

--- a/fpy2/runtime/function.py
+++ b/fpy2/runtime/function.py
@@ -1,15 +1,14 @@
 """FPy functions are the result of `@fpy` decorators."""
 
 from typing import Callable, Optional, TYPE_CHECKING
-from types import FunctionType
 from titanfp.fpbench.fpcast import FPCore
-from titanfp.arithmetic.evalctx import EvalCtx
 
 from .. import ir as fpyir
 from .. import ast as fpyast
 
 from ..analysis import VerifyIR
 from ..frontend import fpcore_to_fpy
+from ..number import Context
 from ..ir import IRCodegen
 from ..transform import SSA
 
@@ -56,7 +55,7 @@ class Function:
     def __str__(self):
         return 'Function(\n' + self.ast.format() + '\n)'
 
-    def __call__(self, *args, ctx: Optional[EvalCtx] = None):
+    def __call__(self, *args, ctx: Optional[Context] = None):
         fn = get_default_function_call()
         return fn(self, *args, ctx=ctx)
 

--- a/tests/unit/defs.py
+++ b/tests/unit/defs.py
@@ -395,14 +395,14 @@ def test_context2():
     with IEEEContext(8, 32, RM.RNE):
         return x + 1
 
-@fpy(name='Test context statement (3/3)')
-def test_context3(x: Real, y: Real):
-    with IEEEContext(8, 32, RM.RNE) as ctx:
-        with ctx.replace(rm=RM.RTP):
-            t0 = x + y
-        with ctx.replace(rm=RM.RTN):
-            t1 = x - y
-        return t0 - t1
+# @fpy(name='Test context statement (3/3)')
+# def test_context3(x: Real, y: Real):
+#     with IEEEContext(8, 32, RM.RNE) as ctx:
+#         with ctx.replace(rm=RM.RTP):
+#             t0 = x + y
+#         with ctx.replace(rm=RM.RTN):
+#             t1 = x - y
+#         return t0 - t1
 
 @fpy(name='Test assertion (1/1)')
 def test_assert():
@@ -581,7 +581,7 @@ tests = [
     test_for3,
     test_context1,
     test_context2,
-    test_context3,
+    # test_context3,
     test_assert,
 ]
 

--- a/tests/unit/defs.py
+++ b/tests/unit/defs.py
@@ -1,4 +1,4 @@
-from fpy2 import fpy
+from fpy2 import fpy, IEEEContext, RM
 from fpy2.typing import *
 
 ### Simple tests
@@ -386,21 +386,21 @@ def test_for3():
 
 @fpy(name='Test context statement (1/3)')
 def test_context1():
-    with Context():
+    with IEEEContext(8, 32, RM.RNE):
         return 0
 
 @fpy(name='Test context statement (2/3)')
 def test_context2():
     x = 1
-    with Context(precision='binary32'):
+    with IEEEContext(8, 32, RM.RNE):
         return x + 1
 
 @fpy(name='Test context statement (3/3)')
 def test_context3(x: Real, y: Real):
-    with Context(precision='binary32'):
-        with Context(round='toPositive'):
+    with IEEEContext(8, 32, RM.RNE) as ctx:
+        with ctx.replace(rm=RM.RTP):
             t0 = x + y
-        with Context(round='toNegative'):
+        with ctx.replace(rm=RM.RTN):
             t1 = x - y
         return t0 - t1
 


### PR DESCRIPTION
This PR requires that rounding contexts must be specified using explicit objects. For example,
```
@fpy
def foo(x):
  with IEEEContext(8, 32, RM.RNE):
    return x + 1
```
rather than the current syntax
```
@fpy
def foo(x):
  with Context(precision='binary32', round='nearestEven'):
    return x + 1
```
This moves away from the FPCore-style contexts where rounding contexts are determined by a dictionary of properties with string keys and arbitrary values.