### PR TITLE
Cleanup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,12 @@
      - `MPSContext` - floating-point with finite precision and a minimum exponent
      - `MPBContext` - floating-point with finite precision, minimum exponent, and maximum value
      - `IEEEContext` - IEEE 754 floating-point
+     - `ExtContext` - Extended-parameter floating-point
+ - Frontend
+   - explicit context syntax
+   - legacy FPCore-like context syntax
+   - foreign values
+   - pattern matching and rewrite system
 
 ## [0.0.2] - 2025-03-20
 ### Features

--- a/fpy2/__init__.py
+++ b/fpy2/__init__.py
@@ -63,7 +63,7 @@ from .interpret import (
     get_default_interpreter,
 )
 
-from .runtime import Function
+from .function import Function
 
 from .utils import (
     fraction,

--- a/fpy2/__init__.py
+++ b/fpy2/__init__.py
@@ -58,7 +58,7 @@ from .interpret import (
     Interpreter,
     PythonInterpreter,
     RealInterpreter,
-    TitanicInterpreter,
+    DefaultInterpreter,
     set_default_interpreter,
     get_default_interpreter,
 )

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -33,6 +33,9 @@ class _LiveVars(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: None) -> _RetType:
         return set()
 
+    def _visit_foreign(self, e: ForeignVal, ctx: None) -> _RetType:
+        return set()
+
     def _visit_context_val(self, e: ContextVal, ctx: None) -> _RetType:
         return set()
 

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -36,9 +36,6 @@ class _LiveVars(ReduceVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: None) -> _RetType:
         return set()
 
-    def _visit_context_val(self, e: ContextVal, ctx: None) -> _RetType:
-        return set()
-
     def _visit_decnum(self, e: Decnum, ctx: None) -> _RetType:
         return set()
 

--- a/fpy2/ast/__init__.py
+++ b/fpy2/ast/__init__.py
@@ -7,6 +7,7 @@ from .formatter import Formatter
 from .fpyast import set_default_formatter
 from .visitor import AstVisitor, DefaultAstVisitor, DefaultAstTransformVisitor
 
+from .context_inline import ContextInline
 from .define_use import DefineUse
 from .live_vars import LiveVars
 from .syntax_check import SyntaxCheck

--- a/fpy2/ast/context_inline.py
+++ b/fpy2/ast/context_inline.py
@@ -1,0 +1,115 @@
+"""Context inlining for FPy ASTs"""
+
+from .fpyast import *
+from .visitor import DefaultAstTransformVisitor
+from ..runtime import ForeignEnv
+
+class _ContextInlineInstance(DefaultAstTransformVisitor):
+    """Per-IR instance of context inlining"""
+    ast: FuncDef
+    env: ForeignEnv
+
+    def __init__(self, ast: FuncDef, env: ForeignEnv):
+        self.ast = ast
+        self.env = env
+
+    def apply(self):
+        return self._visit_function(self.ast, None)
+
+    def _lookup(self, name: NamedId):
+        if name.base not in self.env:
+            raise NameError(f'free variable {name} not in environment')
+        return self.env[name.base]
+
+    def _eval_var(self, e: Var):
+        if e.name.base not in self.env:
+            raise NameError(f'free variable {e.name} not in environment')
+        return self.env.get(e.name.base)
+
+    def _eval_foreign_attr(self, e: ForeignAttribute):
+        # lookup the root value (should be captured)
+        val = self._lookup(e.name)
+        # walk the attribute chain
+        for attr_id in e.attrs:
+            # need to manually lookup the attribute
+            attr = str(attr_id)
+            if isinstance(val, dict):
+                if attr not in val:
+                    raise RuntimeError(f'unknown attribute {attr} for {val}')
+                val = val[attr]
+            elif hasattr(val, attr):
+                val = getattr(val, attr)
+            else:
+                raise RuntimeError(f'unknown attribute {attr} for {val}')
+        return val
+
+    def _eval_context_expr(self, e: ContextExpr):
+        match e.ctor:
+            case ForeignAttribute():
+                ctor = self._eval_foreign_attr(e.ctor)
+            case Var():
+                ctor = self._eval_var(e.ctor)
+
+        args: list[Any] = []
+        for arg in e.args:
+            match arg:
+                case ForeignAttribute():
+                    args.append(self._eval_foreign_attr(arg))
+                case Integer():
+                    args.append(arg.val)
+                case Var():
+                    args.append(self._eval_var(arg))
+                case _:
+                    # TODO: how to compute this
+                    raise RuntimeError('cannot compute', arg)
+
+        kwargs: dict[str, Any] = {}
+        for k, v in e.kwargs:
+            match v:
+                case ForeignAttribute():
+                    kwargs[k] = self._eval_foreign_attr(v)
+                case Integer():
+                    args.append(v.val)
+                case Var():
+                    args.append(self._eval_var(v))
+                case _:
+                    # TODO: how to compute this
+                    raise RuntimeError('cannot compute', arg)
+
+        return ctor(*args, **kwargs)
+
+    def _visit_context(self, stmt: ContextStmt, ctx: None):
+        match stmt.ctx:
+            case ContextExpr():
+                v = self._eval_context_expr(stmt.ctx)
+                if not isinstance(v, Context | FPCoreContext):
+                    raise TypeError(f'Expected `Context` or `FPCoreContext`, got {type(v)} for {v}')
+                context = ForeignVal(v, None)
+            case Var():
+                v = self._eval_var(stmt.ctx)
+                if not isinstance(v, Context | FPCoreContext):
+                    raise TypeError(f'Expected `Context` or `FPCoreContext`, got {type(v)} for {v}')
+                context = ForeignVal(v, None)
+            case ForeignVal():
+                context = stmt.ctx
+            case _:
+                raise RuntimeError('unreachable', stmt.ctx)
+
+        body, _ = self._visit_block(stmt.body, None)
+        s = ContextStmt(stmt.name, context, body, stmt.loc)
+        return s, None
+
+
+class ContextInline:
+    """
+    Context inliner.
+
+    Contexts in FPy programs may be metaprogrammed.
+    This pass resolves the context at each site.
+    """
+
+    @staticmethod
+    def apply(ast: FuncDef, env: ForeignEnv) -> FuncDef:
+        if not isinstance(ast, FuncDef):
+            raise TypeError(f'Expected `FuncDef`, got {type(ast)} for {ast}')
+        return _ContextInlineInstance(ast, env).apply()

--- a/fpy2/ast/define_use.py
+++ b/fpy2/ast/define_use.py
@@ -3,7 +3,6 @@
 from .fpyast import *
 from .visitor import DefaultAstVisitor
 
-
 class _DefineUseInstance(DefaultAstVisitor):
     """Per-IR instance of definition-use analysis"""
     ast: FuncDef | StmtBlock

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -44,9 +44,6 @@ class _FormatterInstance(AstVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: _Ctx):
         return repr(e.val)
 
-    def _visit_context_val(self, e: ContextVal, ctx):
-        return repr(e.val)
-
     def _visit_decnum(self, e: Decnum, ctx: _Ctx):
         return e.val
 

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -41,6 +41,9 @@ class _FormatterInstance(AstVisitor):
     def _visit_bool(self, e: BoolVal, ctx: _Ctx):
         return str(e.val)
 
+    def _visit_foreign(self, e: ForeignVal, ctx: _Ctx):
+        return repr(e.val)
+
     def _visit_context_val(self, e: ContextVal, ctx):
         return repr(e.val)
 

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -236,38 +236,6 @@ class ForeignVal(ValueExpr):
     def __hash__(self) -> int:
         return hash(self.val)
 
-class StringVal(ValueExpr):
-    """FPy AST: string"""
-    val: str
-
-    def __init__(self, val: str, loc: Optional[Location]):
-        super().__init__(loc)
-        self.val = val
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, StringVal):
-            return False
-        return self.val == other.val
-
-    def __hash__(self) -> int:
-        return hash(self.val)
-
-class ContextVal(ValueExpr):
-    """FPy AST: context value"""
-    val: Context | FPCoreContext
-
-    def __init__(self, val: Context | FPCoreContext, loc: Optional[Location]):
-        super().__init__(loc)
-        self.val = val
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, ContextVal):
-            return False
-        return self.val == other.val
-
-    def __hash__(self) -> int:
-        return hash(self.val)
-
 class Decnum(RealVal):
     """FPy AST: decimal number"""
     val: str
@@ -938,13 +906,13 @@ class ForStmt(Stmt):
 class ContextStmt(Stmt):
     """FPy AST: with statement"""
     name: Id
-    ctx: ContextExpr | ContextVal | Var
+    ctx: ContextExpr | Var | ForeignVal
     body: StmtBlock
 
     def __init__(
         self,
         name: Id,
-        ctx: ContextExpr | ContextVal | Var,
+        ctx: ContextExpr | Var | ForeignVal,
         body: StmtBlock,
         loc: Optional[Location]
     ):

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -220,6 +220,22 @@ class RealVal(ValueExpr):
     def __init__(self, loc: Optional[Location]):
         super().__init__(loc)
 
+class ForeignVal(ValueExpr):
+    """FPy AST: native Python value"""
+    val: Any
+
+    def __init__(self, val: Any, loc: Optional[Location]):
+        super().__init__(loc)
+        self.val = val
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ForeignVal):
+            return False
+        return self.val == other.val
+
+    def __hash__(self) -> int:
+        return hash(self.val)
+
 class StringVal(ValueExpr):
     """FPy AST: string"""
     val: str

--- a/fpy2/ast/live_vars.py
+++ b/fpy2/ast/live_vars.py
@@ -28,6 +28,9 @@ class LiveVarsInstance(AstVisitor):
     def _visit_bool(self, e: BoolVal, ctx: None) -> _LiveSet:
         return set()
 
+    def _visit_foreign(self, e: ForeignVal, ctx: None):
+        return set()
+
     def _visit_context_val(self, e: ContextVal, ctx: None):
         return set()
 

--- a/fpy2/ast/live_vars.py
+++ b/fpy2/ast/live_vars.py
@@ -31,9 +31,6 @@ class LiveVarsInstance(AstVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: None):
         return set()
 
-    def _visit_context_val(self, e: ContextVal, ctx: None):
-        return set()
-
     def _visit_decnum(self, e: Decnum, ctx: None) -> _LiveSet:
         return set()
 

--- a/fpy2/ast/syntax_check.py
+++ b/fpy2/ast/syntax_check.py
@@ -109,6 +109,10 @@ class SyntaxCheckInstance(AstVisitor):
         env, _ = ctx
         return env
 
+    def _visit_foreign(self, e: ForeignVal, ctx: _Ctx):
+        env, _ = ctx
+        return env
+
     def _visit_context_val(self, e, ctx):
         env, _ = ctx
         return env

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -22,6 +22,10 @@ class AstVisitor(ABC):
         ...
 
     @abstractmethod
+    def _visit_foreign(self, e: ForeignVal, ctx: Any) -> Any:
+        ...
+
+    @abstractmethod
     def _visit_context_val(self, e: ContextVal, ctx: Any) -> Any:
         ...
 
@@ -165,6 +169,8 @@ class AstVisitor(ABC):
                 return self._visit_var(e, ctx)
             case BoolVal():
                 return self._visit_bool(e, ctx)
+            case ForeignVal():
+                return self._visit_foreign(e, ctx)
             case ContextVal():
                 return self._visit_context_val(e, ctx)
             case Decnum():
@@ -242,6 +248,9 @@ class DefaultAstVisitor(AstVisitor):
         pass
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
+        pass
+
+    def _visit_foreign(self, e: ForeignVal, ctx: Any):
         pass
 
     def _visit_context_val(self, e: ContextVal, ctx: Any):
@@ -372,6 +381,9 @@ class DefaultAstTransformVisitor(AstVisitor):
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return BoolVal(e.val, e.loc)
+
+    def _visit_foreign(self, e: ForeignVal, ctx: Any):
+        return ForeignVal(e.val, e.loc)
 
     def _visit_context_val(self, e: ContextVal, ctx: Any):
         return ContextVal(e.val, e.loc)

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -26,10 +26,6 @@ class AstVisitor(ABC):
         ...
 
     @abstractmethod
-    def _visit_context_val(self, e: ContextVal, ctx: Any) -> Any:
-        ...
-
-    @abstractmethod
     def _visit_decnum(self, e: Decnum, ctx: Any) -> Any:
         ...
 
@@ -171,8 +167,6 @@ class AstVisitor(ABC):
                 return self._visit_bool(e, ctx)
             case ForeignVal():
                 return self._visit_foreign(e, ctx)
-            case ContextVal():
-                return self._visit_context_val(e, ctx)
             case Decnum():
                 return self._visit_decnum(e, ctx)
             case Hexnum():
@@ -251,9 +245,6 @@ class DefaultAstVisitor(AstVisitor):
         pass
 
     def _visit_foreign(self, e: ForeignVal, ctx: Any):
-        pass
-
-    def _visit_context_val(self, e: ContextVal, ctx: Any):
         pass
 
     def _visit_decnum(self, e: Decnum, ctx: Any):
@@ -384,9 +375,6 @@ class DefaultAstTransformVisitor(AstVisitor):
 
     def _visit_foreign(self, e: ForeignVal, ctx: Any):
         return ForeignVal(e.val, e.loc)
-
-    def _visit_context_val(self, e: ContextVal, ctx: Any):
-        return ContextVal(e.val, e.loc)
 
     def _visit_decnum(self, e: Decnum, ctx: Any):
         return Decnum(e.val, e.loc)

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -151,15 +151,6 @@ class FPCoreCompileInstance(ReduceVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx) -> fpc.Expr:
         raise FPCoreCompileError('unsupported value', e.val)
 
-    def _visit_context_val(self, e: ContextVal, ctx) -> fpc.Expr:
-        match e.val:
-            case FPCoreContext():
-                return e.val
-            case Context():
-                FPCoreContext.from_context(e.val)
-            case _:
-                raise FPCoreCompileError('unsupported context value', e.val)
-
     def _visit_decnum(self, e, ctx) -> fpc.Expr:
         return fpc.Decnum(e.val)
 

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -148,6 +148,9 @@ class FPCoreCompileInstance(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: None):
         return fpc.Constant('TRUE' if e.val else 'FALSE')
 
+    def _visit_foreign(self, e: ForeignVal, ctx) -> fpc.Expr:
+        raise FPCoreCompileError('unsupported value', e.val)
+
     def _visit_context_val(self, e: ContextVal, ctx) -> fpc.Expr:
         match e.val:
             case FPCoreContext():

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -8,6 +8,8 @@ from ..ir import *
 
 from ..ast import fpyast as ast
 from ..ast.syntax_check import SyntaxCheck
+from ..function import Function
+from ..transform import UnSSA
 
 from ..ir.codegen import (
     _unary_table,
@@ -16,10 +18,8 @@ from ..ir.codegen import (
     _nary_table
 )
 
-from ..runtime import Function
-from ..transform import UnSSA
-
 from .backend import Backend
+
 
 # reverse operator tables
 _unary_rev_table = { v: k for k, v in _unary_table.items() }

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -43,6 +43,9 @@ class _FPyCompilerInstance(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: None):
         return ast.BoolVal(e.val, None)
 
+    def _visit_foreign(self, e: ForeignVal, ctx: None):
+        return ast.ForeignVal(e.val, None)
+
     def _visit_context_val(self, e: ContextVal, ctx: None):
         return ast.ContextVal(e.val, None)
 

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -46,9 +46,6 @@ class _FPyCompilerInstance(ReduceVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: None):
         return ast.ForeignVal(e.val, None)
 
-    def _visit_context_val(self, e: ContextVal, ctx: None):
-        return ast.ContextVal(e.val, None)
-
     def _visit_decnum(self, e: Decnum, ctx: None):
         return ast.Decnum(e.val, None)
 
@@ -230,8 +227,6 @@ class _FPyCompilerInstance(ReduceVisitor):
             match v:
                 case ForeignAttribute():
                     kwargs.append((k, ast.ForeignAttribute(v.name, v.attrs, None)))
-                case StringVal():
-                    kwargs.append((k, ast.StringVal(v.val, None)))
                 case _:
                     kwargs.append((k, self._visit_expr(v, ctx)))
 

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -239,6 +239,8 @@ class _FPyCompilerInstance(ReduceVisitor):
                 context = self._visit_var(stmt.ctx, ctx)
             case ContextExpr():
                 context = self._visit_context_expr(stmt.ctx, ctx)
+            case ForeignVal():
+                context = ast.ForeignVal(stmt.ctx.val, None)
             case _:
                 raise RuntimeError('unreachable', stmt.ctx)
         body = self._visit_block(stmt.body, None)

--- a/fpy2/decorator.py
+++ b/fpy2/decorator.py
@@ -17,8 +17,10 @@ from typing import (
 
 from .ast import SyntaxCheck, EffectStmt
 from .frontend import Parser
-from .rewrite import Pattern, ExprPattern, StmtPattern
-from .runtime import Function, ForeignEnv
+from .function import Function
+from .rewrite import ExprPattern, StmtPattern
+from .runtime import ForeignEnv
+
 
 P = ParamSpec('P')
 R = TypeVar('R')

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -583,9 +583,9 @@ class _FPCore2FPy:
 
         # try to convert to a native FPy context
         try:
-            ctx_val = ContextVal(fpc_ctx.to_context(), None)
+            ctx_val = ForeignVal(fpc_ctx.to_context(), None)
         except NoSuchContextError:
-            ctx_val = ContextVal(fpc_ctx, None)
+            ctx_val = ForeignVal(fpc_ctx, None)
 
         # bind value to temporary
         t = self.gensym.fresh('t')

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -238,7 +238,7 @@ class Parser:
                 else:
                     return Decnum(str(e.value), loc)
             case str():
-                return StringVal(e.value, loc)
+                return ForeignVal(e.value, loc)
             case _:
                 raise FPyParserError(loc, 'Unsupported constant', e)
 
@@ -247,7 +247,7 @@ class Parser:
         if len(e.args) != 1:
             raise FPyParserError(loc, 'FPy `hexfloat` expects one argument', e)
         arg = self._parse_expr(e.args[0])
-        if not isinstance(arg, StringVal):
+        if not isinstance(arg, ForeignVal):
             raise FPyParserError(loc, 'FPy `hexfloat` expects a string', e)
         return Hexnum(arg.val, loc)
 

--- a/fpy2/function.py
+++ b/fpy2/function.py
@@ -3,20 +3,21 @@
 from typing import Callable, Optional, TYPE_CHECKING
 from titanfp.fpbench.fpcast import FPCore
 
-from .. import ir as fpyir
-from .. import ast as fpyast
+from . import ir as fpyir
+from . import ast as fpyast
 
-from ..analysis import VerifyIR
-from ..frontend import fpcore_to_fpy
-from ..number import Context
-from ..ir import IRCodegen
-from ..transform import SSA
+from .ast import ContextInline
+from .analysis import VerifyIR
+from .frontend import fpcore_to_fpy
+from .number import Context
+from .ir import IRCodegen
+from .transform import SSA
 
-from .env import ForeignEnv
+from .runtime.env import ForeignEnv
 
 # avoids circular dependency issues (useful for type checking)
 if TYPE_CHECKING:
-    from ..interpret import Interpreter
+    from .interpret import Interpreter
 
 
 class Function:
@@ -103,6 +104,8 @@ class Function:
         """Returns the IR of the function."""
         # check if the IR is already cached
         if self._ir is None:
+            # apply AST passes to normalize the AST
+            # ast = ContextInline.apply(self.ast, self.env)
             # lower the AST to IR
             ir = IRCodegen().lower(self.ast)
             ir = SSA.apply(ir)

--- a/fpy2/function.py
+++ b/fpy2/function.py
@@ -105,9 +105,9 @@ class Function:
         # check if the IR is already cached
         if self._ir is None:
             # apply AST passes to normalize the AST
-            # ast = ContextInline.apply(self.ast, self.env)
+            ast = ContextInline.apply(self.ast, self.env)
             # lower the AST to IR
-            ir = IRCodegen().lower(self.ast)
+            ir = IRCodegen().lower(ast)
             ir = SSA.apply(ir)
             VerifyIR().check(ir)
             # cache the IR

--- a/fpy2/interpret/__init__.py
+++ b/fpy2/interpret/__init__.py
@@ -4,6 +4,6 @@ from .interpreter import Interpreter, get_default_interpreter, set_default_inter
 
 from .native import PythonInterpreter
 from .real import RealInterpreter
-from .titanic import TitanicInterpreter
+from .default import DefaultInterpreter
 
-set_default_interpreter(TitanicInterpreter())
+set_default_interpreter(DefaultInterpreter())

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -222,6 +222,9 @@ class _Interpreter(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return e.val
 
+    def _visit_foreign(self, e: ForeignVal, ctx: None):
+        return e.val
+
     def _visit_context_val(self, e: ContextVal, ctx: Any):
         return e.val
 

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -14,7 +14,7 @@ from ..number import Context, Float, IEEEContext, RM
 from ..number.gmp import mpfr_constant
 from ..runtime.trace import ExprTraceEntry
 from ..runtime.env import ForeignEnv
-from ..runtime.function import Function
+from ..function import Function
 from ..ir import *
 from ..utils import decnum_to_fraction, hexnum_to_fraction, digits_to_fraction
 

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -687,13 +687,14 @@ class _Interpreter(ReduceVisitor):
         return super()._visit_statement(stmt, ctx)
 
 
-class TitanicInterpreter(Interpreter):
+class DefaultInterpreter(Interpreter):
     """
     Standard interpreter for FPy programs.
 
-    Programs are evaluated using the Titanic backend (`titanfp`).
-    Booleans are Python `bool` values, real numbers are Titanic `Float` values,
-    and tensors are Titanic `NDArray` values.
+    Values:
+     - booleans are Python `bool` values,
+     - real numbers are FPy `float` values,
+     - tensors are Titanic `NDArray` values.
 
     All operations are correctly-rounded.
     """

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -225,9 +225,6 @@ class _Interpreter(ReduceVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: None):
         return e.val
 
-    def _visit_context_val(self, e: ContextVal, ctx: Any):
-        return e.val
-
     def _visit_decnum(self, e: Decnum, ctx: Context):
         x = decnum_to_fraction(e.val)
         return ctx.round(x)
@@ -641,8 +638,6 @@ class _Interpreter(ReduceVisitor):
             match v:
                 case ForeignAttribute():
                     kwargs[k] = self._visit_foreign_attr(v)
-                case StringVal():
-                    kwargs[k] = str(v.val)
                 case _:
                     v = self._visit_expr(v, ctx)
                     if isinstance(v, Float) and v.is_integer():

--- a/fpy2/interpret/interpreter.py
+++ b/fpy2/interpret/interpreter.py
@@ -5,9 +5,9 @@ Defines the abstract base class for FPy interpreters.
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
+from ..function import Function, set_default_function_call
 from ..ir import Expr
 from ..number import Context
-from ..runtime import Function, set_default_function_call
 from ..runtime.trace import ExprTraceEntry
 
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -182,9 +182,6 @@ class _Interpreter(ReduceVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: None):
         return e.val
 
-    def _visit_context_val(self, e: ContextVal, ctx: Context):
-        return e.val
-
     def _visit_decnum(self, e: Decnum, ctx: Context):
         return float(e.val)
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -179,6 +179,9 @@ class _Interpreter(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: Context):
         return e.val
 
+    def _visit_foreign(self, e: ForeignVal, ctx: None):
+        return e.val
+
     def _visit_context_val(self, e: ContextVal, ctx: Context):
         return e.val
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Optional, Sequence, TypeAlias
 
 from ..number import Context, Float, IEEEContext, RM
 from ..number.gmp import mpfr_constant
-from ..runtime.function import Function
+from ..function import Function
 from ..runtime.env import ForeignEnv
 from ..ir import *
 from ..utils import digits_to_fraction

--- a/fpy2/interpret/real.py
+++ b/fpy2/interpret/real.py
@@ -223,9 +223,6 @@ class _Interpreter(ReduceVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: None):
         return e.val
 
-    def _visit_context_val(self, e: ContextVal, ctx: Any):
-        return e.val
-
     def _visit_decnum(self, e: Decnum, ctx: Context):
         return str(e.val)
 

--- a/fpy2/interpret/real.py
+++ b/fpy2/interpret/real.py
@@ -14,7 +14,7 @@ from ..runtime.real.rival_manager import RivalManager, InsufficientPrecisionErro
 
 from ..number import Context, Float, IEEEContext, RM
 from ..runtime.trace import ExprTraceEntry
-from ..runtime.function import Function
+from ..function import Function
 from ..ir import *
 
 from .interpreter import Interpreter, FunctionReturnException

--- a/fpy2/interpret/real.py
+++ b/fpy2/interpret/real.py
@@ -220,6 +220,9 @@ class _Interpreter(ReduceVisitor):
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return e.val
 
+    def _visit_foreign(self, e: ForeignVal, ctx: None):
+        return e.val
+
     def _visit_context_val(self, e: ContextVal, ctx: Any):
         return e.val
 

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -99,9 +99,6 @@ class _IRCodegenInstance(AstVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: None):
         raise NotImplementedError
 
-    def _visit_context_val(self, e: ContextVal, ctx: None):
-        return ir.ContextVal(e.val)
-
     def _visit_decnum(self, e: Decnum, ctx: None):
         return ir.Decnum(e.val)
 
@@ -245,8 +242,6 @@ class _IRCodegenInstance(AstVisitor):
             match v:
                 case ForeignAttribute():
                     kwargs.append((k, ir.ForeignAttribute(v.name, v.attrs)))
-                case StringVal():
-                    kwargs.append((k, ir.StringVal(v.val)))
                 case _:
                     kwargs.append((k, self._visit_expr(v, ctx)))
 

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -253,6 +253,8 @@ class _IRCodegenInstance(AstVisitor):
                 context = self._visit_var(stmt.ctx, ctx)
             case ContextExpr():
                 context = self._visit_context_expr(stmt.ctx, ctx)
+            case ForeignVal():
+                context = ir.ForeignVal(stmt.ctx.val)
             case _:
                 raise RuntimeError('unreachable', stmt.ctx)
         block = self._visit_block(stmt.body, ctx)

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -96,6 +96,9 @@ class _IRCodegenInstance(AstVisitor):
     def _visit_bool(self, e: BoolVal, ctx: None):
         return ir.BoolVal(e.val)
 
+    def _visit_foreign(self, e: ForeignVal, ctx: None):
+        raise NotImplementedError
+
     def _visit_context_val(self, e: ContextVal, ctx: None):
         return ir.ContextVal(e.val)
 

--- a/fpy2/ir/formatter.py
+++ b/fpy2/ir/formatter.py
@@ -62,6 +62,9 @@ class _FormatterInstance(BaseVisitor):
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return str(e.val)
 
+    def _visit_foreign(self, e: ForeignVal, ctx: Any):
+        return repr(e.val)
+
     def _visit_context_val(self, e: ContextVal, ctx: Any):
         return repr(e.val)
 

--- a/fpy2/ir/formatter.py
+++ b/fpy2/ir/formatter.py
@@ -65,9 +65,6 @@ class _FormatterInstance(BaseVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: Any):
         return repr(e.val)
 
-    def _visit_context_val(self, e: ContextVal, ctx: Any):
-        return repr(e.val)
-
     def _visit_decnum(self, e: Decnum, ctx: _IndentCtx):
         return e.val
 

--- a/fpy2/ir/ir.py
+++ b/fpy2/ir/ir.py
@@ -62,6 +62,14 @@ class BoolVal(ValueExpr):
         super().__init__()
         self.val = val
 
+class ForeignVal(ValueExpr):
+    """FPy node: native Python value"""
+    val: Any
+
+    def __init__(self, val: Any):
+        super().__init__()
+        self.val = val
+
 class ContextVal(ValueExpr):
     """FPy node: context value"""
     val: Context | FPCoreContext

--- a/fpy2/ir/ir.py
+++ b/fpy2/ir/ir.py
@@ -70,22 +70,6 @@ class ForeignVal(ValueExpr):
         super().__init__()
         self.val = val
 
-class ContextVal(ValueExpr):
-    """FPy node: context value"""
-    val: Context | FPCoreContext
-
-    def __init__(self, val: Context | FPCoreContext):
-        super().__init__()
-        self.val = val
-
-class StringVal(ValueExpr):
-    """FPy node: string value"""
-    val: str
-
-    def __init__(self, val: str):
-        super().__init__()
-        self.val = val
-
 class RealVal(ValueExpr):
     """FPy node: abstract real number"""
 
@@ -726,10 +710,10 @@ class ForStmt(Stmt):
 class ContextStmt(Stmt):
     """FPy IR: context statement"""
     name: Id
-    ctx: ContextExpr | ContextVal | Var
+    ctx: ContextExpr | Var | ForeignVal
     body: StmtBlock
 
-    def __init__(self, name: Id, ctx: ContextExpr | ContextVal | Var, body: StmtBlock):
+    def __init__(self, name: Id, ctx: ContextExpr | Var | ForeignVal, body: StmtBlock):
         super().__init__()
         self.name = name
         self.ctx = ctx

--- a/fpy2/ir/visitor.py
+++ b/fpy2/ir/visitor.py
@@ -26,11 +26,6 @@ class BaseVisitor(ABC):
         ...
 
     @abstractmethod
-    def _visit_context_val(self, e: ContextVal, ctx: Any):
-        """Visitor method for `ContextVal` nodes."""
-        ...
-
-    @abstractmethod
     def _visit_decnum(self, e: Decnum, ctx: Any):
         """Visitor method for `Decnum` nodes."""
         ...
@@ -217,8 +212,6 @@ class BaseVisitor(ABC):
                 return self._visit_bool(e, ctx)
             case ForeignVal():
                 return self._visit_foreign(e, ctx)
-            case ContextVal():
-                return self._visit_context_val(e, ctx)
             case Decnum():
                 return self._visit_decnum(e, ctx)
             case Hexnum():
@@ -303,9 +296,6 @@ class DefaultVisitor(Visitor):
         pass
 
     def _visit_foreign(self, e: ForeignVal, ctx: Any):
-        pass
-
-    def _visit_context_val(self, e: ContextVal, ctx: Any):
         pass
 
     def _visit_decnum(self, e: Decnum, ctx: Any):
@@ -432,9 +422,6 @@ class DefaultTransformVisitor(TransformVisitor):
     def _visit_foreign(self, e: ForeignVal, ctx: Any):
         return ForeignVal(e.val)
 
-    def _visit_context_val(self, e: ContextVal, ctx: Any):
-        return ContextVal(e.val)
-
     def _visit_decnum(self, e: Decnum, ctx: Any):
         return Decnum(e.val)
 
@@ -528,8 +515,6 @@ class DefaultTransformVisitor(TransformVisitor):
             match v:
                 case ForeignAttribute():
                     kwargs.append((k, ForeignAttribute(v.name, v.attrs)))
-                case StringVal():
-                    kwargs.append((k, StringVal(v.val)))
                 case _:
                     kwargs.append((k, self._visit_expr(v, ctx)))
 

--- a/fpy2/ir/visitor.py
+++ b/fpy2/ir/visitor.py
@@ -21,6 +21,11 @@ class BaseVisitor(ABC):
         ...
 
     @abstractmethod
+    def _visit_foreign(self, e: ForeignVal, ctx: Any) -> Any:
+        """Visitor method for `ForeignVal` nodes."""
+        ...
+
+    @abstractmethod
     def _visit_context_val(self, e: ContextVal, ctx: Any):
         """Visitor method for `ContextVal` nodes."""
         ...
@@ -210,6 +215,8 @@ class BaseVisitor(ABC):
                 return self._visit_var(e, ctx)
             case BoolVal():
                 return self._visit_bool(e, ctx)
+            case ForeignVal():
+                return self._visit_foreign(e, ctx)
             case ContextVal():
                 return self._visit_context_val(e, ctx)
             case Decnum():
@@ -288,10 +295,14 @@ class TransformVisitor(BaseVisitor):
 
 class DefaultVisitor(Visitor):
     """Default visitor: visits all nodes without doing anything."""
+
     def _visit_var(self, e: Var, ctx: Any):
         pass
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
+        pass
+
+    def _visit_foreign(self, e: ForeignVal, ctx: Any):
         pass
 
     def _visit_context_val(self, e: ContextVal, ctx: Any):
@@ -417,6 +428,9 @@ class DefaultTransformVisitor(TransformVisitor):
 
     def _visit_bool(self, e: BoolVal, ctx: Any):
         return BoolVal(e.val)
+
+    def _visit_foreign(self, e: ForeignVal, ctx: Any):
+        return ForeignVal(e.val)
 
     def _visit_context_val(self, e: ContextVal, ctx: Any):
         return ContextVal(e.val)

--- a/fpy2/ir/visitor.py
+++ b/fpy2/ir/visitor.py
@@ -590,6 +590,8 @@ class DefaultTransformVisitor(TransformVisitor):
                 context = self._visit_var(stmt.ctx, ctx)
             case ContextExpr():
                 context = self._visit_context_expr(stmt.ctx, ctx)
+            case ForeignVal():
+                context = ForeignVal(stmt.ctx.val)
             case _:
                 raise RuntimeError('unreachable', stmt.ctx)
         body, ctx = self._visit_block(stmt.body, ctx)

--- a/fpy2/number/ext.py
+++ b/fpy2/number/ext.py
@@ -1,6 +1,6 @@
 
 
-from ..utils import default_repr, bitmask
+from ..utils import default_repr, enum_repr, bitmask
 
 from enum import IntEnum
 
@@ -10,7 +10,7 @@ from .mpb import MPBContext
 from .real import RealFloat
 from .round import RoundingMode
 
-
+@enum_repr
 class ExtNanKind(IntEnum):
     """
     Describes how NaN values are encoded for `ExtContext` rounding contexts.

--- a/fpy2/number/round.py
+++ b/fpy2/number/round.py
@@ -2,9 +2,12 @@
 This module defines rounding utilities.
 """
 
-from enum import IntEnum
+from enum import Enum
 
-class RoundingDirection(IntEnum):
+from ..utils import enum_repr
+
+@enum_repr
+class RoundingDirection(Enum):
     """Rounding directions for finite-precision operations."""
     RTZ = 0
     """rounding towards zero"""
@@ -15,8 +18,8 @@ class RoundingDirection(IntEnum):
     RTO = 3
     """rounding towards odd"""
 
-
-class RoundingMode(IntEnum):
+@enum_repr
+class RoundingMode(Enum):
     """Rounding modes for finite-precision operations."""
     RNE = 0
     """round to nearest, ties to even"""

--- a/fpy2/profile/expr_profiler.py
+++ b/fpy2/profile/expr_profiler.py
@@ -9,9 +9,9 @@ from typing import Any, Literal, Optional
 from titanfp.arithmetic.ieee754 import Float, IEEECtx
 from titanfp.arithmetic.mpmf import MPMF
 
+from ..function import Function
 from ..ir import Expr
 from ..interpret import Interpreter, RealInterpreter, get_default_interpreter
-from ..runtime import Function
 from ..runtime.trace import ExprTraceEntry
 from ..runtime.metric import ordinal_error
 from ..runtime.real import PrecisionLimitExceeded

--- a/fpy2/profile/function_profiler.py
+++ b/fpy2/profile/function_profiler.py
@@ -9,8 +9,8 @@ from typing import Any, Optional
 from titanfp.arithmetic.ieee754 import Float, IEEECtx
 from titanfp.arithmetic.mpmf import MPMF
 
+from ..function import Function
 from ..interpret import Interpreter, RealInterpreter, get_default_interpreter
-from ..runtime import Function
 from ..runtime.metric import ordinal_error
 from ..runtime.real import PrecisionLimitExceeded
 

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -131,10 +131,6 @@ class _MatcherInst(AstVisitor):
         if e.val != pat.val:
             raise _MatchFailure(f'matching {pat} against {e}')
 
-    def _visit_context_val(self, e: ContextVal, pat: ContextVal):
-        # TODO: does this even make sense?
-        raise _MatchFailure(f'matching {pat} against {e}')
-
     def _visit_decnum(self, e: Decnum, pat: Decnum):
         # this is a semantic match, not a syntactic match!
         if decnum_to_fraction(e.val) != decnum_to_fraction(pat.val):

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -127,6 +127,10 @@ class _MatcherInst(AstVisitor):
         if e.val != pat.val:
             raise _MatchFailure(f'matching {pat} against {e}')
 
+    def _visit_foreign(self, e: ForeignVal, pat: ForeignVal):
+        if e.val != pat.val:
+            raise _MatchFailure(f'matching {pat} against {e}')
+
     def _visit_context_val(self, e: ContextVal, pat: ContextVal):
         # TODO: does this even make sense?
         raise _MatchFailure(f'matching {pat} against {e}')

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -5,7 +5,7 @@ This module defines pattern matching facilities for FPy AST.
 from fractions import Fraction
 
 from ..ast import *
-from ..runtime import Function
+from ..function import Function
 from ..utils import (
     default_repr,
     decnum_to_fraction,

--- a/fpy2/rewrite/rewrite.py
+++ b/fpy2/rewrite/rewrite.py
@@ -2,10 +2,8 @@
 This module defines a rewrite rule.
 """
 
-from dataclasses import dataclass
-
 from ..ast import *
-from ..runtime import Function
+from ..function import Function
 from ..utils import default_repr, sliding_window
 
 from .applier import Applier

--- a/fpy2/runtime/__init__.py
+++ b/fpy2/runtime/__init__.py
@@ -1,6 +1,1 @@
 from .env import ForeignEnv
-from .function import (
-    Function,
-    get_default_function_call,
-    set_default_function_call,
-)

--- a/fpy2/sample/sample.py
+++ b/fpy2/sample/sample.py
@@ -9,7 +9,7 @@ from titanfp.arithmetic.evalctx import determine_ctx
 from titanfp.arithmetic import ieee754
 
 from ..ast import AnyTypeAnn, ScalarTypeAnn, ScalarType
-from ..interpret import TitanicInterpreter
+from ..interpret import DefaultInterpreter
 from ..ir import FuncDef
 from ..runtime import Function, ForeignEnv
 
@@ -86,7 +86,7 @@ def _sample_rejection_one(
     else:
         lo = ieee754.Float(negative=True, isinf=True, ctx=ctx)
         hi = ieee754.Float(negative=False, isinf=True, ctx=ctx)
-        rt = TitanicInterpreter()
+        rt = DefaultInterpreter()
 
         assert 'pre' in fun.ast.ctx, 'missing precondition'
         pre = Function(fun.ast.ctx['pre'], ForeignEnv.empty())

--- a/fpy2/sample/sample.py
+++ b/fpy2/sample/sample.py
@@ -9,9 +9,10 @@ from titanfp.arithmetic.evalctx import determine_ctx
 from titanfp.arithmetic import ieee754
 
 from ..ast import AnyTypeAnn, ScalarTypeAnn, ScalarType
+from ..function import Function
 from ..interpret import DefaultInterpreter
 from ..ir import FuncDef
-from ..runtime import Function, ForeignEnv
+from ..runtime import ForeignEnv
 
 from .table import RangeTable
 

--- a/fpy2/transform/ssa.py
+++ b/fpy2/transform/ssa.py
@@ -287,8 +287,8 @@ class _SSAInstance(DefaultTransformVisitor):
 
         context = self._visit_expr(stmt.ctx, ctx)
         # sanity check
-        if not isinstance(context, Var | ContextExpr):
-            raise RuntimeError(f'context {stmt.ctx} must be a Var | ContextExpr')
+        if not isinstance(context, Var | ContextExpr | ForeignVal):
+            raise RuntimeError(f'context {stmt.ctx} must be a Var | ContextExpr | ForeignVal')
 
         body, body_ctx = self._visit_block(stmt.body, ctx)
         return ContextStmt(stmt.name, context, body), body_ctx

--- a/fpy2/utils/__init__.py
+++ b/fpy2/utils/__init__.py
@@ -2,7 +2,7 @@
 
 from .bits import bitmask, float_to_bits, bits_to_float
 from .compare import CompareOp
-from .defaults import default_repr, rcomparable
+from .decorator import default_repr, rcomparable, enum_repr
 from .error import FPySyntaxError, raise_type_error
 
 from .float_params import (

--- a/fpy2/utils/decorator.py
+++ b/fpy2/utils/decorator.py
@@ -2,6 +2,8 @@
 Decorators implementing some default behavior.
 """
 
+from enum import Enum
+
 ###########################################################
 # Default __repr__ decorator
 
@@ -85,3 +87,19 @@ def rcomparable(cls):
         return this_cls
 
     return wrap
+
+############################################################
+# Default __repr__ for enum values
+
+def __default_enum_repr__(x: Enum):
+    """
+    Default __repr__ implementation for enum values.
+    """
+    return f'{x.__class__.__name__}.{x.name}'
+
+def enum_repr(cls):
+    """
+    Default __repr__ implementation for enum values.
+    """
+    cls.__repr__ = __default_enum_repr__
+    return cls

--- a/infra/real/common.py
+++ b/infra/real/common.py
@@ -1,4 +1,4 @@
-from fpy2 import RealInterpreter, TitanicInterpreter
+from fpy2 import RealInterpreter, DefaultInterpreter
 from titanfp.arithmetic.ieee754 import ieee_ctx
 
 from .config import ReferenceMode
@@ -29,13 +29,13 @@ def select_interpreter(mode: ReferenceMode):
             return RealInterpreter()
         case ReferenceMode.FLOAT_1K:
             ctx = ieee_ctx(19, 1024)
-            return TitanicInterpreter(ctx=ctx)
+            return DefaultInterpreter(ctx=ctx)
         case ReferenceMode.FLOAT_2K:
             ctx = ieee_ctx(19, 2048)
-            return TitanicInterpreter(ctx=ctx)
+            return DefaultInterpreter(ctx=ctx)
         case ReferenceMode.FLOAT_4K:
             ctx = ieee_ctx(19, 4096)
-            return TitanicInterpreter(ctx=ctx)
+            return DefaultInterpreter(ctx=ctx)
         case _:
             raise NotImplementedError(mode)
 

--- a/infra/real/evaluator.py
+++ b/infra/real/evaluator.py
@@ -110,9 +110,9 @@ def run_eval_real(config: Config):
     rt = RealInterpreter()
 
     # baseline interpreter
-    rt_1k = TitanicInterpreter(ctx=ieee_ctx(19, 1024))
-    rt_2k = TitanicInterpreter(ctx=ieee_ctx(19, 2048))
-    rt_4k = TitanicInterpreter(ctx=ieee_ctx(19, 4096))
+    rt_1k = DefaultInterpreter(ctx=ieee_ctx(19, 1024))
+    rt_2k = DefaultInterpreter(ctx=ieee_ctx(19, 2048))
+    rt_4k = DefaultInterpreter(ctx=ieee_ctx(19, 4096))
     base_rts = [rt_1k, rt_2k, rt_4k]
 
     # load benchmarks


### PR DESCRIPTION
Various changes:
 - renamed `TitanicInterpreter` to `DefaultInterpreter
 - add `ForeignVal` node to subsume both `StringVal` and ContextVal` (both of these objects are not native in FPy)
 - adds a context inlining pass that ensures that each context statement has a concrete context at that site