### PR TITLE
Adds tuple unpacking in `for` statements / support for `zip`

### DIFF
--- a/benchmarks/sampling.py
+++ b/benchmarks/sampling.py
@@ -12,17 +12,15 @@ def clamp(x: Real, a: Real, b: Real):
     """
     return min(max(x, a), b)
 
-# TODO: add support for zip
 @fpy(name='vector addition')
 def vector_add(x: tuple[Real, ...], y: tuple[Real, ...]):
     assert len(x) == len(y)
-    return [x[i] + y[i] for i in range(len(x))]
+    return [x + y for x, y in zip(x, y)]
 
-# TODO: add support for zip
 @fpy(name='vector subtraction')
 def vector_sub(x: tuple[Real, ...], y: tuple[Real, ...]):
     assert len(x) == len(y)
-    return [x[i] - y[i] for i in range(len(x))]
+    return [x - y for x, y in zip(x, y)]
 
 @fpy(name='scalar-vector multiplication')
 def vector_mul(s: Real, x: tuple[Real, ...]):

--- a/docs/notes/TODO.md
+++ b/docs/notes/TODO.md
@@ -8,7 +8,6 @@ Frontend:
    - underscore arguments to function
    - f-string
  - language:
-   - support for zip()
    - support for vector addition/multiplication
  - formatter:
    - use IndentCtx

--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -28,9 +28,13 @@ class _DefineUseInstance(DefaultVisitor):
     def _visit_comp_expr(self, e: CompExpr, ctx: None):
         for iterable in e.iterables:
             self._visit_expr(iterable, ctx)
-        for var in e.vars:
-            if isinstance(var, NamedId):
-                self.uses[var] = set()
+        for target in e.targets:
+            match target:
+                case NamedId():
+                    self.uses[target] = set()
+                case TupleBinding():
+                    for name in target.names():
+                        self.uses[name] = set()
         self._visit_expr(e.elt, ctx)
 
     def _visit_simple_assign(self, stmt: SimpleAssign, ctx: None):

--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -71,8 +71,13 @@ class _DefineUseInstance(DefaultVisitor):
 
     def _visit_for(self, stmt: ForStmt, ctx: None):
         self._visit_expr(stmt.iterable, ctx)
-        if isinstance(stmt.var, NamedId):
-            self.uses[stmt.var] = set()
+        match stmt.target:
+            case NamedId():
+                self.uses[stmt.target] = set()
+            case TupleBinding():
+                for var in stmt.target.names():
+                    if isinstance(var, NamedId):
+                        self.uses[var] = set()
         for phi in stmt.phis:
             self.uses[phi.name] = set()
             self.uses[phi.lhs].add(phi)

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -141,9 +141,13 @@ class _LiveVars(ReduceVisitor):
 
     def _visit_for(self, stmt: ForStmt, ctx: _RetType) -> _RetType:
         body_fvs = self._visit_block(stmt.body, ctx)
-        if isinstance(stmt.var, NamedId):
-            body_fvs -= { stmt.var }
-        ctx = ctx | body_fvs
+        match stmt.target:
+            case NamedId():
+                body_fvs -= { stmt.target }
+            case TupleBinding():
+                for var in stmt.target.names():
+                    if isinstance(var, NamedId):
+                        body_fvs.discard(var)
         return ctx | self._visit_expr(stmt.iterable, None)
 
     def _visit_foreign_attr(self, e: ForeignAttribute, ctx: None) -> _RetType:

--- a/fpy2/analysis/reaching_defs.py
+++ b/fpy2/analysis/reaching_defs.py
@@ -72,9 +72,13 @@ class _ReachingDefsInstance(DefaultVisitor):
 
     def _visit_for(self, stmt: ForStmt, ctx: _StmtCtx) -> _RetType:
         defs_in, kill_in = ctx
-        defs = { *defs_in, stmt.var } if isinstance(stmt.var, NamedId) else defs_in
-        _, block_kill = self._visit_block(stmt.body, defs)
+        match stmt.target:
+            case NamedId():
+                defs = { *defs_in, stmt.target }
+            case TupleBinding():
+                defs = defs_in | set(stmt.target.names())
 
+        _, block_kill = self._visit_block(stmt.body, defs)
         defs_out = defs.copy()
         kill_out = kill_in | (defs & block_kill)
         return defs_out, kill_out

--- a/fpy2/analysis/reaching_defs.py
+++ b/fpy2/analysis/reaching_defs.py
@@ -75,6 +75,8 @@ class _ReachingDefsInstance(DefaultVisitor):
         match stmt.target:
             case NamedId():
                 defs = { *defs_in, stmt.target }
+            case UnderscoreId():
+                defs = defs_in.copy()
             case TupleBinding():
                 defs = defs_in | set(stmt.target.names())
 

--- a/fpy2/analysis/verify.py
+++ b/fpy2/analysis/verify.py
@@ -28,18 +28,20 @@ class _VerifyPassInstance(DefaultVisitor):
     def _visit_comp_expr(self, e: CompExpr, ctx: _CtxType):
         for iterable in e.iterables:
             self._visit_expr(iterable, ctx)
-        for var in e.vars:
-            match var:
+        for target in e.targets:
+            match target:
                 case NamedId():
-                    if var in self.types:
-                        raise InvalidIRError(f'reassignment of variable {var}')
-                    self.types[var] = AnyType()
-                    ctx.add(var)
+                    if target in self.types:
+                        raise InvalidIRError(f'reassignment of variable {target}')
+                    self.types[target] = AnyType()
+                    ctx.add(target)
                 case UnderscoreId():
                     pass
+                case TupleBinding():
+                    self._visit_tuple_binding(target, ctx)
                 case _:
-                    raise InvalidIRError('unreachable', var)
-        self._visit_expr(e.elt, ctx)
+                    raise InvalidIRError('unreachable', target)
+        self._visit_expr(e.elt, ctx)  
 
     def _visit_simple_assign(self, stmt: SimpleAssign, ctx: _CtxType):
         self._visit_expr(stmt.expr, ctx)

--- a/fpy2/ast/context_inline.py
+++ b/fpy2/ast/context_inline.py
@@ -1,8 +1,11 @@
 """Context inlining for FPy ASTs"""
 
+from ..fpc_context import FPCoreContext
+from ..number import Context
+from ..runtime import ForeignEnv
+
 from .fpyast import *
 from .visitor import DefaultAstTransformVisitor
-from ..runtime import ForeignEnv
 
 class _ContextInlineInstance(DefaultAstTransformVisitor):
     """Per-IR instance of context inlining"""

--- a/fpy2/ast/define_use.py
+++ b/fpy2/ast/define_use.py
@@ -60,8 +60,12 @@ class _DefineUseInstance(DefaultAstVisitor):
 
     def _visit_for(self, stmt: ForStmt, ctx: None):
         self._visit_expr(stmt.iterable, ctx)
-        if isinstance(stmt.var, NamedId):
-            self.uses[stmt.var] = set()
+        match stmt.target:
+            case NamedId():
+                self.uses[stmt.target] = set()
+            case TupleBinding():
+                for var in stmt.target.names():
+                    self.uses[var] = set()
         self._visit_block(stmt.body, ctx)
 
     def _visit_function(self, func: FuncDef, ctx):

--- a/fpy2/ast/define_use.py
+++ b/fpy2/ast/define_use.py
@@ -30,9 +30,13 @@ class _DefineUseInstance(DefaultAstVisitor):
     def _visit_comp_expr(self, e: CompExpr, ctx: None):
         for iterable in e.iterables:
             self._visit_expr(iterable, ctx)
-        for var in e.vars:
-            if isinstance(var, NamedId):
-                self.uses[var] = set()
+        for target in e.targets:
+            match target:
+                case NamedId():
+                    self.uses[target] = set()
+                case TupleBinding():
+                    for name in target.names():
+                        self.uses[name] = set()
         self._visit_expr(e.elt, ctx)
 
     def _visit_simple_assign(self, stmt: SimpleAssign, ctx: None):

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -215,8 +215,16 @@ class _FormatterInstance(AstVisitor):
         self._visit_block(stmt.body, ctx + 1)
 
     def _visit_for(self, stmt: ForStmt, ctx: _Ctx):
+        match stmt.target:
+            case Id():
+                target = str(stmt.target)
+            case TupleBinding():
+                target = self._visit_tuple_binding(stmt.target)
+            case _:
+                raise RuntimeError('unreachable', stmt.target)
+
         iterable = self._visit_expr(stmt.iterable, ctx)
-        self._add_line(f'for {str(stmt.var)} in {iterable}:', ctx)
+        self._add_line(f'for {target} in {iterable}:', ctx)
         self._visit_block(stmt.body, ctx + 1)
 
     def _visit_context(self, stmt: ContextStmt, ctx: _Ctx):

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -138,6 +138,8 @@ class _FormatterInstance(AstVisitor):
             match target:
                 case NamedId():
                     targets.append(str(target))
+                case UnderscoreId():
+                    pass
                 case TupleBinding():
                     s = self._visit_tuple_binding(target)
                     targets.append(f'({s})')

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -133,9 +133,20 @@ class _FormatterInstance(AstVisitor):
         return f'({", ".join(elts)})'
 
     def _visit_comp_expr(self, e: CompExpr, ctx: _Ctx):
+        targets: list[str] = []
+        for target in e.targets:
+            match target:
+                case NamedId():
+                    targets.append(str(target))
+                case TupleBinding():
+                    s = self._visit_tuple_binding(target)
+                    targets.append(f'({s})')
+                case _:
+                    raise NotImplementedError('unreachable', target)
+
         elt = self._visit_expr(e.elt, ctx)
         iterables = [self._visit_expr(iterable, ctx) for iterable in e.iterables]
-        s = ' '.join(f'for {str(var)} in {iterable}' for var, iterable in zip(e.vars, iterables))
+        s = ' '.join(f'for {target} in {iterable}' for target, iterable in zip(targets, iterables))
         return f'[{elt} {s}]'
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: _Ctx):

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -2,6 +2,7 @@
 
 from pprint import pformat
 
+from ..fpc_context import FPCoreContext
 from .fpyast import *
 from .visitor import AstVisitor
 

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -112,6 +112,8 @@ class _FormatterInstance(AstVisitor):
                 return ' and '.join(args)
             case NaryOpKind.OR:
                 return ' or '.join(args)
+            case NaryOpKind.ZIP:
+                return f'zip({", ".join(args)})'
             case _:
                 raise NotImplementedError
 

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -87,8 +87,9 @@ class TernaryOpKind(IntEnum):
 
 class NaryOpKind(IntEnum):
     # boolean operations
-    AND = 1
-    OR = 2
+    AND = 0
+    OR = 1
+    ZIP = 2
 
 @default_repr
 class Ast(ABC):

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -6,8 +6,6 @@ from abc import ABC, abstractmethod
 from enum import IntEnum
 from typing import Any, Optional, Self, Sequence, TypeAlias
 
-from ..fpc_context import FPCoreContext
-from ..number import Context
 from ..utils import CompareOp, Id, NamedId, UnderscoreId, Location, default_repr
 
 

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -4,7 +4,7 @@ This module contains the AST for FPy programs.
 
 from abc import ABC, abstractmethod
 from enum import IntEnum
-from typing import Any, Optional, Self, Sequence
+from typing import Any, Optional, Self, Sequence, TypeAlias
 
 from ..fpc_context import FPCoreContext
 from ..number import Context
@@ -877,31 +877,34 @@ class WhileStmt(Stmt):
     def __hash__(self) -> int:
         return hash((self.cond, self.body))
 
+
+ForBinding: TypeAlias = Id | TupleBinding
+
 class ForStmt(Stmt):
     """FPy AST: for statement"""
-    var: Id
+    target: ForBinding
     iterable: Expr
     body: StmtBlock
 
     def __init__(
         self,
-        var: Id,
+        target: ForBinding,
         iterable: Expr,
         body: StmtBlock,
         loc: Optional[Location]
     ):
         super().__init__(loc)
-        self.var = var
+        self.target = target
         self.iterable = iterable
         self.body = body
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ForStmt):
             return False
-        return self.var == other.var and self.iterable == other.iterable and self.body == other.body
+        return self.target == other.target and self.iterable == other.iterable and self.body == other.body
 
     def __hash__(self) -> int:
-        return hash((self.var, self.iterable, self.body))
+        return hash((self.target, self.iterable, self.body))
 
 class ContextStmt(Stmt):
     """FPy AST: with statement"""

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -505,31 +505,69 @@ class TupleExpr(Expr):
     def __hash__(self) -> int:
         return hash(tuple(self.args))
 
+class TupleBinding(Ast):
+    """FPy AST: tuple binding"""
+    elts: list[Id | Self]
+
+    def __init__(
+        self,
+        vars: Sequence[Id | Self],
+        loc: Optional[Location]
+    ):
+        super().__init__(loc)
+        self.elts = list(vars)
+
+    def __iter__(self):
+        return iter(self.elts)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TupleBinding):
+            return False
+        return self.elts == other.elts
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.elts))
+
+    def names(self) -> set[NamedId]:
+        ids: set[NamedId] = set()
+        for v in self.elts:
+            if isinstance(v, NamedId):
+                ids.add(v)
+            elif isinstance(v, UnderscoreId):
+                pass
+            elif isinstance(v, TupleBinding):
+                ids |= v.names()
+            else:
+                raise NotImplementedError('unexpected tuple identifier', v)
+        return ids
+
+Binding: TypeAlias = Id | TupleBinding
+
 class CompExpr(Expr):
     """FPy AST: comprehension expression"""
-    vars: list[Id]
+    targets: list[Binding]
     iterables: list[Expr]
     elt: Expr
 
     def __init__(
         self,
-        vars: Sequence[Id],
+        targets: Sequence[Binding],
         iterables: Sequence[Expr],
         elt: Expr,
         loc: Optional[Location]
     ):
         super().__init__(loc)
-        self.vars = list(vars)
+        self.targets = list(targets)
         self.iterables = list(iterables)
         self.elt = elt
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CompExpr):
             return False
-        return self.vars == other.vars and self.iterables == other.iterables and self.elt == other.elt
+        return self.targets == other.targets and self.iterables == other.iterables and self.elt == other.elt
     
     def __hash__(self) -> int:
-        return hash((tuple(self.vars), tuple(self.iterables), self.elt))
+        return hash((tuple(self.targets), tuple(self.iterables), self.elt))
 
 class TupleRef(Expr):
     """FPy AST: tuple indexing expression"""
@@ -715,45 +753,9 @@ class SimpleAssign(Stmt):
         if not isinstance(other, SimpleAssign):
             return False
         return self.var == other.var and self.expr == other.expr and self.ann == other.ann
-    
+
     def __hash__(self) -> int:
         return hash((self.var, self.expr, self.ann))
-
-class TupleBinding(Ast):
-    """FPy AST: tuple binding"""
-    elts: list[Id | Self]
-
-    def __init__(
-        self,
-        vars: Sequence[Id | Self],
-        loc: Optional[Location]
-    ):
-        super().__init__(loc)
-        self.elts = list(vars)
-
-    def __iter__(self):
-        return iter(self.elts)
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, TupleBinding):
-            return False
-        return self.elts == other.elts
-
-    def __hash__(self) -> int:
-        return hash(tuple(self.elts))
-
-    def names(self) -> set[NamedId]:
-        ids: set[NamedId] = set()
-        for v in self.elts:
-            if isinstance(v, NamedId):
-                ids.add(v)
-            elif isinstance(v, UnderscoreId):
-                pass
-            elif isinstance(v, TupleBinding):
-                ids |= v.names()
-            else:
-                raise NotImplementedError('unexpected tuple identifier', v)
-        return ids
 
 class TupleUnpack(Stmt):
     """FPy AST: unpacking / destructing a tuple"""
@@ -876,18 +878,15 @@ class WhileStmt(Stmt):
     def __hash__(self) -> int:
         return hash((self.cond, self.body))
 
-
-ForBinding: TypeAlias = Id | TupleBinding
-
 class ForStmt(Stmt):
     """FPy AST: for statement"""
-    target: ForBinding
+    target: Binding
     iterable: Expr
     body: StmtBlock
 
     def __init__(
         self,
-        target: ForBinding,
+        target: Binding,
         iterable: Expr,
         body: StmtBlock,
         loc: Optional[Location]

--- a/fpy2/ast/live_vars.py
+++ b/fpy2/ast/live_vars.py
@@ -87,7 +87,12 @@ class LiveVarsInstance(AstVisitor):
 
     def _visit_comp_expr(self, e: CompExpr, ctx: None) -> _LiveSet:
         live = self._visit_expr(e.elt, ctx)
-        live -= set([var for var in e.vars if isinstance(var, NamedId)])
+        for target in e.targets:
+            match target:
+                case NamedId():
+                    live -= { target }
+                case TupleBinding():
+                    live |= target.names()
         for iterable in e.iterables:
             live |= self._visit_expr(iterable, ctx)
         return live

--- a/fpy2/ast/live_vars.py
+++ b/fpy2/ast/live_vars.py
@@ -154,8 +154,11 @@ class LiveVarsInstance(AstVisitor):
     def _visit_for(self, stmt: ForStmt, live: _LiveSet) -> _LiveSet:
         live = set(live)
         live |= self._visit_block(stmt.body, live)
-        if isinstance(stmt.var, NamedId):
-            live -= { stmt.var }
+        match stmt.target:
+            case NamedId():
+                live -= { stmt.target }
+            case TupleBinding():
+                live -= stmt.target.names()
         live |= self._visit_expr(stmt.iterable, None)
         return live
 

--- a/fpy2/ast/syntax_check.py
+++ b/fpy2/ast/syntax_check.py
@@ -286,8 +286,11 @@ class SyntaxCheckInstance(AstVisitor):
     def _visit_for(self, stmt: ForStmt, ctx: _Ctx):
         env, _ = ctx
         self._visit_expr(stmt.iterable, ctx)
-        if isinstance(stmt.var, NamedId):
-            env = env.extend(stmt.var)
+        match stmt.target:
+            case NamedId():
+                env = env.extend(stmt.target)
+            case TupleBinding():
+                env = self._visit_tuple_binding(stmt.target, ctx)
         body_env = self._visit_block(stmt.body, (env, False))
         return env.merge(body_env)
 

--- a/fpy2/ast/syntax_check.py
+++ b/fpy2/ast/syntax_check.py
@@ -188,9 +188,12 @@ class SyntaxCheckInstance(AstVisitor):
         env, _ = ctx
         for iterable in e.iterables:
             self._visit_expr(iterable, ctx)
-        for var in e.vars:
-            if isinstance(var, NamedId):
-                env = env.extend(var)
+        for target in e.targets:
+            match target:
+                case NamedId():
+                    env = env.extend(target)
+                case TupleBinding():
+                    env = self._visit_tuple_binding(target, ctx)
         self._visit_expr(e.elt, (env, False))
         return env
 

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -517,9 +517,17 @@ class DefaultAstTransformVisitor(AstVisitor):
         return s, ctx
 
     def _visit_for(self, stmt: ForStmt, ctx: Any):
+        match stmt.target:
+            case Id():
+                target = stmt.target
+            case TupleBinding():
+                target = self._visit_tuple_binding(stmt.target)
+            case _:
+                raise RuntimeError('unreachable', stmt.target)
+
         iterable = self._visit_expr(stmt.iterable, ctx)
         body, _ = self._visit_block(stmt.body, ctx)
-        s = ForStmt(stmt.var, iterable, body, stmt.loc)
+        s = ForStmt(target, iterable, body, stmt.loc)
         return s, ctx
 
     def _visit_context(self, stmt: ContextStmt, ctx: Any):

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -483,7 +483,7 @@ class DefaultAstTransformVisitor(AstVisitor):
                     new_vars.append(self._visit_tuple_binding(var))
                 case _:
                     raise NotImplementedError(f'unreachable {var}')
-        return new_vars
+        return TupleBinding(new_vars, binding.loc)
 
     def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: Any):
         binding = self._visit_tuple_binding(stmt.binding)

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -431,9 +431,19 @@ class DefaultAstTransformVisitor(AstVisitor):
         return TupleRef(value, slices, e.loc)
 
     def _visit_comp_expr(self, e: CompExpr, ctx: Any):
+        targets: list[Id | TupleBinding] = []
+        for target in e.targets:
+            match target:
+                case Id():
+                    targets.append(target)
+                case TupleBinding():
+                    targets.append(self._visit_tuple_binding(target))
+                case _:
+                    raise RuntimeError('unreachable', target)
+
         iterables = [self._visit_expr(iterable, ctx) for iterable in e.iterables]
         elt = self._visit_expr(e.elt, ctx)
-        return CompExpr(e.vars, iterables, elt, e.loc)
+        return CompExpr(targets, iterables, elt, e.loc)
 
     def _visit_if_expr(self, e: IfExpr, ctx: Any):
         cond = self._visit_expr(e.cond, ctx)

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -112,15 +112,17 @@ class FPCoreCompileInstance(ReduceVisitor):
             case _:
                 raise FPCoreCompileError('unsupported argument type', arg)
 
-    def _compile_tuple_binding(self, tuple_id: str, binding: TupleBinding, pos: list[int]):
+    def _compile_tuple_binding(self, tuple_id: str, binding: TupleBinding, pos: list[fpc.Expr]):
         tuple_binds: list[tuple[str, fpc.Expr]] = []
         for i, elt in enumerate(binding):
             match elt:
                 case Id():
-                    idxs = [fpc.Integer(idx) for idx in [i, *pos]]
-                    tuple_binds.append((str(elt), fpc.Ref(fpc.Var(tuple_id), *idxs)))
+                    idxs = [fpc.Integer(i), *pos]
+                    tuple_bind = (str(elt), fpc.Ref(fpc.Var(tuple_id), *idxs))
+                    tuple_binds.append(tuple_bind)
                 case TupleBinding():
-                    tuple_binds += self._compile_tuple_binding(tuple_id, elt, [i, *pos])
+                    idxs = [fpc.Integer(i), *pos]
+                    tuple_binds += self._compile_tuple_binding(tuple_id, elt, idxs)
                 case _:
                     raise FPCoreCompileError('unexpected tensor element', elt)
         return tuple_binds
@@ -142,38 +144,38 @@ class FPCoreCompileInstance(ReduceVisitor):
             case _:
                 raise NotImplementedError('unreachable', op)
 
-    def _visit_var(self, e, ctx) -> fpc.Expr:
+    def _visit_var(self, e: Var, ctx: None) -> fpc.Expr:
         return fpc.Var(str(e.name))
 
     def _visit_bool(self, e: BoolVal, ctx: None):
         return fpc.Constant('TRUE' if e.val else 'FALSE')
 
-    def _visit_foreign(self, e: ForeignVal, ctx) -> fpc.Expr:
+    def _visit_foreign(self, e: ForeignVal, ctx: None) -> fpc.Expr:
         raise FPCoreCompileError('unsupported value', e.val)
 
-    def _visit_decnum(self, e, ctx) -> fpc.Expr:
+    def _visit_decnum(self, e: Decnum, ctx: None) -> fpc.Expr:
         return fpc.Decnum(e.val)
 
-    def _visit_hexnum(self, e, ctx):
+    def _visit_hexnum(self, e: Hexnum, ctx: None):
         raise fpc.Hexnum(e.val)
 
-    def _visit_integer(self, e, ctx) -> fpc.Expr:
+    def _visit_integer(self, e: Integer, ctx: None) -> fpc.Expr:
         return fpc.Integer(e.val)
 
-    def _visit_rational(self, e, ctx):
+    def _visit_rational(self, e: Rational, ctx: None):
         raise fpc.Rational(e.p, e.q)
 
-    def _visit_constant(self, e, ctx):
+    def _visit_constant(self, e: Constant, ctx: None):
         raise fpc.Constant(e.val)
 
-    def _visit_digits(self, e, ctx) -> fpc.Expr:
+    def _visit_digits(self, e: Digits, ctx: None) -> fpc.Expr:
         return fpc.Digits(e.m, e.e, e.b)
 
-    def _visit_unknown(self, e, ctx) -> fpc.Expr:
+    def _visit_unknown(self, e: UnknownCall, ctx: None) -> fpc.Expr:
         args = [self._visit_expr(c, ctx) for c in e.children]
         return fpc.UnknownOperator(e.name, *args)
 
-    def _visit_range(self, e: Range, ctx) -> fpc.Expr:
+    def _visit_range(self, e: Range, ctx: None) -> fpc.Expr:
         # expand range expression
         tuple_id = 'i' # only identifier in scope => no need for uniqueness
         size = self._visit_expr(e.children[0], ctx)
@@ -204,7 +206,7 @@ class FPCoreCompileInstance(ReduceVisitor):
             )
         )
 
-    def _visit_zip(self, e: Zip, ctx) -> fpc.Expr:
+    def _visit_zip(self, e: Zip, ctx: None) -> fpc.Expr:
         # expand zip expression (for N=2)
         #  (let ([t0 <tuple0>] [t1 <tuple1>])
         #    (tensor ([i (size t0 0)])
@@ -224,7 +226,7 @@ class FPCoreCompileInstance(ReduceVisitor):
                 )
             )
 
-    def _visit_nary_expr(self, e, ctx) -> fpc.Expr:
+    def _visit_nary_expr(self, e: NaryExpr, ctx: None) -> fpc.Expr:
         match e:
             case Range():
                 # range expression
@@ -285,10 +287,10 @@ class FPCoreCompileInstance(ReduceVisitor):
             case _:
                 raise NotImplementedError('unreachable', e.ops)
 
-    def _visit_tuple_expr(self, e, ctx) -> fpc.Expr:
+    def _visit_tuple_expr(self, e: TupleExpr, ctx: None) -> fpc.Expr:
         return fpc.Array(*[self._visit_expr(c, ctx) for c in e.children])
 
-    def _visit_tuple_ref(self, e, ctx) -> fpc.Expr:
+    def _visit_tuple_ref(self, e: TupleRef, ctx: None) -> fpc.Expr:
         value = self._visit_expr(e.value, ctx)
         slices = [self._visit_expr(s, ctx) for s in e.slices]
         return fpc.Ref(value, *slices)
@@ -309,7 +311,7 @@ class FPCoreCompileInstance(ReduceVisitor):
         if_expr = fpc.If(cond_expr, ift_expr, iff_expr)
         return fpc.Tensor(tensor_dims, if_expr)
 
-    def _visit_tuple_set(self, e, ctx) -> fpc.Expr:
+    def _visit_tuple_set(self, e: TupleSet, ctx: None) -> fpc.Expr:
         # general case:
         # 
         #   (let ([t <tuple>] [i0 <index>] ... [v <value>]))
@@ -355,12 +357,12 @@ class FPCoreCompileInstance(ReduceVisitor):
         return fpc.Let(let_bindings, tensor_expr)
 
 
-    def _visit_comp_expr(self, e, ctx) -> fpc.Expr:
-        if len(e.vars) == 1:
+    def _visit_comp_expr(self, e: CompExpr, ctx: None) -> fpc.Expr:
+        if len(e.targets) == 1:
             # simple case:
-            # (let ([t <iterable>]) (tensor ([i (size t)]) (let ([<var> (ref t i)]) <elt>))
+            # (let ([t <iterable>]) (tensor ([i (size t 0)]) (let ([<var> (ref t i)]) <elt>))
+            target = e.targets[0]
             iterable = e.iterables[0]
-            var = str(e.vars[0])
 
             tuple_id = str(self.gensym.fresh('t'))
             iter_id = str(self.gensym.fresh('i'))
@@ -369,12 +371,20 @@ class FPCoreCompileInstance(ReduceVisitor):
 
             let_bindings = [(tuple_id, iterable)]
             tensor_dims: list[tuple[str, fpc.Expr]] = [(iter_id, _size0_expr(tuple_id))]
-            ref_bindings: list[tuple[str, fpc.Expr]] = [(var, fpc.Ref(fpc.Var(tuple_id), fpc.Var(iter_id)))]
+            match target:
+                case NamedId():
+                    ref_bindings = [(str(target), fpc.Ref(fpc.Var(tuple_id), fpc.Var(iter_id)))]
+                case UnderscoreId():
+                    ref_bindings = []
+                case TupleBinding():
+                    ref_bindings = self._compile_tuple_binding(tuple_id, target, [fpc.Var(iter_id)])
+                case _:
+                    raise RuntimeError('unreachable', target)
             return fpc.Let(let_bindings, fpc.Tensor(tensor_dims, fpc.Let(ref_bindings, elt)))
         else:
             # hard case:
             # (let ([t0 <iterable>] ...)
-            #   (let ([n0 (size t0)] ...)
+            #   (let ([n0 (size t0 0)] ...)
             #     (tensor ([k (! :precision integer (* n0 ...))])
             #       (let ([i0 (! :precision integer :round toZero (/ k (* n1 ...)))]
             #             [i1 (! :precision integer :round toZero (fmod (/ k (* n2 ...)) n1))]
@@ -384,20 +394,20 @@ class FPCoreCompileInstance(ReduceVisitor):
             #           <elt>))))
 
             # bind the tuples to temporaries
-            tuple_ids = [str(self.gensym.fresh('t')) for _ in e.vars]
+            tuple_ids = [str(self.gensym.fresh('t')) for _ in e.targets]
             tuple_binds: list[tuple[str, fpc.Expr]] = [
                 (tid, self._visit_expr(iterable, ctx))
                 for tid, iterable in zip(tuple_ids, e.iterables)
             ]
             # bind the sizes to temporaries
-            size_ids = [str(self.gensym.fresh('n')) for _ in e.vars]
+            size_ids = [str(self.gensym.fresh('n')) for _ in e.targets]
             size_binds: list[tuple[str, fpc.Expr]] = [
                 (sid, _size0_expr(tid))
                 for sid, tid in zip(size_ids, tuple_ids)
             ]
             # bind the indices to temporaries
             idx_ctx = { 'precision': 'integer', 'round': 'toZero' }
-            idx_ids = [str(self.gensym.fresh('i')) for _ in e.vars]
+            idx_ids = [str(self.gensym.fresh('i')) for _ in e.targets]
             idx_binds: list[tuple[str, fpc.Expr]] = []
             for i, iid in enumerate(idx_ids):
                 if i == 0:
@@ -414,18 +424,22 @@ class FPCoreCompileInstance(ReduceVisitor):
             iter_id = str(self.gensym.fresh('k'))
             iter_expr = fpc.Ctx(iter_ctx, _nary_mul([fpc.Var(sid) for sid in size_ids]))
             # reference variables
-            ref_ids = [str(self.gensym.refresh(var)) for var in e.vars]
-            ref_binds: list[tuple[str, fpc.Expr]] = [
-                (rid, fpc.Ref(fpc.Var(tid), fpc.Var(iid)))
-                for rid, tid, iid in zip(ref_ids, tuple_ids, idx_ids)
-            ]
+            ref_binds: list[tuple[str, fpc.Expr]] = []
+            for target, tid, iid in zip(e.targets, tuple_ids, idx_ids):
+                match target:
+                    case NamedId():
+                        ref_id = str(self.gensym.refresh(target))
+                        ref_bind = (ref_id, fpc.Ref(fpc.Var(tid), fpc.Var(iid)))
+                        ref_binds.append(ref_bind)
+                    case TupleBinding():
+                        ref_binds += self._compile_tuple_binding(tid, target, [fpc.Var(iid)])
             # element expression
             elt = self._visit_expr(e.elt, ctx)
             # compose the expression
             tensor_expr = fpc.Tensor([(iter_id, iter_expr)], fpc.Let(idx_binds, fpc.Let(ref_binds, elt)))
             return fpc.Let(tuple_binds, fpc.Let(size_binds, tensor_expr))
 
-    def _visit_if_expr(self, e, ctx) -> fpc.Expr:
+    def _visit_if_expr(self, e: IfExpr, ctx: None) -> fpc.Expr:
         cond = self._visit_expr(e.cond, ctx)
         ift = self._visit_expr(e.ift, ctx)
         iff = self._visit_expr(e.iff, ctx)
@@ -444,13 +458,13 @@ class FPCoreCompileInstance(ReduceVisitor):
     def _visit_index_assign(self, stmt: IndexAssign, ctx: fpc.Expr):
         raise FPCoreCompileError(f'cannot compile to FPCore: {type(stmt).__name__}')
 
-    def _visit_if1(self, stmt, ctx):
+    def _visit_if1(self, stmt: If1Stmt, ctx: None):
         raise FPCoreCompileError(f'cannot compile to FPCore: {type(stmt).__name__}')
 
-    def _visit_if(self, stmt, ctx):
+    def _visit_if(self, stmt: IfStmt, ctx: None):
         raise FPCoreCompileError(f'cannot compile to FPCore: {type(stmt).__name__}')
 
-    def _visit_while(self, stmt, ctx: fpc.Expr):
+    def _visit_while(self, stmt: WhileStmt, ctx: fpc.Expr):
         if len(stmt.phis) != 1:
             raise FPCoreCompileError('while loops must have exactly one phi node')
         phi = stmt.phis[0]
@@ -485,7 +499,7 @@ class FPCoreCompileInstance(ReduceVisitor):
     def _visit_context_expr(self, e: ContextExpr, ctx: None):
         raise RuntimeError('do not call')
 
-    def _visit_context(self, stmt, ctx):
+    def _visit_context(self, stmt: ContextStmt, ctx: None):
         body = self._visit_block(stmt.body, ctx)
         # extract a context value
         match stmt.ctx:
@@ -506,17 +520,17 @@ class FPCoreCompileInstance(ReduceVisitor):
                 raise FPCoreCompileError('Expected `Context` or `FPCoreContext`', val)
         return fpc.Ctx(props, body)
 
-    def _visit_assert(self, stmt: AssertStmt, ctx):
+    def _visit_assert(self, stmt: AssertStmt, ctx: None):
         # strip the assertion
         return ctx
 
     def _visit_effect(self, stmt: EffectStmt, ctx: fpc.Expr):
         raise FPCoreCompileError('FPCore does not support effectful computation')
 
-    def _visit_return(self, stmt, ctx) -> fpc.Expr:
+    def _visit_return(self, stmt: ReturnStmt, ctx: None) -> fpc.Expr:
         return self._visit_expr(stmt.expr, ctx)
 
-    def _visit_block(self, block, ctx: Optional[fpc.Expr]):
+    def _visit_block(self, block: StmtBlock, ctx: Optional[fpc.Expr]):
         if ctx is None:
             e = self._visit_statement(block.stmts[-1], None)
             stmts = block.stmts[:-1]
@@ -531,7 +545,7 @@ class FPCoreCompileInstance(ReduceVisitor):
 
         return e
 
-    def _visit_function(self, func, ctx: Optional[fpc.Expr]):
+    def _visit_function(self, func: FuncDef, ctx: Optional[fpc.Expr]):
         args = [self._compile_arg(arg) for arg in func.args]
         body = self._visit_block(func.body, ctx)
         # TODO: parse data

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -8,7 +8,7 @@ from ..ir import *
 
 from ..ast import fpyast as ast
 from ..ast.syntax_check import SyntaxCheck
-from ..function import Function
+from ..fpc_context import FPCoreContext
 from ..transform import UnSSA
 
 from ..ir.codegen import (
@@ -201,9 +201,17 @@ class _FPyCompilerInstance(ReduceVisitor):
         if stmt.phis != []:
             raise ValueError(f'expected no phis in statement: {stmt}')
 
+        match stmt.target:
+            case Id():
+                target = stmt.target
+            case TupleBinding():
+                target = self._visit_tuple_binding(stmt.target)
+            case _:
+                raise RuntimeError('unreachable', stmt.target)
+
         iterable = self._visit_expr(stmt.iterable, None)
         body = self._visit_block(stmt.body, None)
-        return ast.ForStmt(stmt.var, iterable, body, None)
+        return ast.ForStmt(target, iterable, body, None)
 
     def _visit_context_expr(self, e: ContextExpr, ctx: Any):
         match e.ctor:

--- a/fpy2/backend/fpy.py
+++ b/fpy2/backend/fpy.py
@@ -130,9 +130,20 @@ class _FPyCompilerInstance(ReduceVisitor):
         raise NotImplementedError('do not call')
 
     def _visit_comp_expr(self, e: CompExpr, ctx: None):
+        targets: list[Id | ast.TupleBinding] = []
+        for target in e.targets:
+            match target:
+                case Id():
+                    targets.append(target)
+                case TupleBinding():
+                    bind = self._visit_tuple_binding(target)
+                    targets.append(bind)
+                case _:
+                    raise RuntimeError('unreachable', target)
+
         iters = [self._visit_expr(i, None) for i in e.iterables]
         elt = self._visit_expr(e.elt, None)
-        return ast.CompExpr(e.vars, iters, elt, None)
+        return ast.CompExpr(targets, iters, elt, None)
 
     def _visit_if_expr(self, e: IfExpr, ctx: None):
         cond = self._visit_expr(e.cond, None)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -472,14 +472,14 @@ class Parser:
             case ast.List():
                 return TupleExpr([self._parse_expr(e) for e in e.elts], loc)
             case ast.ListComp():
-                vars: list[Id] = []
+                targets: list[Id | TupleBinding] = []
                 iterables: list[Expr] = []
                 for gen in e.generators:
-                    var, iterable = self._parse_comprehension(gen, loc)
-                    vars.append(var)
+                    target, iterable = self._parse_comprehension(gen, loc)
+                    targets.append(target)
                     iterables.append(iterable)
                 elt = self._parse_expr(e.elt)
-                return CompExpr(vars, iterables, elt, loc)
+                return CompExpr(targets, iterables, elt, loc)
             case ast.Subscript():
                 value, slices = self._parse_subscript(e)
                 return TupleRef(value, slices, loc)
@@ -493,29 +493,25 @@ class Parser:
                     raise FPyParserError(loc, 'expression is unsupported in FPy', e)
                 return self._parse_foreign_attribute(e)
 
-    def _parse_tuple_target(self, target: ast.expr, st: ast.stmt):
+    def _parse_tuple_target(self, target: ast.expr, e: ast.AST):
         loc = self._parse_location(target)
         match target:
             case ast.Name():
                 return self._parse_id(target)
             case ast.Tuple():
-                elts = [self._parse_tuple_target(elt, st) for elt in target.elts]
+                elts = [self._parse_tuple_target(elt, e) for elt in target.elts]
                 return TupleBinding(elts, loc)
             case _:
-                raise FPyParserError(loc, 'FPy expects an identifier', target, st)       
+                raise FPyParserError(loc, 'FPy expects an identifier', target, e)       
 
     def _parse_comprehension(self, gen: ast.comprehension, loc: Location):
         if gen.is_async:
             raise FPyParserError(loc, 'FPy does not support async comprehensions', gen)
         if gen.ifs != []:
             raise FPyParserError(loc, 'FPy does not support if conditions in comprehensions', gen)
-        match gen.target:
-            case ast.Name():
-                ident = self._parse_id(gen.target)
-                iterable = self._parse_expr(gen.iter)
-                return ident, iterable
-            case _:
-                raise FPyParserError(loc, 'FPy expects an identifier', gen.target, gen)
+        target = self._parse_tuple_target(gen.target, gen)
+        iterable = self._parse_expr(gen.iter)
+        return target, iterable
 
     def _parse_contextdata(self, e: ast.expr):
         loc = self._parse_location(e)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -679,13 +679,10 @@ class Parser:
             case ast.For():
                 if stmt.orelse != []:
                     raise FPyParserError(loc, 'FPy does not support else clause in for statement', stmt)
-                if not isinstance(stmt.target, ast.Name):
-                    raise FPyParserError(loc, 'FPy expects an identifier', stmt)
-
-                ident = self._parse_id(stmt.target)
+                for_target = self._parse_tuple_target(stmt.target, stmt)
                 iterable = self._parse_expr(stmt.iter)
                 block = self._parse_statements(stmt.body)
-                return ForStmt(ident, iterable, block, loc)
+                return ForStmt(for_target, iterable, block, loc)
             case ast.Return():
                 if stmt.value is None:
                     raise FPyParserError(loc, 'Return statement must have value', stmt)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -109,7 +109,8 @@ _ternary_table = {
 
 _nary_table = {
     'and': NaryOpKind.AND,
-    'or': NaryOpKind.OR
+    'or': NaryOpKind.OR,
+    'zip': NaryOpKind.ZIP,
 }
 
 _special_functions = {

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -589,8 +589,11 @@ class _Interpreter(ReduceVisitor):
             raise TypeError(f'expected a tensor, got {iterable}')
 
         for val in iterable:
-            if isinstance(stmt.var, NamedId):
-                self.env[stmt.var] = val
+            match stmt.target:
+                case NamedId():
+                    self.env[stmt.target] = val
+                case TupleBinding():
+                    self._unpack_tuple(stmt.target, val, ctx)
             self._visit_block(stmt.body, ctx)
             for phi in stmt.phis:
                 self.env[phi.name] = self.env[phi.rhs]

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -327,6 +327,22 @@ class _Interpreter(ReduceVisitor):
             raise TypeError(f'expected an integer argument, got {dim}')
         return Float.from_int(v.shape[int(dim)], ctx=ctx)
 
+    def _apply_zip(self, e: NaryExpr, ctx: Context):
+        """Apply the `zip` method to the given n-ary expression."""
+        if len(e.children) == 0:
+            return NDArray([])
+
+        # evaluate all children
+        arrays: list[NDArray] = []
+        for arg in e.children:
+            val = self._visit_expr(arg, ctx)
+            if not isinstance(val, NDArray):
+                raise TypeError(f'expected a tensor argument, got {val}')
+            arrays.append(val)
+
+        # zip the arrays
+        return NDArray(zip(*arrays))
+
     def _visit_nary_expr(self, e: NaryExpr, ctx: Context):
         if e.name in _method_table:
             return self._apply_method(e, ctx)
@@ -346,6 +362,8 @@ class _Interpreter(ReduceVisitor):
             return self._apply_dim(e, ctx)
         elif isinstance(e, Size):
             return self._apply_size(e, ctx)
+        elif isinstance(e, Zip):
+            return self._apply_zip(e, ctx)
         else:
             raise NotImplementedError('unknown n-ary expression', e)
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -340,13 +340,18 @@ class _Interpreter(ReduceVisitor):
         if bindings == []:
             elts.append(self._visit_expr(elt, ctx))
         else:
-            var, iterable = bindings[0]
+            target, iterable = bindings[0]
             array = self._visit_expr(iterable, ctx)
             if not isinstance(array, tuple):
                 raise TypeError(f'expected a tensor, got {array}')
             for val in array:
-                if isinstance(var, NamedId):
-                    self.env[var] = val
+                match target:
+                    case NamedId():
+                        self.env[target] = val
+                    case TupleBinding():
+                        self._unpack_tuple(target, val, ctx)
+                    case _:
+                        raise RuntimeError('unreachable', target)
                 self._apply_comp(bindings[1:], elt, ctx, elts)
 
     def _visit_comp_expr(self, e: CompExpr, ctx: Context):
@@ -356,10 +361,13 @@ class _Interpreter(ReduceVisitor):
         self._apply_comp(bindings, e.elt, ctx, elts)
 
         # remove temporarily bound variables
-        for var in e.vars:
-            if isinstance(var, NamedId):
-                del self.env[var]
- 
+        for target in e.targets:
+            match target:
+                case NamedId():
+                    del self.env[target]
+                case TupleBinding():
+                    for var in target.names():
+                        del self.env[var]
         # the result
         return tuple(elts)
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -460,8 +460,11 @@ class _Interpreter(ReduceVisitor):
             raise TypeError(f'expected a tensor, got {iterable}')
 
         for val in iterable:
-            if isinstance(stmt.var, NamedId):
-                self.env[stmt.var] = val
+            match stmt.target:
+                case NamedId():
+                    self.env[stmt.target] = val
+                case TupleBinding():
+                    self._unpack_tuple(stmt.target, val, ctx)
             self._visit_block(stmt.body, ctx)
             for phi in stmt.phis:
                 self.env[phi.name] = self.env[phi.rhs]

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -332,7 +332,7 @@ class _Interpreter(ReduceVisitor):
 
     def _apply_comp(
         self,
-        bindings: list[tuple[Id, Expr]],
+        bindings: list[tuple[Id | TupleBinding, Expr]],
         elt: Expr,
         ctx: Context,
         elts: list[Any]
@@ -352,7 +352,7 @@ class _Interpreter(ReduceVisitor):
     def _visit_comp_expr(self, e: CompExpr, ctx: Context):
         # evaluate comprehension
         elts: list[Any] = []
-        bindings = [(var, iterable) for var, iterable in zip(e.vars, e.iterables)]
+        bindings = list(zip(e.targets, e.iterables))
         self._apply_comp(bindings, e.elt, ctx, elts)
 
         # remove temporarily bound variables

--- a/fpy2/interpret/real.py
+++ b/fpy2/interpret/real.py
@@ -586,8 +586,11 @@ class _Interpreter(ReduceVisitor):
             raise TypeError(f'expected a tensor, got {iterable}')
 
         for val in iterable:
-            if isinstance(stmt.var, NamedId):
-                self.env[stmt.var] = val
+            match stmt.target:
+                case NamedId():
+                    self.env[stmt.target] = val
+                case TupleBinding():
+                    raise NotImplementedError('tuple unpacking in for loops is not supported')
             self._visit_block(stmt.body, ctx)
             for phi in stmt.phis:
                 self.env[phi.name] = self.env[phi.rhs]

--- a/fpy2/interpret/real.py
+++ b/fpy2/interpret/real.py
@@ -252,6 +252,8 @@ class _Interpreter(ReduceVisitor):
             return self._apply_or(e, ctx)
         elif isinstance(e, Range):
             return self._apply_range(e, ctx)
+        elif isinstance(e, Zip):
+            return self._apply_zip(e, ctx)
         else:
             raise NotImplementedError('unknown n-ary expression', e)
 
@@ -288,6 +290,22 @@ class _Interpreter(ReduceVisitor):
         if not stop.is_integer():
             raise TypeError(f'expected an integer argument, got {stop}')
         return NDArray([str(i) for i in range(int(stop))])
+
+    def _apply_zip(self, e: NaryExpr, ctx: Context):
+        """Apply the `zip` method to the given n-ary expression."""
+        if len(e.children) == 0:
+            return NDArray([])
+
+        # evaluate all children
+        arrays: list[NDArray] = []
+        for arg in e.children:
+            val = self._visit_expr(arg, ctx)
+            if not isinstance(val, NDArray):
+                raise TypeError(f'expected a tensor argument, got {val}')
+            arrays.append(val)
+
+        # zip the arrays
+        return NDArray(zip(*arrays))
 
     def _visit_comp_expr(self, e: CompExpr, ctx: Context):
         raise NotImplementedError

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -218,9 +218,16 @@ class _IRCodegenInstance(AstVisitor):
         return ir.WhileStmt(cond, body, [])
 
     def _visit_for(self, stmt: ForStmt, ctx: None):
+        match stmt.target:
+            case Id():
+                target = stmt.target
+            case TupleBinding():
+                target = self._visit_tuple_binding(stmt.target)
+            case _:
+                raise RuntimeError('unreachable', stmt.target)
         iterable = self._visit_expr(stmt.iterable, ctx)
         body = self._visit_block(stmt.body, ctx)
-        return ir.ForStmt(stmt.var, AnyType(), iterable, body, [])
+        return ir.ForStmt(target, AnyType(), iterable, body, [])
 
     def _visit_context_expr(self, e: ContextExpr, ctx: None):
         match e.ctor:

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -77,7 +77,8 @@ _ternary_table: dict[TernaryOpKind, type[ir.TernaryExpr]] = {
 
 _nary_table: dict[NaryOpKind, type[ir.NaryExpr]] = {
     NaryOpKind.AND: ir.And,
-    NaryOpKind.OR: ir.Or
+    NaryOpKind.OR: ir.Or,
+    NaryOpKind.ZIP: ir.Zip
 }
 
 class _IRCodegenInstance(AstVisitor):

--- a/fpy2/ir/codegen.py
+++ b/fpy2/ir/codegen.py
@@ -162,9 +162,19 @@ class _IRCodegenInstance(AstVisitor):
         return ir.TupleExpr(*elts)
 
     def _visit_comp_expr(self, e: CompExpr, ctx: None):
+        targets: list[Id | ir.TupleBinding] = []
+        for target in e.targets:
+            match target:
+                case Id():
+                    targets.append(target)
+                case TupleBinding():
+                    targets.append(self._visit_tuple_binding(target))
+                case _:
+                    raise NotImplementedError('unexpected target', target)
+
         iterables = [self._visit_expr(arg, ctx) for arg in e.iterables]
         elt = self._visit_expr(e.elt, ctx)
-        return ir.CompExpr(list(e.vars), iterables, elt)
+        return ir.CompExpr(targets, iterables, elt)
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: None):
         value = self._visit_expr(e.value, ctx)

--- a/fpy2/ir/formatter.py
+++ b/fpy2/ir/formatter.py
@@ -215,9 +215,17 @@ class _FormatterInstance(BaseVisitor):
         self._visit_block(stmt.body, ctx.indent())
 
     def _visit_for(self, stmt: ForStmt, ctx: _IndentCtx):
+        match stmt.target:
+            case Id():
+                target = str(stmt.target)
+            case TupleBinding():
+                target = self._visit_tuple_binding(stmt.target)
+            case _:
+                raise RuntimeError('unreachable', stmt.target)
+
         iterable = self._visit_expr(stmt.iterable, ctx)
         self._visit_loop_phis(stmt.phis, ctx, None)
-        self._add_line(f'for {str(stmt.var)} in {iterable}:', ctx)
+        self._add_line(f'for {target} in {iterable}:', ctx)
         self._visit_block(stmt.body, ctx.indent())
 
     def _visit_context(self, stmt: ContextStmt, ctx: _IndentCtx):

--- a/fpy2/ir/formatter.py
+++ b/fpy2/ir/formatter.py
@@ -133,9 +133,20 @@ class _FormatterInstance(BaseVisitor):
         return f'set({arg_str})'
 
     def _visit_comp_expr(self, e: CompExpr, ctx: _IndentCtx):
+        targets: list[str] = []
+        for target in e.targets:
+            match target:
+                case NamedId():
+                    targets.append(str(target))
+                case TupleBinding():
+                    s = self._visit_tuple_binding(target)
+                    targets.append(f'({s})')
+                case _:
+                    raise NotImplementedError('unreachable', target)
+
         elt = self._visit_expr(e.elt, ctx)
         iterables = [self._visit_expr(iterable, ctx) for iterable in e.iterables]
-        s = ' '.join(f'for {str(var)} in {iterable}' for var, iterable in zip(e.vars, iterables))
+        s = ' '.join(f'for {target} in {iterable}' for target, iterable in zip(targets, iterables))
         return f'[{elt} {s}]'
 
     def _visit_if_expr(self, e: IfExpr, ctx: _IndentCtx):

--- a/fpy2/ir/ir.py
+++ b/fpy2/ir/ir.py
@@ -3,10 +3,8 @@ This module contains the intermediate representation (IR).
 """
 
 from abc import abstractmethod
-from typing import Any, Optional, Self, Sequence
+from typing import Any, Optional, Self, Sequence, TypeAlias
 
-from ..fpc_context import FPCoreContext
-from ..number import Context
 from ..utils import CompareOp, Id, NamedId, UnderscoreId, default_repr
 
 from .types import IRType
@@ -683,6 +681,8 @@ class WhileStmt(Stmt):
         self.body = body
         self.phis = phis
 
+ForBinding: TypeAlias = Id | TupleBinding
+
 class ForStmt(Stmt):
     """
     FPy IR: for statement
@@ -693,15 +693,22 @@ class ForStmt(Stmt):
     - `phi.name` is the SSA name of the variable after the block
     """
 
-    var: Id
+    target: ForBinding
     ty: IRType
     iterable: Expr
     body: StmtBlock
     phis: list[PhiNode]
 
-    def __init__(self, var: Id, ty: IRType, iterable: Expr, body: StmtBlock, phis: list[PhiNode]):
+    def __init__(
+        self,
+        target: ForBinding,
+        ty: IRType,
+        iterable: Expr,
+        body: StmtBlock,
+        phis: list[PhiNode]
+    ):
         super().__init__()
-        self.var = var
+        self.target = target
         self.ty = ty
         self.iterable = iterable
         self.body = body

--- a/fpy2/ir/ir.py
+++ b/fpy2/ir/ir.py
@@ -425,6 +425,10 @@ class Size(BinaryExpr):
     """FPy node: size operator"""
     name: str = 'size'
 
+class Zip(NaryExpr):
+    """FPy node: zip operator"""
+    name: str = 'zip'
+
 # Comparisons
 
 class Compare(Expr):

--- a/fpy2/ir/visitor.py
+++ b/fpy2/ir/visitor.py
@@ -576,12 +576,20 @@ class DefaultTransformVisitor(TransformVisitor):
         return s, ctx
 
     def _visit_for(self, stmt: ForStmt, ctx: Any):
+        match stmt.target:
+            case Id():
+                target = stmt.target
+            case TupleBinding():
+                target = self._copy_tuple_binding(stmt.target)
+            case _:
+                raise RuntimeError('unreachable', stmt.target)
+
         iterable = self._visit_expr(stmt.iterable, ctx)
         init_phis, init_ctx = self._visit_loop_phis(stmt.phis, ctx, None)
         body, rctx = self._visit_block(stmt.body, init_ctx)
 
         phis, ctx = self._visit_loop_phis(init_phis, ctx, rctx)
-        s = ForStmt(stmt.var, stmt.ty, iterable, body, phis)
+        s = ForStmt(target, stmt.ty, iterable, body, phis)
         return s, ctx
 
     def _visit_context(self, stmt: ContextStmt, ctx: Any):

--- a/fpy2/ir/visitor.py
+++ b/fpy2/ir/visitor.py
@@ -483,9 +483,19 @@ class DefaultTransformVisitor(TransformVisitor):
         return TupleSet(value, slices, expr)
 
     def _visit_comp_expr(self, e: CompExpr, ctx: Any):
+        targets: list[Id | TupleBinding] = []
+        for target in e.targets:
+            match target:
+                case Id():
+                    targets.append(target)
+                case TupleBinding():
+                    targets.append(self._copy_tuple_binding(target))
+                case _:
+                    raise RuntimeError('unreachable', target)
+
         iterables = [self._visit_expr(iterable, ctx) for iterable in e.iterables]
         elt = self._visit_expr(e.elt, ctx)
-        return CompExpr(e.vars, iterables, elt)
+        return CompExpr(targets, iterables, elt)
 
     def _visit_if_expr(self, e: IfExpr, ctx: Any):
         cond = self._visit_expr(e.cond, ctx)

--- a/fpy2/rewrite/applier.py
+++ b/fpy2/rewrite/applier.py
@@ -101,10 +101,19 @@ class _StmtApplierInst(DefaultAstTransformVisitor):
             return Var(self.free[e.name], None)
 
     def _visit_comp_expr(self, e: CompExpr, ctx: None):
-        vars = [self._visit_id(v) for v in e.vars]
+        targets: list[Id | TupleBinding] = []
+        for target in e.targets:
+            match target:
+                case Id():
+                    targets.append(self._visit_id(target))
+                case TupleBinding():
+                    targets.append(self._visit_tuple_binding(target))
+                case _:
+                    raise RuntimeError(f'unreachable case: {target}')
+
         iterables = [self._visit_expr(e, None) for e in e.iterables]
         elt = self._visit_expr(e.elt, None)
-        return CompExpr(vars, iterables, elt, None)
+        return CompExpr(targets, iterables, elt, None)
 
     def _visit_simple_assign(self, stmt: SimpleAssign, ctx: None):
         ident = self._visit_id(stmt.var)

--- a/fpy2/rewrite/applier.py
+++ b/fpy2/rewrite/applier.py
@@ -154,10 +154,15 @@ class _StmtApplierInst(DefaultAstTransformVisitor):
         return s, None
 
     def _visit_for(self, stmt: ForStmt, ctx: None):
-        var = self._visit_id(stmt.var)
+        match stmt.target:
+            case Id():
+                target = self._visit_id(stmt.target)
+            case TupleBinding():
+                target = self._visit_tuple_binding(stmt.target)
+
         iterable = self._visit_expr(stmt.iterable, None)
         body, _ = self._visit_block(stmt.body, None)
-        s = ForStmt(var, iterable, body, None)
+        s = ForStmt(target, iterable, body, None)
         return s, None
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -218,8 +218,14 @@ class _MatcherInst(AstVisitor):
     def _visit_comp_expr(self, e: CompExpr, pat: CompExpr):
         if len(e.iterables) != len(pat.iterables):
             raise _MatchFailure(f'matching {pat} against {e}')
-        for name, pname in zip(e.vars, pat.vars):
-            self._visit_target(name, pname)
+        for target, ptarget in zip(e.targets, pat.targets):
+            match target, ptarget:
+                case Id(), Id():
+                    self._visit_target(target, ptarget)
+                case TupleBinding(), TupleBinding():
+                    self._visit_tuple_binding(target, ptarget)
+                case _:
+                    raise _MatchFailure(f'matching {ptarget} against {target}')
         for it, pit in zip(e.iterables, pat.iterables):
             self._visit_expr(it, pit)
         self._visit_expr(e.elt, pat.elt)

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -290,8 +290,14 @@ class _MatcherInst(AstVisitor):
         self._visit_block(stmt.body, pat.body)
 
     def _visit_for(self, stmt: ForStmt, pat: ForStmt):
+        match stmt.target, pat.target:
+            case Id(), Id():
+                self._visit_target(stmt.target, pat.target)
+            case TupleBinding(), TupleBinding():
+                self._visit_tuple_binding(stmt.target, pat.target)
+            case _, _:
+                raise _MatchFailure(f'matching {pat.target} against {stmt.target}')
         self._visit_expr(stmt.iterable, pat.iterable)
-        self._visit_target(stmt.var, pat.var)
         self._visit_block(stmt.body, pat.body)
 
     def _visit_context(self, stmt: ContextStmt, pat: ContextStmt):

--- a/fpy2/transform/__init__.py
+++ b/fpy2/transform/__init__.py
@@ -3,6 +3,7 @@ This module defines compiler transforms over FPy IR.
 """
 
 from .for_bundling import ForBundling
+from .for_unpack import ForUnpack
 from .func_update import FuncUpdate
 from .ssa import SSA
 from .simplify_if import SimplifyIf

--- a/fpy2/transform/for_unpack.py
+++ b/fpy2/transform/for_unpack.py
@@ -1,0 +1,71 @@
+"""
+Transformation pass to push tuple unpacking in a for loop to the body.
+"""
+
+from ..analysis import DefineUse, VerifyIR
+from ..ir import *
+from ..utils import Gensym
+
+
+class _ForUnpackInstance(DefaultTransformVisitor):
+    """Single-use instance of the ForUnpack pass."""
+    func: FuncDef
+    gensym: Gensym
+
+    def __init__(self, func: FuncDef, names: set[NamedId]):
+        self.func = func
+        self.gensym = Gensym(reserved=names)
+
+    def apply(self) -> FuncDef:
+        return self._visit_function(self.func, None)
+
+    def _visit_for(self, stmt: ForStmt, ctx: None) -> tuple[ForStmt, None]:
+        match stmt.target:
+            case Id():
+                return super()._visit_for(stmt, None)
+            case TupleBinding():
+                t_id = self.gensym.fresh('t')
+                iterable = self._visit_expr(stmt.iterable, None)
+                body, _ = self._visit_block(stmt.body, None)
+                phis, _ = self._visit_loop_phis(stmt.phis, ctx, None)
+
+                binding = self._copy_tuple_binding(stmt.target)
+                body.stmts.insert(0, TupleUnpack(binding, AnyType(), Var(t_id)))
+                s = ForStmt(t_id, stmt.ty, iterable, body, phis)
+                print(s.format())
+                return s, None
+            case _:
+                raise RuntimeError('unreachable', stmt.target)
+
+
+class ForUnpack:
+    """
+    Transformation pass to move any tuple unpacking in a for loop to its body.
+
+    ```
+    for x, y in iterable:
+        ...
+    ```
+    becomes
+
+    ```
+    for t in iterable:
+        x, y = t
+        ...
+    ```
+
+    where `t` is a fresh variable.
+    """
+
+    @staticmethod
+    def apply(func: FuncDef, names: Optional[set[NamedId]] = None) -> FuncDef:
+        """
+        Apply the transformation to the given function definition.
+        """
+        if names is None:
+            uses = DefineUse.analyze(func)
+            names = set(uses.keys())
+        inst = _ForUnpackInstance(func, names)
+        func = inst.apply()
+        VerifyIR.check(func)
+        return func

--- a/fpy2/transform/ssa.py
+++ b/fpy2/transform/ssa.py
@@ -231,6 +231,7 @@ class _SSAInstance(DefaultTransformVisitor):
             case TupleBinding():
                 iter_name, ctx = self._visit_tuple_binding(stmt.target, ctx)
             case _:
+                iter_name = stmt.target
                 ctx = ctx.copy()
 
         # compute variables requiring phi node

--- a/fpy2/transform/ssa.py
+++ b/fpy2/transform/ssa.py
@@ -47,7 +47,7 @@ class _SSAInstance(DefaultTransformVisitor):
                 case UnderscoreId():
                     targets.append(target)
                 case TupleBinding():
-                    t, _ = self._visit_tuple_binding(target, ctx)
+                    t, ctx = self._visit_tuple_binding(target, ctx)
                     targets.append(t)
                 case _:
                     raise NotImplementedError('unreachable', target)

--- a/fpy2/transform/ssa.py
+++ b/fpy2/transform/ssa.py
@@ -221,14 +221,14 @@ class _SSAInstance(DefaultTransformVisitor):
         iterable = self._visit_expr(stmt.iterable, ctx)
 
         # generate a new name if needed
-        match stmt.var:
+        match stmt.target:
             case NamedId():
-                iter_name = self.gensym.refresh(stmt.var)
-                ctx = { **ctx, stmt.var: iter_name }
-            case UnderscoreId():
-                iter_name = stmt.var
+                iter_name = self.gensym.refresh(stmt.target)
+                ctx = { **ctx, stmt.target: iter_name }
+            case TupleBinding():
+                iter_name, ctx = self._visit_tuple_binding(stmt.target, ctx)
             case _:
-                raise NotImplementedError('unreachable', stmt.var)
+                ctx = ctx.copy()
 
         # compute variables requiring phi node
         reach = self.reaches[stmt.body]

--- a/fpy2/transform/unssa.py
+++ b/fpy2/transform/unssa.py
@@ -170,13 +170,19 @@ class _UnSSAInstance(DefaultTransformVisitor):
         return s, None
 
     def _visit_for(self, stmt: ForStmt, ctx: None):
-        if isinstance(stmt.var, NamedId):
-            var: Id = self.env.get(stmt.var, stmt.var)
-        else:
-            var = stmt.var
+        match stmt.target:
+            case NamedId():
+                target: Id | TupleBinding = self.env.get(stmt.target, stmt.target)
+            case Id():
+                target = stmt.target
+            case TupleBinding():
+                target = self._visit_tuple_binding(stmt.target)
+            case _:
+                raise RuntimeError(f'unexpected target {stmt.target}')
+    
         iterable = self._visit_expr(stmt.iterable, ctx)
         body, _ = self._visit_block(stmt.body, ctx)
-        s = ForStmt(var, stmt.ty, iterable, body, [])
+        s = ForStmt(target, stmt.ty, iterable, body, [])
         return s, None
 
 

--- a/tests/unit/defs.py
+++ b/tests/unit/defs.py
@@ -210,6 +210,10 @@ def test_list_comp1():
 def test_list_comp2():
     return [x + y for x in range(4) for y in range(5)]
 
+@fpy
+def test_list_comp3():
+    return [x + y for x, y in zip([0, 1, 2], [3, 4, 5])]
+
 @fpy(name='Test list ref (1/3)')
 def test_list_ref1():
     x = [1.0, 2.0, 3.0]
@@ -383,6 +387,15 @@ def test_for3():
         x += i
         y += 2 * i
     return x, y
+
+@fpy
+def test_for4() -> Real:
+    xs = (1, 2, 3)
+    ys = (3, 5, 7)
+    sum = 0.0
+    for x, y in zip(xs, ys):
+        sum += x * y
+    return sum
 
 @fpy(name='Test context statement (1/3)')
 def test_context1():
@@ -574,6 +587,7 @@ tests = [
     test_list_size2,
     test_list_comp1,
     test_list_comp2,
+    test_list_comp3,
     test_list_ref1,
     test_list_ref2,
     test_list_ref3,
@@ -594,6 +608,7 @@ tests = [
     test_for1,
     test_for2,
     test_for3,
+    test_for4,
     test_context1,
     test_context2,
     # test_context3,

--- a/tests/unit/defs.py
+++ b/tests/unit/defs.py
@@ -423,8 +423,8 @@ def dpN(xs: tuple[Real, ...], ys: tuple[Real, ...]) -> Real:
     assert len(xs) == len(ys)
     sum = 0.0
     with RealContext():
-        for i in range(len(xs)):
-            sum += xs[i] * ys[i]
+        for x, y in zip(xs, ys):
+            sum += x * y
     return round(sum)
 
 @fpy(


### PR DESCRIPTION
This PR adds:
- tuple unpacking in `for` statements
```
for x, y in <iterable>:
   ...
```
- tuple unpacking in (list) comprehensions
```
[x + y for x, y in zip(xs, ys)]
```
- native support for Python's `zip`