### PR TITLE
Copy propagation pass

### DIFF
--- a/docs/source/ast.rst
+++ b/docs/source/ast.rst
@@ -57,6 +57,10 @@ Analyses
 Tranformations
 ---------------------------
 
+.. automodule:: fpy2.transform.CopyPropagate
+   :members:
+   :show-inheritance:
+
 .. autoclass:: fpy2.transform.ContextInline
    :members:
    :show-inheritance:

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -100,7 +100,7 @@ class _MatcherInst(AstVisitor):
         if name in self.subst:
             # check if the current binding is the same as `e`
             bound = self.subst[name]
-            if e != bound:
+            if not e.is_equiv(bound):
                 raise _MatchFailure(f'conflicting bindings for {name}: {bound} != {e}')
         else:
             # insert a new binding

--- a/fpy2/transform/__init__.py
+++ b/fpy2/transform/__init__.py
@@ -2,6 +2,7 @@
 This module defines compiler transforms over FPy IR.
 """
 
+from .copy_propagate import CopyPropagate
 from .context_inline import ContextInline
 from .for_bundling import ForBundling
 from .for_unpack import ForUnpack

--- a/fpy2/transform/copy_propagate.py
+++ b/fpy2/transform/copy_propagate.py
@@ -1,0 +1,67 @@
+"""
+Copy propagation.
+"""
+
+from ..analysis import DefineUse, SyntaxCheck
+from ..ast import *
+
+
+class _CopyPropagateInstance(DefaultAstVisitor):
+    """Single-use instance of copy propagation."""
+    func: FuncDef
+    xform: DefaultAstTransformVisitor
+
+    def __init__(self, func: FuncDef):
+        self.func = func
+        self.xform = DefaultAstTransformVisitor()
+
+    def apply(self):
+        """Applies copy propagation to the function."""
+        # create a copy of the AST and run definition-use analysis
+        func = self.xform._visit_function(self.func, None)
+        def_use = DefineUse.analyze(func)
+
+        # find direct assigments and substitute them
+        remove: set[SimpleAssign] = set()
+        for d, uses in def_use.uses.items():
+            if isinstance(d, SimpleAssign) and isinstance(d.expr, Var):
+                # direct assignment: x = y
+                # substitute all occurences of this definition of `x` with `y`
+                remove.add(d)
+                for use in uses:
+                    match use:
+                        case Var():
+                            use.name = d.expr.name
+                        case IndexAssign():
+                            use.var = d.expr.name
+                        case _:
+                            raise RuntimeError('unreachable', use)
+
+        # eliminate the assignments
+        self._visit_function(func, remove)
+        return func
+
+    def _visit_block(self, block: StmtBlock, ctx: set[SimpleAssign]):
+        stmts: list[Stmt] = []
+        for stmt in block.stmts:
+            if not isinstance(stmt, SimpleAssign) or stmt not in ctx:
+                self._visit_statement(stmt, ctx)
+                stmts.append(stmt)
+        block.stmts = stmts
+
+
+class CopyPropagate:
+    """
+    Copy propagation.
+
+    This transform replaces any variable that is assigned another variable.
+    """
+
+    @staticmethod
+    def apply(func: FuncDef):
+        """Applies copy propagation to the given AST."""
+        if not isinstance(func, FuncDef):
+            raise TypeError(f'Expected \'FuncDef\' for {func}, got {type(func)}')
+        func = _CopyPropagateInstance(func).apply()
+        SyntaxCheck.check(func)
+        return func

--- a/fpy2/utils/gensym.py
+++ b/fpy2/utils/gensym.py
@@ -14,6 +14,7 @@ class Gensym(object):
     has generated or reserved.
     """
     _idents: set[NamedId]
+    _generated: set[NamedId]
     _counter: int
     _rename_hook: Optional[Callable[[str], str]]
 
@@ -29,6 +30,7 @@ class Gensym(object):
             self._idents = set(reserved)
             self._counter = len(reserved)
 
+        self._generated = set()
         self._rename_hook = rename_hook
 
     def _copy_id(self, id: NamedId) -> NamedId:
@@ -39,7 +41,7 @@ class Gensym(object):
                 return NamedId(id.base, id.count)
 
     def reserve(self, *idents: NamedId):
-        """Reserves a set of identifiers"""
+        """Reserves a set of identifiers. Does not add to `self.generated`."""
         for ident in idents:
             if not isinstance(ident, NamedId):
                 raise TypeError('must be a list of identifiers', idents)
@@ -55,6 +57,7 @@ class Gensym(object):
             self._counter += 1
 
         self._idents.add(ident)
+        self._generated.add(ident)
         return ident
 
     def fresh(self, prefix: str = 't'):
@@ -77,3 +80,8 @@ class Gensym(object):
     @property
     def names(self):
         return set(self._idents)
+
+    @property
+    def generated(self):
+        """Returns the set of generated identifiers."""
+        return set(self._generated)

--- a/tests/rewrite/test_applier.py
+++ b/tests/rewrite/test_applier.py
@@ -1,7 +1,7 @@
 import unittest
 
 from fpy2 import fpy, pattern, Function
-from fpy2.ast import Fma, Var, NamedId, SimpleAssign, StmtBlock, Call
+from fpy2.ast import Expr, Stmt, StmtBlock, FuncDef, Fma, Var, NamedId, SimpleAssign, Call
 from fpy2.rewrite.applier import Applier
 from fpy2.rewrite.matcher import Matcher
 from fpy2.typing import *
@@ -27,7 +27,17 @@ def g(x, y, z):
     return t
 
 
-class ApplierExprTestCase(unittest.TestCase):
+class _ApplierTestCase(unittest.TestCase):
+
+    def assertAstEqual(
+        self,
+        a: Expr | Stmt | StmtBlock | FuncDef,
+        b: Expr | Stmt | StmtBlock | FuncDef
+    ):
+        self.assertTrue(a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n')
+
+
+class ApplierExprTestCase(_ApplierTestCase):
     """Testing `Applier` for expressions"""
 
     def test_fma_example_1(self):
@@ -36,7 +46,7 @@ class ApplierExprTestCase(unittest.TestCase):
         a = Applier(insert_fma_r)
         matches = m.match(f)
         f2 = a.apply(matches[0])
-        self.assertEqual(f2, Fma(
+        self.assertAstEqual(f2, Fma(
             Var(NamedId('x'), None),
             Var(NamedId('y'), None),
             Var(NamedId('z'), None),
@@ -49,7 +59,7 @@ class ApplierExprTestCase(unittest.TestCase):
         a = Applier(insert_fma_r)
         matches = m.match(g)
         f2 = a.apply(matches[0])
-        self.assertEqual(f2, Fma(
+        self.assertAstEqual(f2, Fma(
             Var(NamedId('x'), None),
             Var(NamedId('y'), None),
             Var(NamedId('z'), None),
@@ -74,7 +84,7 @@ def insert_sum_l(xs):
 def insert_sum_r(xs):
     y = sum(xs)
 
-class ApplierStmtTestCase(unittest.TestCase):
+class ApplierStmtTestCase(_ApplierTestCase):
     """Testing `Applier` for sum expressions"""
 
     def test_sum_example_1(self):
@@ -83,7 +93,7 @@ class ApplierStmtTestCase(unittest.TestCase):
         a = Applier(insert_sum_r)
         matches = m.match(h)
         h2 = a.apply(matches[0])
-        self.assertEqual(
+        self.assertAstEqual(
             h2, 
             StmtBlock([
                 SimpleAssign(

--- a/tests/rewrite/test_matcher.py
+++ b/tests/rewrite/test_matcher.py
@@ -1,7 +1,7 @@
 import unittest
 
 from fpy2 import fpy, pattern, Function
-from fpy2.ast import Add, Var, NamedId, Integer
+from fpy2.ast import Add, Var, NamedId, Integer, Expr, Stmt, StmtBlock, FuncDef
 from fpy2.rewrite.matcher import Matcher
 from fpy2.typing import *
 
@@ -26,7 +26,16 @@ def h(x, y, z):
     return t
 
 
-class MatchExprTestCase(unittest.TestCase):
+class _MatcherTestCase(unittest.TestCase):
+
+    def assertAstEqual(
+        self,
+        a: Expr | Stmt | StmtBlock | FuncDef,
+        b: Expr | Stmt | StmtBlock | FuncDef
+    ):
+        self.assertTrue(a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n')
+
+class MatchExprTestCase(_MatcherTestCase):
     """Testing `Matcher.match()` for expressions"""
 
     def test_compare(self):
@@ -42,8 +51,8 @@ class MatchExprTestCase(unittest.TestCase):
         m = Matcher(compare_pattern1)
         matches = m.match(f1)
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].subst['a'], Var(NamedId('x'), None))
-        self.assertEqual(matches[0].subst['b'], Var(NamedId('y'), None))
+        self.assertAstEqual(matches[0].subst['a'], Var(NamedId('x'), None))
+        self.assertAstEqual(matches[0].subst['b'], Var(NamedId('y'), None))
 
 
     def test_fma_example_1(self):
@@ -51,18 +60,18 @@ class MatchExprTestCase(unittest.TestCase):
         m = Matcher(insert_fma_l)
         matches = m.match(f)
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].subst['a'], Var(NamedId('x'), None))
-        self.assertEqual(matches[0].subst['b'], Var(NamedId('y'), None))
-        self.assertEqual(matches[0].subst['c'], Var(NamedId('z'), None))
+        self.assertAstEqual(matches[0].subst['a'], Var(NamedId('x'), None))
+        self.assertAstEqual(matches[0].subst['b'], Var(NamedId('y'), None))
+        self.assertAstEqual(matches[0].subst['c'], Var(NamedId('z'), None))
 
     def test_fma_example_2(self):
         assert isinstance(g, Function)
         m = Matcher(insert_fma_l)
         matches = m.match(g)
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].subst['a'], Var(NamedId('y'), None))
-        self.assertEqual(matches[0].subst['b'], Var(NamedId('z'), None))
-        self.assertEqual(matches[0].subst['c'], Var(NamedId('x'), None))
+        self.assertAstEqual(matches[0].subst['a'], Var(NamedId('y'), None))
+        self.assertAstEqual(matches[0].subst['b'], Var(NamedId('z'), None))
+        self.assertAstEqual(matches[0].subst['c'], Var(NamedId('x'), None))
 
     def test_fma_example_3(self):
         assert isinstance(h, Function)
@@ -71,14 +80,14 @@ class MatchExprTestCase(unittest.TestCase):
         self.assertEqual(len(matches), 2)
 
         m0 = matches[0]
-        self.assertEqual(m0.subst['a'], Var(NamedId('x'), None))
-        self.assertEqual(m0.subst['b'], Var(NamedId('y'), None))
-        self.assertEqual(m0.subst['c'], Var(NamedId('z'), None))
+        self.assertAstEqual(m0.subst['a'], Var(NamedId('x'), None))
+        self.assertAstEqual(m0.subst['b'], Var(NamedId('y'), None))
+        self.assertAstEqual(m0.subst['c'], Var(NamedId('z'), None))
 
         m1 = matches[1]
-        self.assertEqual(m1.subst['a'], Integer(10, None))
-        self.assertEqual(m1.subst['b'], Var(NamedId('y'), None))
-        self.assertEqual(m1.subst['c'], Var(NamedId('z'), None))
+        self.assertAstEqual(m1.subst['a'], Integer(10, None))
+        self.assertAstEqual(m1.subst['b'], Var(NamedId('y'), None))
+        self.assertAstEqual(m1.subst['c'], Var(NamedId('z'), None))
 
 
 @fpy
@@ -95,7 +104,7 @@ def insert_sum_l(xs):
         y += x
 
 
-class MatchStmtTestCase(unittest.TestCase):
+class MatchStmtTestCase(_MatcherTestCase):
     """Testing `Matcher.match()` for statements"""
 
     def test_unpack(self):
@@ -116,13 +125,13 @@ class MatchStmtTestCase(unittest.TestCase):
         m = Matcher(unpack_pattern1)
         matches = m.match(f1)
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].subst['a'], Var(NamedId('x'), None))
-        self.assertEqual(matches[0].subst['b'], Var(NamedId('y'), None))
+        self.assertAstEqual(matches[0].subst['a'], Var(NamedId('x'), None))
+        self.assertAstEqual(matches[0].subst['b'], Var(NamedId('y'), None))
 
         m = Matcher(unpack_pattern2)
         matches = m.match(f1)
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].subst['a'], Var(NamedId('x'), None))
+        self.assertAstEqual(matches[0].subst['a'], Var(NamedId('x'), None))
 
     def test_if(self):
         @pattern
@@ -144,9 +153,9 @@ class MatchStmtTestCase(unittest.TestCase):
         m = Matcher(if_pattern1)
         matches = m.match(f)
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].subst['t'], Var(NamedId('x'), None))
-        self.assertEqual(matches[0].subst['c1'], Integer(1, None))
-        self.assertEqual(matches[0].subst['c2'], Integer(2, None))
+        self.assertAstEqual(matches[0].subst['t'], Var(NamedId('x'), None))
+        self.assertAstEqual(matches[0].subst['c1'], Integer(1, None))
+        self.assertAstEqual(matches[0].subst['c2'], Integer(2, None))
 
     def test_while(self):
         @pattern
@@ -166,9 +175,9 @@ class MatchStmtTestCase(unittest.TestCase):
         m = Matcher(while_pattern1)
         matches = m.match(f)
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].subst['t'], Var(NamedId('x'), None))
-        self.assertEqual(matches[0].subst['N'], Integer(100, None))
-        self.assertEqual(matches[0].subst['e'], Add(Var(NamedId('x'), None), Integer(1, None), None))
+        self.assertAstEqual(matches[0].subst['t'], Var(NamedId('x'), None))
+        self.assertAstEqual(matches[0].subst['N'], Integer(100, None))
+        self.assertAstEqual(matches[0].subst['e'], Add(Var(NamedId('x'), None), Integer(1, None), None))
 
 
     def test_fma_example_1(self):
@@ -177,6 +186,6 @@ class MatchStmtTestCase(unittest.TestCase):
         matches = m.match(f2)
 
         self.assertEqual(len(matches), 1)
-        self.assertEqual(matches[0].subst['y'], Var(NamedId('sum'), None))
-        self.assertEqual(matches[0].subst['x'], Var(NamedId('n'), None))
-        self.assertEqual(matches[0].subst['xs'], Var(NamedId('lst'), None))
+        self.assertAstEqual(matches[0].subst['y'], Var(NamedId('sum'), None))
+        self.assertAstEqual(matches[0].subst['x'], Var(NamedId('n'), None))
+        self.assertAstEqual(matches[0].subst['xs'], Var(NamedId('lst'), None))

--- a/tests/rewrite/test_rewrite.py
+++ b/tests/rewrite/test_rewrite.py
@@ -1,5 +1,7 @@
 import unittest
 
+from typing import TypeAlias
+
 from fpy2 import *
 from fpy2.typing import *
 from fpy2.ast import *
@@ -223,12 +225,15 @@ def if_not_test1(c):
     return x
 
 
-
 class RewriteTestCase(unittest.TestCase):
     """Testing `Pattern` parsing for examples"""
 
-    def assertAstEqual(self, a: Ast, b: Ast):
-        self.assertEqual(a, b, f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n')
+    def assertAstEqual(
+        self,
+        a: Expr | Stmt | StmtBlock | FuncDef,
+        b: Expr | Stmt | StmtBlock | FuncDef
+    ):
+        self.assertTrue(a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n')
 
     def test_fma_example1(self):
         assert isinstance(f, Function)


### PR DESCRIPTION
This PR adds a copy propagation pass.

In doing so, the AST no longer has dunder methods `__eq__` and `__hash__`  (equality is by `id()`). Adds `is_equiv()` method to check for structural equivalence.