### PR TITLE
Cleanup

### DIFF
--- a/docs/notes/TODO.md
+++ b/docs/notes/TODO.md
@@ -13,11 +13,7 @@ Frontend:
    - use IndentCtx
 
 Middle-end:
- - do we really need a separate AST / IR?
- - String IR node
  - passes:
-  - copy propagation
-  - eliminate unneeded phi variables
   - dead code elimination
   - variable renaming
 
@@ -29,8 +25,8 @@ Backend:
     - detect multi-variable for loops
 
 Misc:
- - Rational contains a Fraction
- - decnum and hexnum conversion to Fraction
+ - fma for RealContext
+ - separable mathematical core
 
 Interpreters:
  - integrate FPCoreContext into other interpreters
@@ -40,4 +36,3 @@ Numbers:
 
 Documentation:
   - integrate config with pyproject.toml
-  - document IR / IR transformation passes

--- a/docs/source/ast.rst
+++ b/docs/source/ast.rst
@@ -13,15 +13,15 @@ The Abstract Syntax Tree (AST) is a representation of an FPy program.
 Visitors
 ---------------------------
 
-.. automodule:: fpy2.ast.AstVisitor
+.. automodule:: fpy2.ast.Visitor
    :members:
    :show-inheritance:
 
-.. autoclass:: fpy2.ast.DefaultAstVisitor
+.. autoclass:: fpy2.ast.DefaultVisitor
    :members:
    :show-inheritance:
 
-.. autoclass:: fpy2.ast.DefaultAstTransformVisitor
+.. autoclass:: fpy2.ast.DefaultTransformVisitor
    :members:
    :show-inheritance:
 

--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -125,14 +125,9 @@ class _DefineUseInstance(DefaultAstVisitor):
             self._visit_expr(iterable, ctx)
         ctx = ctx.copy()
         for target in e.targets:
-            match target:
-                case NamedId():
-                    self._add_def(target, e)
-                    ctx[target] = e
-                case TupleBinding():
-                    for name in target.names():
-                        self._add_def(name, e)
-                        ctx[name] = e
+            for name in target.names():
+                self._add_def(name, e)
+                ctx[name] = e
         self._visit_expr(e.elt, ctx)
 
     def _visit_simple_assign(self, stmt: SimpleAssign, ctx: DefinitionCtx):

--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -130,7 +130,7 @@ class _DefineUseInstance(DefaultVisitor):
                 ctx[name] = e
         self._visit_expr(e.elt, ctx)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: DefinitionCtx):
+    def _visit_assign(self, stmt: Assign, ctx: DefinitionCtx):
         self._visit_expr(stmt.expr, ctx)
         if isinstance(stmt.var, NamedId):
             self._add_def(stmt.var, stmt)

--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import TypeAlias, Union
 
 from ..ast.fpyast import *
-from ..ast.visitor import DefaultAstVisitor
+from ..ast.visitor import DefaultVisitor
 from ..utils import default_repr
 
 Definition: TypeAlias = Argument | Stmt | CompExpr
@@ -82,7 +82,7 @@ class DefineUseAnalysis:
         return DefineUseAnalysis({}, {}, {}, {})
 
 
-class _DefineUseInstance(DefaultAstVisitor):
+class _DefineUseInstance(DefaultVisitor):
     """Per-IR instance of definition-use analysis"""
     ast: FuncDef | StmtBlock
     analysis: DefineUseAnalysis

--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -132,12 +132,6 @@ class _DefineUseInstance(DefaultVisitor):
 
     def _visit_assign(self, stmt: Assign, ctx: DefinitionCtx):
         self._visit_expr(stmt.expr, ctx)
-        if isinstance(stmt.var, NamedId):
-            self._add_def(stmt.var, stmt)
-            ctx[stmt.var] = stmt
-
-    def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: DefinitionCtx):
-        self._visit_expr(stmt.expr, ctx)
         for var in stmt.binding.names():
             self._add_def(var, stmt)
             ctx[var] = stmt

--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -72,7 +72,7 @@ class DefinitionCtx(dict[NamedId, Definition | _DefineUnion]):
 class DefineUseAnalysis:
     """Result of definition-use analysis"""
     defs: dict[NamedId, set[Definition]]
-    uses: dict[Definition, set[Var | IndexAssign]]
+    uses: dict[Definition, set[Var | IndexedAssign]]
     stmts: dict[Stmt, tuple[DefinitionCtx, DefinitionCtx]]
     blocks: dict[StmtBlock, tuple[DefinitionCtx, DefinitionCtx]]
 
@@ -107,7 +107,7 @@ class _DefineUseInstance(DefaultAstVisitor):
         self.analysis.defs[name].add(definition)
         self.analysis.uses[definition] = set()
 
-    def _add_use(self, name: NamedId, use: Var | IndexAssign, ctx: DefinitionCtx):
+    def _add_use(self, name: NamedId, use: Var | IndexedAssign, ctx: DefinitionCtx):
         def_or_union = ctx[name]
         if isinstance(def_or_union, _DefineUnion):
             for def_ in def_or_union.defs:
@@ -142,7 +142,7 @@ class _DefineUseInstance(DefaultAstVisitor):
             self._add_def(var, stmt)
             ctx[var] = stmt
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: DefinitionCtx):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: DefinitionCtx):
         self._add_use(stmt.var, stmt, ctx)
         for slice in stmt.slices:
             self._visit_expr(slice, ctx)

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -119,7 +119,7 @@ class LiveVarsInstance(Visitor):
                 live.add(arg)
         return live
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, live: _LiveSet) -> _LiveSet:
+    def _visit_assign(self, stmt: Assign, live: _LiveSet) -> _LiveSet:
         live = set(live)
         if isinstance(stmt.var, NamedId):
             live -= { stmt.var }

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -132,7 +132,7 @@ class LiveVarsInstance(AstVisitor):
         live |= self._visit_expr(stmt.expr, None)
         return live
 
-    def _visit_index_assign(self, stmt: IndexAssign, live: _LiveSet) -> _LiveSet:
+    def _visit_indexed_assign(self, stmt: IndexedAssign, live: _LiveSet) -> _LiveSet:
         live = set(live)
         live |= self._visit_expr(stmt.expr, None)
         for s in stmt.slices:

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -88,11 +88,7 @@ class LiveVarsInstance(AstVisitor):
     def _visit_comp_expr(self, e: CompExpr, ctx: None) -> _LiveSet:
         live = self._visit_expr(e.elt, ctx)
         for target in e.targets:
-            match target:
-                case NamedId():
-                    live -= { target }
-                case TupleBinding():
-                    live |= target.names()
+            live |= target.names()
         for iterable in e.iterables:
             live |= self._visit_expr(iterable, ctx)
         return live

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -121,13 +121,6 @@ class LiveVarsInstance(Visitor):
 
     def _visit_assign(self, stmt: Assign, live: _LiveSet) -> _LiveSet:
         live = set(live)
-        if isinstance(stmt.var, NamedId):
-            live -= { stmt.var }
-        live |= self._visit_expr(stmt.expr, None)
-        return live
-
-    def _visit_tuple_unpack(self, stmt: TupleUnpack, live: _LiveSet) -> _LiveSet:
-        live = set(live)
         live -= stmt.binding.names()
         live |= self._visit_expr(stmt.expr, None)
         return live

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -4,7 +4,7 @@ from ..ast import *
 
 _LiveSet = set[NamedId]
 
-class LiveVarsInstance(AstVisitor):
+class LiveVarsInstance(Visitor):
     """Single-use live variable analyzer"""
 
     ast: FuncDef | Expr

--- a/fpy2/analysis/syntax_check.py
+++ b/fpy2/analysis/syntax_check.py
@@ -242,7 +242,7 @@ class SyntaxCheckInstance(Visitor):
                         if free not in self.free_vars:
                             raise FPySyntaxError('context is data-dependent')
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: _Ctx):
+    def _visit_assign(self, stmt: Assign, ctx: _Ctx):
         env, _ = ctx
         self._visit_expr(stmt.expr, ctx)
         if isinstance(stmt.var, NamedId):

--- a/fpy2/analysis/syntax_check.py
+++ b/fpy2/analysis/syntax_check.py
@@ -267,7 +267,7 @@ class SyntaxCheckInstance(AstVisitor):
         self._visit_expr(stmt.expr, ctx)
         return self._visit_tuple_binding(stmt.binding, ctx)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: _Ctx):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: _Ctx):
         env, _ = ctx
         self._mark_use(stmt.var, env)
         for s in stmt.slices:

--- a/fpy2/analysis/syntax_check.py
+++ b/fpy2/analysis/syntax_check.py
@@ -5,7 +5,7 @@ from typing import Optional, Self
 from ..utils import FPySyntaxError
 
 from ..ast.fpyast import *
-from ..ast.visitor import AstVisitor
+from ..ast.visitor import Visitor
 from .live_vars import LiveVars
 
 class _Env:
@@ -41,7 +41,7 @@ _Ctx = tuple[_Env, bool]
 2nd element: whether the current block is at the top-level.
 """
 
-class SyntaxCheckInstance(AstVisitor):
+class SyntaxCheckInstance(Visitor):
     """Single-use instance of syntax checking"""
     func: FuncDef
     free_vars: set[NamedId]

--- a/fpy2/ast/__init__.py
+++ b/fpy2/ast/__init__.py
@@ -4,6 +4,6 @@ Abstract Syntax Tree (AST) for the FPy language.
 
 from .fpyast import *
 from .formatter import Formatter, BaseFormatter
-from .visitor import AstVisitor, DefaultAstVisitor, DefaultAstTransformVisitor
+from .visitor import Visitor, DefaultVisitor, DefaultTransformVisitor
 
 set_default_formatter(Formatter())

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -4,11 +4,11 @@ from pprint import pformat
 
 from ..fpc_context import FPCoreContext
 from .fpyast import *
-from .visitor import AstVisitor
+from .visitor import Visitor
 
 _Ctx = int
 
-class _FormatterInstance(AstVisitor):
+class _FormatterInstance(Visitor):
     """Single-instance visitor for pretty printing FPy ASTs"""
     ast: Ast
     fmt: str

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -196,7 +196,7 @@ class _FormatterInstance(Visitor):
 
         return f'{ctor_str}({", ".join(arg_strs)})'
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: _Ctx):
+    def _visit_assign(self, stmt: Assign, ctx: _Ctx):
         val = self._visit_expr(stmt.expr, ctx)
         self._add_line(f'{str(stmt.var)} = {val}', ctx)
 

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -218,7 +218,7 @@ class _FormatterInstance(AstVisitor):
         vars = self._visit_tuple_binding(stmt.binding)
         self._add_line(f'{vars} = {val}', ctx)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: _Ctx):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: _Ctx):
         slices = [self._visit_expr(slice, ctx) for slice in stmt.slices]
         val = self._visit_expr(stmt.expr, ctx)
         ref_str = ''.join(f'[{slice}]' for slice in slices)

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -923,7 +923,7 @@ class StmtBlock(Ast):
 #             and self.expr.is_equiv(other.expr)
 #         )
 
-class SimpleAssign(Stmt):
+class Assign(Stmt):
     """FPy AST: variable assignment"""
     var: Id
     expr: Expr
@@ -943,7 +943,7 @@ class SimpleAssign(Stmt):
 
     def is_equiv(self, other):
         return (
-            isinstance(other, SimpleAssign)
+            isinstance(other, Assign)
             and self.var == other.var
             and self.expr.is_equiv(other.expr)
         )

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -898,74 +898,27 @@ class StmtBlock(Ast):
             and all(s1.is_equiv(s2) for s1, s2 in zip(self.stmts, other.stmts))
         )
 
-# class SimpleAssign(Stmt):
-#     """FPy AST: variable assignment"""
-#     binding: Id | TupleBinding
-#     type: Optional[TypeAnn]
-#     expr: Expr
-
-#     def __init__(
-#         self,
-#         binding: Id | TupleBinding,
-#         type: Optional[TypeAnn],
-#         expr: Expr,
-#         loc: Optional[Location]
-#     ):
-#         super().__init__(loc)
-#         self.binding = binding
-#         self.type = type
-#         self.expr = expr
-
-#     def is_equiv(self, other):
-#         return (
-#             isinstance(other, SimpleAssign)
-#             and self.binding.is_equiv(other.binding)
-#             and self.expr.is_equiv(other.expr)
-#         )
-
 class Assign(Stmt):
     """FPy AST: variable assignment"""
-    var: Id
+    binding: Id | TupleBinding
+    type: Optional[TypeAnn]
     expr: Expr
-    ann: Optional[TypeAnn]
 
     def __init__(
         self,
-        var: Id,
+        binding: Id | TupleBinding,
+        type: Optional[TypeAnn],
         expr: Expr,
-        ann: Optional[TypeAnn],
         loc: Optional[Location]
     ):
         super().__init__(loc)
-        self.var = var
+        self.binding = binding
+        self.type = type
         self.expr = expr
-        self.ann = ann
 
     def is_equiv(self, other):
         return (
             isinstance(other, Assign)
-            and self.var == other.var
-            and self.expr.is_equiv(other.expr)
-        )
-
-class TupleUnpack(Stmt):
-    """FPy AST: unpacking / destructing a tuple"""
-    binding: TupleBinding
-    expr: Expr
-
-    def __init__(
-        self,
-        vars: TupleBinding,
-        expr: Expr,
-        loc: Optional[Location]
-    ):
-        super().__init__(loc)
-        self.binding = vars
-        self.expr = expr
-
-    def is_equiv(self, other) -> bool:
-        return (
-            isinstance(other, TupleUnpack)
             and self.binding.is_equiv(other.binding)
             and self.expr.is_equiv(other.expr)
         )

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -681,21 +681,11 @@ class TupleBinding(Ast):
         return iter(self.elts)
 
     def is_equiv(self, other) -> bool:
-        if not isinstance(other, TupleBinding):
-            return False
-        if len(self.elts) != len(other.elts):
-            return False
-        for self_elt, other_elt in zip(self.elts, other.elts):
-            match self_elt, other_elt:
-                case Id(), Id():
-                    if self_elt != other_elt:
-                        return False
-                case TupleBinding(), TupleBinding():
-                    if not self_elt.is_equiv(other_elt):
-                        return False
-                case _:
-                    return False
-        return True
+        return (
+            isinstance(other, TupleBinding)
+            and len(self.elts) == len(other.elts)
+            and all(self_elt.is_equiv(other_elt) for self_elt, other_elt in zip(self.elts, other.elts))
+        )
 
     def names(self) -> set[NamedId]:
         ids: set[NamedId] = set()
@@ -730,22 +720,11 @@ class CompExpr(Expr):
         self.elt = elt
 
     def is_equiv(self, other) -> bool:
-        if not isinstance(other, CompExpr):
-            return False
-        if len(self.targets) != len(other.targets):
-            return False
-        for self_target, other_target in zip(self.targets, other.targets):
-            match self_target, other_target:
-                case Id(), Id():
-                    if self_target != other_target:
-                        return False
-                case TupleBinding(), TupleBinding():
-                    if not self_target.is_equiv(other_target):
-                        return False
-                case _:
-                    return False
         return (
-            all(i.is_equiv(o_i) for i, o_i in zip(self.iterables, other.iterables))
+            isinstance(other, CompExpr)
+            and len(self.targets) == len(other.targets)
+            and all(t.is_equiv(o_t) for t, o_t in zip(self.targets, other.targets))
+            and all(i.is_equiv(o_i) for i, o_i in zip(self.iterables, other.iterables))
             and self.elt.is_equiv(other.elt)
         )
 
@@ -919,6 +898,31 @@ class StmtBlock(Ast):
             and all(s1.is_equiv(s2) for s1, s2 in zip(self.stmts, other.stmts))
         )
 
+# class SimpleAssign(Stmt):
+#     """FPy AST: variable assignment"""
+#     binding: Id | TupleBinding
+#     type: Optional[TypeAnn]
+#     expr: Expr
+
+#     def __init__(
+#         self,
+#         binding: Id | TupleBinding,
+#         type: Optional[TypeAnn],
+#         expr: Expr,
+#         loc: Optional[Location]
+#     ):
+#         super().__init__(loc)
+#         self.binding = binding
+#         self.type = type
+#         self.expr = expr
+
+#     def is_equiv(self, other):
+#         return (
+#             isinstance(other, SimpleAssign)
+#             and self.binding.is_equiv(other.binding)
+#             and self.expr.is_equiv(other.expr)
+#         )
+
 class SimpleAssign(Stmt):
     """FPy AST: variable assignment"""
     var: Id
@@ -1082,19 +1086,10 @@ class ForStmt(Stmt):
         self.body = body
 
     def is_equiv(self, other) -> bool:
-        if not isinstance(other, ForStmt):
-            return False
-        match self.target, other.target:
-            case Id(), Id():
-                if self.target != other.target:
-                    return False
-            case TupleBinding(), TupleBinding():
-                if not self.target.is_equiv(other.target):
-                    return False
-            case _:
-                return False
         return (
-            self.iterable.is_equiv(other.iterable)
+            isinstance(other, ForStmt)
+            and self.target.is_equiv(other.target)
+            and self.iterable.is_equiv(other.iterable)
             and self.body.is_equiv(other.body)
         )
 

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -970,7 +970,7 @@ class TupleUnpack(Stmt):
             and self.expr.is_equiv(other.expr)
         )
 
-class IndexAssign(Stmt):
+class IndexedAssign(Stmt):
     """FPy AST: assignment to tuple indexing"""
     var: NamedId
     slices: list[Expr]
@@ -990,7 +990,7 @@ class IndexAssign(Stmt):
 
     def is_equiv(self, other) -> bool:
         return (
-            isinstance(other, IndexAssign)
+            isinstance(other, IndexedAssign)
             and self.var == other.var
             and len(self.slices) == len(other.slices)
             and all(s1.is_equiv(s2) for s1, s2 in zip(self.slices, other.slices))

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from .fpyast import *
 
-class AstVisitor(ABC):
+class Visitor(ABC):
     """
     Visitor base class for FPy AST nodes.
     """
@@ -241,7 +241,7 @@ class AstVisitor(ABC):
 #####################################################################
 # Default visitor
 
-class DefaultAstVisitor(AstVisitor):
+class DefaultVisitor(Visitor):
     """Default visitor: visits all nodes without doing anything."""
 
     def _visit_var(self, e: Var, ctx: Any):
@@ -376,7 +376,7 @@ class DefaultAstVisitor(AstVisitor):
 #####################################################################
 # Default transform visitor
 
-class DefaultAstTransformVisitor(AstVisitor):
+class DefaultTransformVisitor(Visitor):
     """Default visitor: visits all nodes without doing anything."""
 
     def _visit_var(self, e: Var, ctx: Any):

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -101,7 +101,7 @@ class Visitor(ABC):
     # Statements
 
     @abstractmethod
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: Any) -> Any:
+    def _visit_assign(self, stmt: Assign, ctx: Any) -> Any:
         ...
 
     @abstractmethod
@@ -213,8 +213,8 @@ class Visitor(ABC):
     def _visit_statement(self, stmt: Stmt, ctx: Any) -> Any:
         """Dispatch to the appropriate visit method for a statement."""
         match stmt:
-            case SimpleAssign():
-                return self._visit_simple_assign(stmt, ctx)
+            case Assign():
+                return self._visit_assign(stmt, ctx)
             case TupleUnpack():
                 return self._visit_tuple_unpack(stmt, ctx)
             case IndexedAssign():
@@ -325,7 +325,7 @@ class DefaultVisitor(Visitor):
             if not isinstance(arg, ForeignAttribute):
                 self._visit_expr(arg, ctx)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: Any):
+    def _visit_assign(self, stmt: Assign, ctx: Any):
         self._visit_expr(stmt.expr, ctx)
 
     def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: Any):
@@ -496,9 +496,9 @@ class DefaultTransformVisitor(Visitor):
 
         return ContextExpr(ctor, args, kwargs, e.loc)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: Any):
+    def _visit_assign(self, stmt: Assign, ctx: Any):
         expr = self._visit_expr(stmt.expr, ctx)
-        s = SimpleAssign(stmt.var, expr, stmt.ann, stmt.loc)
+        s = Assign(stmt.var, expr, stmt.ann, stmt.loc)
         return s, ctx
 
     def _visit_tuple_binding(self, binding: TupleBinding, ctx: Any):

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -109,7 +109,7 @@ class AstVisitor(ABC):
         ...
 
     @abstractmethod
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: Any) -> Any:
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: Any) -> Any:
         ...
 
     @abstractmethod
@@ -217,8 +217,8 @@ class AstVisitor(ABC):
                 return self._visit_simple_assign(stmt, ctx)
             case TupleUnpack():
                 return self._visit_tuple_unpack(stmt, ctx)
-            case IndexAssign():
-                return self._visit_index_assign(stmt, ctx)
+            case IndexedAssign():
+                return self._visit_indexed_assign(stmt, ctx)
             case If1Stmt():
                 return self._visit_if1(stmt, ctx)
             case IfStmt():
@@ -331,7 +331,7 @@ class DefaultAstVisitor(AstVisitor):
     def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: Any):
         self._visit_expr(stmt.expr, ctx)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: Any):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: Any):
         for s in stmt.slices:
             self._visit_expr(s, ctx)
         self._visit_expr(stmt.expr, ctx)
@@ -519,10 +519,10 @@ class DefaultAstTransformVisitor(AstVisitor):
         s = TupleUnpack(binding, expr, stmt.loc)
         return s, ctx
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: Any):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: Any):
         slices = [self._visit_expr(s, ctx) for s in stmt.slices]
         expr = self._visit_expr(stmt.expr, ctx)
-        s = IndexAssign(stmt.var, slices, expr, stmt.loc)
+        s = IndexedAssign(stmt.var, slices, expr, stmt.loc)
         return s, ctx
 
     def _visit_if1(self, stmt: If1Stmt, ctx: Any):

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -494,7 +494,7 @@ class FPCoreCompileInstance(Visitor):
         iff = self._visit_expr(e.iff, ctx)
         return fpc.If(cond, ift, iff)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: fpc.Expr):
+    def _visit_assign(self, stmt: Assign, ctx: fpc.Expr):
         bindings = [(str(stmt.var), self._visit_expr(stmt.expr, None))]
         return fpc.Let(bindings, ctx)
 

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -504,7 +504,7 @@ class FPCoreCompileInstance(AstVisitor):
         destruct_bindings = self._compile_tuple_binding(tuple_id, stmt.binding, [])
         return fpc.Let([tuple_bind] + destruct_bindings, ctx)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: fpc.Expr):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: fpc.Expr):
         raise FPCoreCompileError(f'cannot compile to FPCore: {type(stmt).__name__}')
 
     def _visit_if1(self, stmt: If1Stmt, ctx: None):

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -98,7 +98,7 @@ def _size0_expr(x: str):
     return fpc.Size(fpc.Var(x), fpc.Integer(0))
 
 
-class FPCoreCompileInstance(AstVisitor):
+class FPCoreCompileInstance(Visitor):
     """Compilation instance from FPy to FPCore"""
     func: FuncDef
     def_use: DefineUseAnalysis

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -263,8 +263,8 @@ class _FPCore2FPy:
 
         # emit temporary to bind result of branches
         t = self.gensym.fresh('t')
-        ift_ctx.stmts.append(Assign(t, ift_expr, None, None))
-        iff_ctx.stmts.append(Assign(t, iff_expr, None, None))
+        ift_ctx.stmts.append(Assign(t, None, ift_expr, None))
+        iff_ctx.stmts.append(Assign(t, None, iff_expr, None))
 
         # create if statement and bind it
         if_stmt = IfStmt(cond_expr, StmtBlock(ift_ctx.stmts), StmtBlock(iff_ctx.stmts), None)
@@ -283,7 +283,7 @@ class _FPCore2FPy:
             # bind value to variable
             t = self.gensym.fresh(var)
             env = { **env, var: t }
-            stmt = Assign(t, v_e, None, None)
+            stmt = Assign(t, None, v_e, None)
             ctx.stmts.append(stmt)
 
         return self._visit(e.body, _Ctx(env=env, props=ctx.props, stmts=ctx.stmts))
@@ -297,7 +297,7 @@ class _FPCore2FPy:
             # bind value to variable
             t = self.gensym.fresh(var)
             env = { **env, var: t }
-            stmt = Assign(t, init_e, None, None)
+            stmt = Assign(t, None, init_e, None)
             ctx.stmts.append(stmt)
 
         # compile condition
@@ -310,7 +310,7 @@ class _FPCore2FPy:
         for var, _, update in e.while_bindings:
             # compile value and update loop variable
             update_e = self._visit(update, update_ctx)
-            stmt = Assign(env[var], update_e, None, None)
+            stmt = Assign(env[var], None, update_e, None)
             stmts.append(stmt)
 
         # append while statement
@@ -330,7 +330,7 @@ class _FPCore2FPy:
             # bind value to variable
             t = self.gensym.fresh(var)
             env = { **env, var: t }
-            stmt = Assign(t, init_e, None, None)
+            stmt = Assign(t, None, init_e, None)
             ctx.stmts.append(stmt)
 
         # compile condition
@@ -347,14 +347,14 @@ class _FPCore2FPy:
             # bind value to temporary
             t = self.gensym.fresh('t')
             loop_env = { **loop_env, var: t }
-            stmt = Assign(t, update_e, None, None)
+            stmt = Assign(t, None, update_e, None)
             stmts.append(stmt)
 
         # rebind temporaries
         for var, _, _ in e.while_bindings:
             v = env[var]
             t = loop_env[var]
-            stmt = Assign(v, Var(t, None), None, None)
+            stmt = Assign(v, None, Var(t, None), None)
             stmts.append(stmt)
 
         # append while statement
@@ -401,7 +401,7 @@ class _FPCore2FPy:
         bound_vars: list[NamedId] = []
         for _, val in e.dim_bindings:
             t = self.gensym.fresh('t')
-            stmt: Stmt = Assign(t, self._visit(val, ctx), None, None)
+            stmt: Stmt = Assign(t, None, self._visit(val, ctx), None)
             ctx.stmts.append(stmt)
             bound_vars.append(t)
 
@@ -413,14 +413,14 @@ class _FPCore2FPy:
             init_e = self._visit(init, init_ctx)
             # bind value to variable
             t = self.gensym.fresh(var)
-            stmt = Assign(t, init_e, None, None)
+            stmt = Assign(t, None, init_e, None)
             ctx.stmts.append(stmt)
             init_env[var] = t
 
         # initialize tensor
         tuple_id = self.gensym.fresh('t')
         zeroed = _zeros([Var(var, None) for var in bound_vars])
-        stmt = Assign(tuple_id, zeroed, None, None)
+        stmt = Assign(tuple_id, None, zeroed, None)
         ctx.stmts.append(stmt)
 
         # initial iteration variables
@@ -446,7 +446,7 @@ class _FPCore2FPy:
             update_e = self._visit(update, loop_ctx)
             # bind value to temporary
             t = loop_ctx.env[var]
-            stmt = Assign(t, update_e, None, None)
+            stmt = Assign(t, None, update_e, None)
             loop_stmts.append(stmt)
 
         return Var(tuple_id, None)
@@ -466,14 +466,14 @@ class _FPCore2FPy:
         bound_vars: list[NamedId] = []
         for _, val in e.dim_bindings:
             t = self.gensym.fresh('t')
-            stmt: Stmt = Assign(t, self._visit(val, ctx), None, None)
+            stmt: Stmt = Assign(t, None, self._visit(val, ctx), None)
             ctx.stmts.append(stmt)
             bound_vars.append(t)
 
         # initialize tensor
         tuple_id = self.gensym.fresh('t')
         zeroed = _zeros([Var(var, None) for var in bound_vars])
-        stmt = Assign(tuple_id, zeroed, None, None)
+        stmt = Assign(tuple_id, None, zeroed, None)
         ctx.stmts.append(stmt)
 
         # initial iteration variables
@@ -517,7 +517,7 @@ class _FPCore2FPy:
         bound_vars: list[NamedId] = []
         for _, val in e.dim_bindings:
             t = self.gensym.fresh('t')
-            stmt: Stmt = Assign(t, self._visit(val, ctx), None, None)
+            stmt: Stmt = Assign(t, None, self._visit(val, ctx), None)
             ctx.stmts.append(stmt)
             bound_vars.append(t)
 
@@ -529,7 +529,7 @@ class _FPCore2FPy:
             init_e = self._visit(init, init_ctx)
             # bind value to variable
             t = self.gensym.fresh(var)
-            stmt = Assign(t, init_e, None, None)
+            stmt = Assign(t, None, init_e, None)
             ctx.stmts.append(stmt)
             init_env[var] = t
 
@@ -550,7 +550,7 @@ class _FPCore2FPy:
             for var, _, update in e.while_bindings:
                 t = loop_env[var]
                 update_e = self._visit(update, loop_ctx)
-                stmt = Assign(t, update_e, None, None)
+                stmt = Assign(t, None, update_e, None)
                 loop_stmts.append(stmt)
         else:
             # temporary update variables
@@ -558,7 +558,7 @@ class _FPCore2FPy:
             for var, _, update in e.while_bindings:
                 update_e = self._visit(update, loop_ctx)
                 update_var = self.gensym.fresh(var)
-                stmt = Assign(update_var, update_e, None, None)
+                stmt = Assign(update_var, None, update_e, None)
                 loop_stmts.append(stmt)
                 update_env[var] = update_var
 
@@ -566,7 +566,7 @@ class _FPCore2FPy:
             for var, _, _ in e.while_bindings:
                 x = init_env[var]
                 t = update_env[var]
-                stmt = Assign(x, Var(t, None), None, None)
+                stmt = Assign(x, None, Var(t, None), None)
                 loop_stmts.append(stmt)
 
         body_ctx = _Ctx(env=init_env, props=ctx.props, stmts=ctx.stmts)
@@ -589,7 +589,7 @@ class _FPCore2FPy:
 
         # bind value to temporary
         t = self.gensym.fresh('t')
-        block = StmtBlock(val_ctx.stmts + [Assign(t, val, None, None)])
+        block = StmtBlock(val_ctx.stmts + [Assign(t, None, val, None)])
         stmt = ContextStmt(UnderscoreId(), ctx_val, block, None)
         ctx.stmts.append(stmt)
         return Var(t, None)
@@ -686,7 +686,7 @@ class _FPCore2FPy:
                         dim_ids.append(UnderscoreId())
 
                 shape_e = Shape(Var(t, None), None)
-                stmt = TupleUnpack(TupleBinding(dim_ids, None), shape_e, None)
+                stmt = Assign(TupleBinding(dim_ids, None), None, shape_e, None)
                 ctx.stmts.append(stmt)
                 for dim, dim_id in zip(shape, dim_ids):
                     if isinstance(dim, str):

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -263,8 +263,8 @@ class _FPCore2FPy:
 
         # emit temporary to bind result of branches
         t = self.gensym.fresh('t')
-        ift_ctx.stmts.append(SimpleAssign(t, ift_expr, None, None))
-        iff_ctx.stmts.append(SimpleAssign(t, iff_expr, None, None))
+        ift_ctx.stmts.append(Assign(t, ift_expr, None, None))
+        iff_ctx.stmts.append(Assign(t, iff_expr, None, None))
 
         # create if statement and bind it
         if_stmt = IfStmt(cond_expr, StmtBlock(ift_ctx.stmts), StmtBlock(iff_ctx.stmts), None)
@@ -283,7 +283,7 @@ class _FPCore2FPy:
             # bind value to variable
             t = self.gensym.fresh(var)
             env = { **env, var: t }
-            stmt = SimpleAssign(t, v_e, None, None)
+            stmt = Assign(t, v_e, None, None)
             ctx.stmts.append(stmt)
 
         return self._visit(e.body, _Ctx(env=env, props=ctx.props, stmts=ctx.stmts))
@@ -297,7 +297,7 @@ class _FPCore2FPy:
             # bind value to variable
             t = self.gensym.fresh(var)
             env = { **env, var: t }
-            stmt = SimpleAssign(t, init_e, None, None)
+            stmt = Assign(t, init_e, None, None)
             ctx.stmts.append(stmt)
 
         # compile condition
@@ -310,7 +310,7 @@ class _FPCore2FPy:
         for var, _, update in e.while_bindings:
             # compile value and update loop variable
             update_e = self._visit(update, update_ctx)
-            stmt = SimpleAssign(env[var], update_e, None, None)
+            stmt = Assign(env[var], update_e, None, None)
             stmts.append(stmt)
 
         # append while statement
@@ -330,7 +330,7 @@ class _FPCore2FPy:
             # bind value to variable
             t = self.gensym.fresh(var)
             env = { **env, var: t }
-            stmt = SimpleAssign(t, init_e, None, None)
+            stmt = Assign(t, init_e, None, None)
             ctx.stmts.append(stmt)
 
         # compile condition
@@ -347,14 +347,14 @@ class _FPCore2FPy:
             # bind value to temporary
             t = self.gensym.fresh('t')
             loop_env = { **loop_env, var: t }
-            stmt = SimpleAssign(t, update_e, None, None)
+            stmt = Assign(t, update_e, None, None)
             stmts.append(stmt)
 
         # rebind temporaries
         for var, _, _ in e.while_bindings:
             v = env[var]
             t = loop_env[var]
-            stmt = SimpleAssign(v, Var(t, None), None, None)
+            stmt = Assign(v, Var(t, None), None, None)
             stmts.append(stmt)
 
         # append while statement
@@ -401,7 +401,7 @@ class _FPCore2FPy:
         bound_vars: list[NamedId] = []
         for _, val in e.dim_bindings:
             t = self.gensym.fresh('t')
-            stmt: Stmt = SimpleAssign(t, self._visit(val, ctx), None, None)
+            stmt: Stmt = Assign(t, self._visit(val, ctx), None, None)
             ctx.stmts.append(stmt)
             bound_vars.append(t)
 
@@ -413,14 +413,14 @@ class _FPCore2FPy:
             init_e = self._visit(init, init_ctx)
             # bind value to variable
             t = self.gensym.fresh(var)
-            stmt = SimpleAssign(t, init_e, None, None)
+            stmt = Assign(t, init_e, None, None)
             ctx.stmts.append(stmt)
             init_env[var] = t
 
         # initialize tensor
         tuple_id = self.gensym.fresh('t')
         zeroed = _zeros([Var(var, None) for var in bound_vars])
-        stmt = SimpleAssign(tuple_id, zeroed, None, None)
+        stmt = Assign(tuple_id, zeroed, None, None)
         ctx.stmts.append(stmt)
 
         # initial iteration variables
@@ -446,7 +446,7 @@ class _FPCore2FPy:
             update_e = self._visit(update, loop_ctx)
             # bind value to temporary
             t = loop_ctx.env[var]
-            stmt = SimpleAssign(t, update_e, None, None)
+            stmt = Assign(t, update_e, None, None)
             loop_stmts.append(stmt)
 
         return Var(tuple_id, None)
@@ -466,14 +466,14 @@ class _FPCore2FPy:
         bound_vars: list[NamedId] = []
         for _, val in e.dim_bindings:
             t = self.gensym.fresh('t')
-            stmt: Stmt = SimpleAssign(t, self._visit(val, ctx), None, None)
+            stmt: Stmt = Assign(t, self._visit(val, ctx), None, None)
             ctx.stmts.append(stmt)
             bound_vars.append(t)
 
         # initialize tensor
         tuple_id = self.gensym.fresh('t')
         zeroed = _zeros([Var(var, None) for var in bound_vars])
-        stmt = SimpleAssign(tuple_id, zeroed, None, None)
+        stmt = Assign(tuple_id, zeroed, None, None)
         ctx.stmts.append(stmt)
 
         # initial iteration variables
@@ -517,7 +517,7 @@ class _FPCore2FPy:
         bound_vars: list[NamedId] = []
         for _, val in e.dim_bindings:
             t = self.gensym.fresh('t')
-            stmt: Stmt = SimpleAssign(t, self._visit(val, ctx), None, None)
+            stmt: Stmt = Assign(t, self._visit(val, ctx), None, None)
             ctx.stmts.append(stmt)
             bound_vars.append(t)
 
@@ -529,7 +529,7 @@ class _FPCore2FPy:
             init_e = self._visit(init, init_ctx)
             # bind value to variable
             t = self.gensym.fresh(var)
-            stmt = SimpleAssign(t, init_e, None, None)
+            stmt = Assign(t, init_e, None, None)
             ctx.stmts.append(stmt)
             init_env[var] = t
 
@@ -550,7 +550,7 @@ class _FPCore2FPy:
             for var, _, update in e.while_bindings:
                 t = loop_env[var]
                 update_e = self._visit(update, loop_ctx)
-                stmt = SimpleAssign(t, update_e, None, None)
+                stmt = Assign(t, update_e, None, None)
                 loop_stmts.append(stmt)
         else:
             # temporary update variables
@@ -558,7 +558,7 @@ class _FPCore2FPy:
             for var, _, update in e.while_bindings:
                 update_e = self._visit(update, loop_ctx)
                 update_var = self.gensym.fresh(var)
-                stmt = SimpleAssign(update_var, update_e, None, None)
+                stmt = Assign(update_var, update_e, None, None)
                 loop_stmts.append(stmt)
                 update_env[var] = update_var
 
@@ -566,7 +566,7 @@ class _FPCore2FPy:
             for var, _, _ in e.while_bindings:
                 x = init_env[var]
                 t = update_env[var]
-                stmt = SimpleAssign(x, Var(t, None), None, None)
+                stmt = Assign(x, Var(t, None), None, None)
                 loop_stmts.append(stmt)
 
         body_ctx = _Ctx(env=init_env, props=ctx.props, stmts=ctx.stmts)
@@ -589,7 +589,7 @@ class _FPCore2FPy:
 
         # bind value to temporary
         t = self.gensym.fresh('t')
-        block = StmtBlock(val_ctx.stmts + [SimpleAssign(t, val, None, None)])
+        block = StmtBlock(val_ctx.stmts + [Assign(t, val, None, None)])
         stmt = ContextStmt(UnderscoreId(), ctx_val, block, None)
         ctx.stmts.append(stmt)
         return Var(t, None)

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -437,7 +437,7 @@ class _FPCore2FPy:
 
         # set tensor element
         body_e = self._visit(e.body, loop_ctx)
-        stmt = IndexAssign(tuple_id, [Var(v, None) for v in iter_vars], body_e, None)
+        stmt = IndexedAssign(tuple_id, [Var(v, None) for v in iter_vars], body_e, None)
         loop_stmts.append(stmt)
 
         # compile loop updates
@@ -490,7 +490,7 @@ class _FPCore2FPy:
 
         # set tensor element
         body_e = self._visit(e.body, loop_ctx)
-        stmt = IndexAssign(tuple_id, [Var(v, None) for v in iter_vars], body_e, None)
+        stmt = IndexedAssign(tuple_id, [Var(v, None) for v in iter_vars], body_e, None)
         loop_stmts.append(stmt)
 
         return Var(tuple_id, None)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -624,7 +624,7 @@ class Parser:
 
         value = self._parse_expr(stmt.value)
         e = cls(Var(ident, loc), value, loc)
-        return SimpleAssign(ident, e, None, loc)
+        return Assign(ident, e, None, loc)
 
     def _parse_statement(self, stmt: ast.stmt) -> Stmt:
         """Parse a Python statement."""
@@ -643,7 +643,7 @@ class Parser:
                 ident = self._parse_id(stmt.target)
                 ty = self._parse_type_annotation(stmt.annotation)
                 value = self._parse_expr(stmt.value)
-                return SimpleAssign(ident, value, ty, loc)
+                return Assign(ident, value, ty, loc)
             case ast.Assign():
                 if len(stmt.targets) != 1:
                     raise FPyParserError(loc, 'FPy only supports single assignment', stmt)
@@ -652,7 +652,7 @@ class Parser:
                     case ast.Name():
                         ident = self._parse_id(target)
                         value = self._parse_expr(stmt.value)
-                        return SimpleAssign(ident, value, None, loc)
+                        return Assign(ident, value, None, loc)
                     case ast.Tuple():
                         binding = self._parse_tuple_target(target, stmt)
                         value = self._parse_expr(stmt.value)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -662,7 +662,7 @@ class Parser:
                         if not isinstance(var, Var):
                             raise FPyParserError(loc, 'FPy expects a variable', target, stmt)
                         value = self._parse_expr(stmt.value)
-                        return IndexAssign(var.name, slices, value, loc)
+                        return IndexedAssign(var.name, slices, value, loc)
                     case _:
                         raise FPyParserError(loc, 'Unexpected binding type', stmt)
             case ast.If():

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -582,22 +582,6 @@ class Parser:
                 return ContextExpr(ctor, pos_args, kw_args, loc)
             case _:
                 raise FPyParserError(loc, 'FPy expects a valid context expression', e, item)
-        # match e:
-        #     case ast.Call():
-        #         call_name = self._parse_call(e)
-        #         if call_name != 'Context':
-        #             raise FPyParserError(loc, 'FPy with statements only expect `Context`', e)
-        #         if e.args != []:
-        #             raise FPyParserError(loc, 'FPy with statements do not expect arguments', e)
-        #         # TODO: what data is allowed?
-        #         props: dict[str, Any] = {}
-        #         for kwd in e.keywords:
-        #             if kwd.arg is None:
-        #                 raise FPyParserError(loc, '`Context` only takes keyword arguments', e)
-        #             props[kwd.arg] = self._parse_contextdata(kwd.value)
-        #         return props
-        #     case _:
-        #         raise FPyParserError(loc, 'FPy expects an identifier', e, item)
 
     def _parse_augassign(self, stmt: ast.AugAssign):
         loc = self._parse_location(stmt)
@@ -624,7 +608,7 @@ class Parser:
 
         value = self._parse_expr(stmt.value)
         e = cls(Var(ident, loc), value, loc)
-        return Assign(ident, e, None, loc)
+        return Assign(ident, None, e, loc)
 
     def _parse_statement(self, stmt: ast.stmt) -> Stmt:
         """Parse a Python statement."""
@@ -643,7 +627,7 @@ class Parser:
                 ident = self._parse_id(stmt.target)
                 ty = self._parse_type_annotation(stmt.annotation)
                 value = self._parse_expr(stmt.value)
-                return Assign(ident, value, ty, loc)
+                return Assign(ident, ty, value, loc)
             case ast.Assign():
                 if len(stmt.targets) != 1:
                     raise FPyParserError(loc, 'FPy only supports single assignment', stmt)
@@ -652,11 +636,11 @@ class Parser:
                     case ast.Name():
                         ident = self._parse_id(target)
                         value = self._parse_expr(stmt.value)
-                        return Assign(ident, value, None, loc)
+                        return Assign(ident, None, value, loc)
                     case ast.Tuple():
                         binding = self._parse_tuple_target(target, stmt)
                         value = self._parse_expr(stmt.value)
-                        return TupleUnpack(binding, value, loc)
+                        return Assign(binding, None, value, loc)
                     case ast.Subscript():
                         var, slices = self._parse_subscript(target)
                         if not isinstance(var, Var):

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -498,12 +498,8 @@ class _Interpreter(DefaultAstVisitor):
 
         # remove temporarily bound variables
         for target in e.targets:
-            match target:
-                case NamedId():
-                    del ctx.env[target]
-                case TupleBinding():
-                    for var in target.names():
-                        del ctx.env[var]
+            for name in target.names():
+                del ctx.env[name]
         return NDArray(elts)
 
     def _visit_if_expr(self, e: IfExpr, ctx: _EvalCtx):

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -538,7 +538,7 @@ class _Interpreter(DefaultAstVisitor):
             raise TypeError(f'expected a tuple, got {val}')
         self._unpack_tuple(stmt.binding, val, ctx)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: _EvalCtx) -> None:
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: _EvalCtx) -> None:
         # lookup the array
         array = self._lookup(stmt.var, ctx)
 

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -121,7 +121,7 @@ class _EvalCtx:
     """rounding context for evaluation"""
 
 
-class _Interpreter(DefaultAstVisitor):
+class _Interpreter(DefaultVisitor):
     """Single-use interpreter for a function"""
 
     foreign: ForeignEnv

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -508,7 +508,7 @@ class _Interpreter(DefaultVisitor):
             raise TypeError(f'expected a boolean, got {cond}')
         return self._visit_expr(e.ift if cond else e.iff, ctx)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: _EvalCtx) -> None:
+    def _visit_assign(self, stmt: Assign, ctx: _EvalCtx) -> None:
         val = self._visit_expr(stmt.expr, ctx)
         match stmt.var:
             case NamedId():

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -459,12 +459,8 @@ class _Interpreter(AstVisitor):
 
         # remove temporarily bound variables
         for target in e.targets:
-            match target:
-                case NamedId():
-                    del ctx.env[target]
-                case TupleBinding():
-                    for var in target.names():
-                        del ctx.env[var]
+            for name in target.names():
+                del ctx.env[name]
         # the result
         return tuple(elts)
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -101,7 +101,7 @@ class _EvalCtx:
     """rounding context for evaluation"""
 
 
-class _Interpreter(AstVisitor):
+class _Interpreter(Visitor):
     """Single-use interpreter for a function."""
 
     foreign: ForeignEnv

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -500,7 +500,7 @@ class _Interpreter(AstVisitor):
             raise TypeError(f'expected a tuple, got {val}')
         self._unpack_tuple(stmt.binding, val, ctx)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: _EvalCtx):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: _EvalCtx):
         # lookup the array
         array0 = self._lookup(stmt.var, ctx)
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -470,7 +470,7 @@ class _Interpreter(Visitor):
             raise TypeError(f'expected a boolean, got {cond}')
         return self._visit_expr(e.ift if cond else e.iff, ctx)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: _EvalCtx):
+    def _visit_assign(self, stmt: Assign, ctx: _EvalCtx):
         val = self._visit_expr(stmt.expr, ctx)
         match stmt.var:
             case NamedId():

--- a/fpy2/rewrite/applier.py
+++ b/fpy2/rewrite/applier.py
@@ -139,11 +139,11 @@ class _StmtApplierInst(DefaultAstTransformVisitor):
         s = TupleUnpack(binding, expr, None)
         return s, None
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: None):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: None):
         var = self._visit_id(stmt.var)
         slices = [self._visit_expr(s, None) for s in stmt.slices]
         expr = self._visit_expr(stmt.expr, None)
-        s = IndexAssign(var, slices, expr, None)
+        s = IndexedAssign(var, slices, expr, None)
         return s, None
 
     def _visit_if(self, stmt: IfStmt, ctx: None):

--- a/fpy2/rewrite/applier.py
+++ b/fpy2/rewrite/applier.py
@@ -22,7 +22,7 @@ class SubstitutionError(Exception):
     def __str__(self):
         return f'SubstitutionError: {self.message}'
 
-class _ExprApplierInst(DefaultAstTransformVisitor):
+class _ExprApplierInst(DefaultTransformVisitor):
     """
     FPy pattern match applier instance for expressions.
 
@@ -49,7 +49,7 @@ class _ExprApplierInst(DefaultAstTransformVisitor):
             return super()._visit_var(e, ctx)
 
 
-class _StmtApplierInst(DefaultAstTransformVisitor):
+class _StmtApplierInst(DefaultTransformVisitor):
     """
     FPy pattern match applier instance for statements.
 

--- a/fpy2/rewrite/applier.py
+++ b/fpy2/rewrite/applier.py
@@ -115,10 +115,10 @@ class _StmtApplierInst(DefaultTransformVisitor):
         elt = self._visit_expr(e.elt, None)
         return CompExpr(targets, iterables, elt, None)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: None):
+    def _visit_assign(self, stmt: Assign, ctx: None):
         ident = self._visit_id(stmt.var)
         expr = self._visit_expr(stmt.expr, None)
-        s =  SimpleAssign(ident, expr, stmt.ann, None)
+        s =  Assign(ident, expr, stmt.ann, None)
         return s, None
 
     def _visit_tuple_binding(self, binding: TupleBinding, ctx: None):

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -55,7 +55,7 @@ class StmtMatch(LocatedMatch):
         self.idx = idx
 
 
-class _MatcherInst(AstVisitor):
+class _MatcherInst(Visitor):
     """
     FPy pattern matching instance for a pattern and sub-program.
 
@@ -359,7 +359,7 @@ class _MatcherInst(AstVisitor):
         return super()._visit_statement(stmt, pat)
 
 
-class _ExprMatcherEngine(DefaultAstVisitor):
+class _ExprMatcherEngine(DefaultVisitor):
     """FPy pattern matching for expression patterns"""
     pattern: ExprPattern
     func: FuncDef
@@ -383,7 +383,7 @@ class _ExprMatcherEngine(DefaultAstVisitor):
             self.matches.append(pmatch)
         super()._visit_expr(e, ctx)
 
-class _StmtMatcherEngine(DefaultAstVisitor):
+class _StmtMatcherEngine(DefaultVisitor):
     """FPy pattern matching for statement patterns"""
     pattern: StmtPattern
     func: FuncDef

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -259,7 +259,7 @@ class _MatcherInst(Visitor):
                 case _, _:
                     raise RuntimeError(f'unreachable case: {c1} vs {c2}')
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, pat: SimpleAssign):
+    def _visit_assign(self, stmt: Assign, pat: Assign):
         self._visit_target(stmt.var, pat.var)
         self._visit_expr(stmt.expr, pat.expr)
 

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -284,7 +284,7 @@ class _MatcherInst(AstVisitor):
         self._visit_tuple_binding(stmt.binding, pat.binding)
         self._visit_expr(stmt.expr, pat.expr)
 
-    def _visit_index_assign(self, stmt: IndexAssign, pat: IndexAssign):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, pat: IndexedAssign):
         self._visit_target(stmt.var, pat.var)
         for e, p in zip(stmt.slices, pat.slices):
             self._visit_expr(e, p)

--- a/fpy2/rewrite/rewrite.py
+++ b/fpy2/rewrite/rewrite.py
@@ -31,7 +31,7 @@ class _RewriteContext:
 
 
 
-class _RewriteEngine(DefaultAstTransformVisitor):
+class _RewriteEngine(DefaultTransformVisitor):
     """Rewrite rule applier for a given rewrite rule."""
 
     matcher: Matcher

--- a/fpy2/transform/context_inline.py
+++ b/fpy2/transform/context_inline.py
@@ -5,9 +5,9 @@ from ..number import Context
 from ..env import ForeignEnv
 
 from ..ast.fpyast import *
-from ..ast.visitor import DefaultAstTransformVisitor
+from ..ast.visitor import DefaultTransformVisitor
 
-class _ContextInlineInstance(DefaultAstTransformVisitor):
+class _ContextInlineInstance(DefaultTransformVisitor):
     """Per-IR instance of context inlining"""
     ast: FuncDef
     env: ForeignEnv

--- a/fpy2/transform/copy_propagate.py
+++ b/fpy2/transform/copy_propagate.py
@@ -41,7 +41,7 @@ class _CopyPropagateInstance(DefaultAstVisitor):
                         match use:
                             case Var():
                                 use.name = d.expr.name
-                            case IndexAssign():
+                            case IndexedAssign():
                                 use.var = d.expr.name
                             case _:
                                 raise RuntimeError('unreachable', use)

--- a/fpy2/transform/copy_propagate.py
+++ b/fpy2/transform/copy_propagate.py
@@ -26,14 +26,14 @@ class _CopyPropagateInstance(DefaultVisitor):
         def_use = DefineUse.analyze(func)
 
         # find direct assigments and substitute them
-        remove: set[SimpleAssign] = set()
+        remove: set[Assign] = set()
         for name, defs in def_use.defs.items():
             # skip any names not matching the filter
             if self.names is not None and name not in self.names:
                 continue
 
             for d in defs:
-                if isinstance(d, SimpleAssign) and isinstance(d.expr, Var):
+                if isinstance(d, Assign) and isinstance(d.expr, Var):
                     # direct assignment: x = y
                     # substitute all occurences of this definition of `x` with `y`
                     remove.add(d)
@@ -50,10 +50,10 @@ class _CopyPropagateInstance(DefaultVisitor):
         self._visit_function(func, remove)
         return func
 
-    def _visit_block(self, block: StmtBlock, ctx: set[SimpleAssign]):
+    def _visit_block(self, block: StmtBlock, ctx: set[Assign]):
         stmts: list[Stmt] = []
         for stmt in block.stmts:
-            if not isinstance(stmt, SimpleAssign) or stmt not in ctx:
+            if not isinstance(stmt, Assign) or stmt not in ctx:
                 self._visit_statement(stmt, ctx)
                 stmts.append(stmt)
         block.stmts = stmts

--- a/fpy2/transform/copy_propagate.py
+++ b/fpy2/transform/copy_propagate.py
@@ -8,16 +8,16 @@ from ..analysis import DefineUse, SyntaxCheck
 from ..ast import *
 
 
-class _CopyPropagateInstance(DefaultAstVisitor):
+class _CopyPropagateInstance(DefaultVisitor):
     """Single-use instance of copy propagation."""
     func: FuncDef
     names: Optional[set[NamedId]]
-    xform: DefaultAstTransformVisitor
+    xform: DefaultTransformVisitor
 
     def __init__(self, func: FuncDef, names: Optional[set[NamedId]]):
         self.func = func
         self.names = names
-        self.xform = DefaultAstTransformVisitor()
+        self.xform = DefaultTransformVisitor()
 
     def apply(self):
         """Applies copy propagation to the function."""

--- a/fpy2/transform/for_bundling.py
+++ b/fpy2/transform/for_bundling.py
@@ -91,7 +91,8 @@ class _ForBundlingInstance(DefaultTransformVisitor):
                     raise RuntimeError('unreachable', stmt.target)
 
             # create a tuple of mutated variables
-            s: Stmt = Assign(t, TupleExpr([Var(var, None) for var in mutated], None), None, None)
+            e = TupleExpr([Var(var, None) for var in mutated], None)
+            s: Stmt = Assign(t, None, e, None)
             stmts.append(s)
 
             # transform target
@@ -109,12 +110,12 @@ class _ForBundlingInstance(DefaultTransformVisitor):
 
             # unpack the tuple at the start of the body
             # replace any variable in the target with `_`
-            unpack_names = [UnderscoreId() if var in target_names else rename[var] for var in mutated]
-            s = TupleUnpack(TupleBinding(unpack_names, None), Var(t, None), None)
+            binding = TupleBinding([UnderscoreId() if var in target_names else rename[var] for var in mutated], None)
+            s = Assign(binding, None, Var(t, None), None)
             body.stmts.insert(0, s)
 
             # repack the tuple at the end of the body
-            s = Assign(t, TupleExpr([Var(rename[v], None) for v in mutated], None), None, None)
+            s = Assign(t, None, TupleExpr([Var(rename[v], None) for v in mutated], None), None)
             body.stmts.append(s)
 
             # append the for statement
@@ -122,7 +123,7 @@ class _ForBundlingInstance(DefaultTransformVisitor):
             stmts.append(s)
 
             # unpack the tuple after the loop
-            s = TupleUnpack(TupleBinding(mutated, None), Var(t, None), None)
+            s = Assign(TupleBinding(mutated, None), None, Var(t, None), None)
             stmts.append(s)
 
             return StmtBlock(stmts)

--- a/fpy2/transform/for_bundling.py
+++ b/fpy2/transform/for_bundling.py
@@ -8,7 +8,7 @@ from ..ast import *
 from ..utils import Gensym
 
 
-class _ForBundlingInstance(DefaultAstTransformVisitor):
+class _ForBundlingInstance(DefaultTransformVisitor):
     """Single-use instance of the ForBundling pass."""
     func: FuncDef
     def_use: DefineUseAnalysis

--- a/fpy2/transform/for_bundling.py
+++ b/fpy2/transform/for_bundling.py
@@ -91,7 +91,7 @@ class _ForBundlingInstance(DefaultTransformVisitor):
                     raise RuntimeError('unreachable', stmt.target)
 
             # create a tuple of mutated variables
-            s: Stmt = SimpleAssign(t, TupleExpr([Var(var, None) for var in mutated], None), None, None)
+            s: Stmt = Assign(t, TupleExpr([Var(var, None) for var in mutated], None), None, None)
             stmts.append(s)
 
             # transform target
@@ -114,7 +114,7 @@ class _ForBundlingInstance(DefaultTransformVisitor):
             body.stmts.insert(0, s)
 
             # repack the tuple at the end of the body
-            s = SimpleAssign(t, TupleExpr([Var(rename[v], None) for v in mutated], None), None, None)
+            s = Assign(t, TupleExpr([Var(rename[v], None) for v in mutated], None), None, None)
             body.stmts.append(s)
 
             # append the for statement

--- a/fpy2/transform/for_unpack.py
+++ b/fpy2/transform/for_unpack.py
@@ -6,7 +6,7 @@ from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
 from ..ast import *
 from ..utils import Gensym
 
-class _ForUnpackInstance(DefaultAstTransformVisitor):
+class _ForUnpackInstance(DefaultTransformVisitor):
     """Single-use instance of the ForUnpack pass."""
     func: FuncDef
     gensym: Gensym

--- a/fpy2/transform/for_unpack.py
+++ b/fpy2/transform/for_unpack.py
@@ -32,7 +32,7 @@ class _ForUnpackInstance(DefaultTransformVisitor):
                 binding = self._visit_tuple_binding(stmt.target, ctx)
 
                 # insert tuple unpacking at the beginning of the body
-                body.stmts.insert(0, TupleUnpack(binding, Var(t, None), None))
+                body.stmts.insert(0, Assign(binding, None, Var(t, None), None))
 
                 # create the for statement with the fresh variable
                 s = ForStmt(t, iterable, body, None)

--- a/fpy2/transform/func_update.py
+++ b/fpy2/transform/func_update.py
@@ -7,7 +7,7 @@ from typing import Optional
 from ..analysis import DefineUse, SyntaxCheck
 from ..ast import *
 
-class _FuncUpdateInstance(DefaultAstTransformVisitor):
+class _FuncUpdateInstance(DefaultTransformVisitor):
     """Single-use instance of the FuncUpdate pass."""
     func: FuncDef
 

--- a/fpy2/transform/func_update.py
+++ b/fpy2/transform/func_update.py
@@ -21,7 +21,7 @@ class _FuncUpdateInstance(DefaultTransformVisitor):
         slices = [self._visit_expr(slice, ctx) for slice in stmt.slices]
         expr = self._visit_expr(stmt.expr, ctx)
         e = TupleSet(Var(stmt.var, None), slices, expr, stmt.loc)
-        s = Assign(stmt.var, e, None, stmt.loc)
+        s = Assign(stmt.var, None, e, stmt.loc)
         return s, None
 
 class FuncUpdate:

--- a/fpy2/transform/func_update.py
+++ b/fpy2/transform/func_update.py
@@ -17,7 +17,7 @@ class _FuncUpdateInstance(DefaultAstTransformVisitor):
     def apply(self) -> FuncDef:
         return self._visit_function(self.func, None)
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: None):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: None):
         slices = [self._visit_expr(slice, ctx) for slice in stmt.slices]
         expr = self._visit_expr(stmt.expr, ctx)
         e = TupleSet(Var(stmt.var, None), slices, expr, stmt.loc)

--- a/fpy2/transform/func_update.py
+++ b/fpy2/transform/func_update.py
@@ -21,7 +21,7 @@ class _FuncUpdateInstance(DefaultTransformVisitor):
         slices = [self._visit_expr(slice, ctx) for slice in stmt.slices]
         expr = self._visit_expr(stmt.expr, ctx)
         e = TupleSet(Var(stmt.var, None), slices, expr, stmt.loc)
-        s = SimpleAssign(stmt.var, e, None, stmt.loc)
+        s = Assign(stmt.var, e, None, stmt.loc)
         return s, None
 
 class FuncUpdate:

--- a/fpy2/transform/rename_target.py
+++ b/fpy2/transform/rename_target.py
@@ -34,14 +34,14 @@ class _RenameTargetInstance(DefaultTransformVisitor):
         elt = self._visit_expr(e.elt, ctx)
         return CompExpr(targets, iterables, elt, e.loc)
 
-    def _visit_simple_assign(self, stmt: SimpleAssign, ctx: None):
+    def _visit_assign(self, stmt: Assign, ctx: None):
         match stmt.var:
             case NamedId():
                 var: Id = self.rename.get(stmt.var, stmt.var)
             case _:
                 var = stmt.var
         expr = self._visit_expr(stmt.expr, ctx)
-        s = SimpleAssign(var, expr, stmt.ann, stmt.loc)
+        s = Assign(var, expr, stmt.ann, stmt.loc)
         return s, None
 
     def _visit_binding(self, binding: Id | TupleBinding, ctx: None):

--- a/fpy2/transform/rename_target.py
+++ b/fpy2/transform/rename_target.py
@@ -3,7 +3,7 @@
 from ..ast import *
 from ..analysis import SyntaxCheck
 
-class _RenameTargetInstance(DefaultAstTransformVisitor):
+class _RenameTargetInstance(DefaultTransformVisitor):
     """Renames targets in a function."""
     ast: FuncDef | StmtBlock
     rename: dict[NamedId, NamedId]

--- a/fpy2/transform/rename_target.py
+++ b/fpy2/transform/rename_target.py
@@ -64,11 +64,11 @@ class _RenameTargetInstance(DefaultAstTransformVisitor):
         s = TupleUnpack(binding, expr, stmt.loc)
         return s, None
 
-    def _visit_index_assign(self, stmt: IndexAssign, ctx: None):
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: None):
         var = self.rename.get(stmt.var, stmt.var)
         slices = [self._visit_expr(slice, ctx) for slice in stmt.slices]
         expr = self._visit_expr(stmt.expr, ctx)
-        s = IndexAssign(var, slices, expr, stmt.loc)
+        s = IndexedAssign(var, slices, expr, stmt.loc)
         return s, None
 
     def _visit_for(self, stmt: ForStmt, ctx: None):

--- a/fpy2/transform/rename_target.py
+++ b/fpy2/transform/rename_target.py
@@ -34,16 +34,6 @@ class _RenameTargetInstance(DefaultTransformVisitor):
         elt = self._visit_expr(e.elt, ctx)
         return CompExpr(targets, iterables, elt, e.loc)
 
-    def _visit_assign(self, stmt: Assign, ctx: None):
-        match stmt.var:
-            case NamedId():
-                var: Id = self.rename.get(stmt.var, stmt.var)
-            case _:
-                var = stmt.var
-        expr = self._visit_expr(stmt.expr, ctx)
-        s = Assign(var, expr, stmt.ann, stmt.loc)
-        return s, None
-
     def _visit_binding(self, binding: Id | TupleBinding, ctx: None):
         match binding:
             case NamedId():
@@ -58,10 +48,10 @@ class _RenameTargetInstance(DefaultTransformVisitor):
     def _visit_tuple_binding(self, binding: TupleBinding, ctx: None):
         return TupleBinding([self._visit_binding(elt, ctx) for elt in binding.elts], None)
 
-    def _visit_tuple_unpack(self, stmt: TupleUnpack, ctx: None):
-        binding = self._visit_tuple_binding(stmt.binding, ctx)
+    def _visit_assign(self, stmt: Assign, ctx: None):
+        binding = self._visit_binding(stmt.binding, ctx)
         expr = self._visit_expr(stmt.expr, ctx)
-        s = TupleUnpack(binding, expr, stmt.loc)
+        s = Assign(binding, stmt.type, expr, stmt.loc)
         return s, None
 
     def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: None):

--- a/fpy2/transform/simplify_if.py
+++ b/fpy2/transform/simplify_if.py
@@ -8,7 +8,7 @@ from .copy_propagate import CopyPropagate
 from .rename_target import RenameTarget
 
 
-class _SimplifyIfInstance(DefaultAstTransformVisitor):
+class _SimplifyIfInstance(DefaultTransformVisitor):
     """Single-use instance of the SimplifyIf pass."""
     func: FuncDef
     def_use: DefineUseAnalysis

--- a/fpy2/transform/simplify_if.py
+++ b/fpy2/transform/simplify_if.py
@@ -32,7 +32,7 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
         # generate temporary if needed
         if not isinstance(cond, Var):
             t = self.gensym.fresh('cond')
-            s = Assign(t, cond, BoolTypeAnn(None), None)
+            s = Assign(t, BoolTypeAnn(None), cond, None)
             stmts.append(s)
             cond = Var(t, None)
 
@@ -50,14 +50,14 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
         # generate assignments and inline the body
         for var in mutated:
             t = rename[var]
-            s = Assign(t, Var(var, None), None, None)
+            s = Assign(t, None, Var(var, None), None)
             stmts.append(s)
         stmts.extend(body.stmts)
 
         # make if expressions for each mutated variable
         for var in mutated:
             e = IfExpr(cond, Var(rename[var], None), Var(var, None), None)
-            s = Assign(var, e, None, None)
+            s = Assign(var, None, e, None)
             stmts.append(s)
 
         return StmtBlock(stmts)
@@ -72,7 +72,7 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
         # generate temporary if needed
         if not isinstance(cond, Var):
             t = self.gensym.fresh('cond')
-            s = Assign(t, cond, BoolTypeAnn(None), None)
+            s = Assign(t, BoolTypeAnn(None), cond, None)
             stmts.append(s)
             cond = Var(t, None)
 
@@ -107,13 +107,13 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
 
         for var in mutated_ift:
             t = rename_ift[var]
-            s = Assign(t, Var(var, None), None, None)
+            s = Assign(t, None, Var(var, None), None)
             stmts.append(s)
         stmts.extend(ift.stmts)
 
         for var in mutated_iff:
             t = rename_iff[var]
-            s = Assign(t, Var(var, None), None, None)
+            s = Assign(t, None, Var(var, None), None)
             stmts.append(s)
         stmts.extend(iff.stmts)
 
@@ -124,7 +124,7 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
                 ift_name = rename_ift.get(var, var)
                 iff_name = rename_iff.get(var, var)
                 e = IfExpr(cond, Var(ift_name, None), Var(iff_name, None), None)
-                s = Assign(var, e, None, None)
+                s = Assign(var, None, e, None)
                 stmts.append(s)
                 unique.add(var)
 

--- a/fpy2/transform/simplify_if.py
+++ b/fpy2/transform/simplify_if.py
@@ -32,7 +32,7 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
         # generate temporary if needed
         if not isinstance(cond, Var):
             t = self.gensym.fresh('cond')
-            s = SimpleAssign(t, cond, BoolTypeAnn(None), None)
+            s = Assign(t, cond, BoolTypeAnn(None), None)
             stmts.append(s)
             cond = Var(t, None)
 
@@ -50,14 +50,14 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
         # generate assignments and inline the body
         for var in mutated:
             t = rename[var]
-            s = SimpleAssign(t, Var(var, None), None, None)
+            s = Assign(t, Var(var, None), None, None)
             stmts.append(s)
         stmts.extend(body.stmts)
 
         # make if expressions for each mutated variable
         for var in mutated:
             e = IfExpr(cond, Var(rename[var], None), Var(var, None), None)
-            s = SimpleAssign(var, e, None, None)
+            s = Assign(var, e, None, None)
             stmts.append(s)
 
         return StmtBlock(stmts)
@@ -72,7 +72,7 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
         # generate temporary if needed
         if not isinstance(cond, Var):
             t = self.gensym.fresh('cond')
-            s = SimpleAssign(t, cond, BoolTypeAnn(None), None)
+            s = Assign(t, cond, BoolTypeAnn(None), None)
             stmts.append(s)
             cond = Var(t, None)
 
@@ -107,13 +107,13 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
 
         for var in mutated_ift:
             t = rename_ift[var]
-            s = SimpleAssign(t, Var(var, None), None, None)
+            s = Assign(t, Var(var, None), None, None)
             stmts.append(s)
         stmts.extend(ift.stmts)
 
         for var in mutated_iff:
             t = rename_iff[var]
-            s = SimpleAssign(t, Var(var, None), None, None)
+            s = Assign(t, Var(var, None), None, None)
             stmts.append(s)
         stmts.extend(iff.stmts)
 
@@ -124,7 +124,7 @@ class _SimplifyIfInstance(DefaultTransformVisitor):
                 ift_name = rename_ift.get(var, var)
                 iff_name = rename_iff.get(var, var)
                 e = IfExpr(cond, Var(ift_name, None), Var(iff_name, None), None)
-                s = SimpleAssign(var, e, None, None)
+                s = Assign(var, e, None, None)
                 stmts.append(s)
                 unique.add(var)
 

--- a/fpy2/transform/while_bundling.py
+++ b/fpy2/transform/while_bundling.py
@@ -12,7 +12,7 @@ from .rename_target import RenameTarget
 
 _Ctx = dict[NamedId, Expr]
 
-class _WhileBundlingInstance(DefaultAstTransformVisitor):
+class _WhileBundlingInstance(DefaultTransformVisitor):
     """Single-use instance of the WhileBundling pass."""
     func: FuncDef
     def_use: DefineUseAnalysis

--- a/fpy2/transform/while_bundling.py
+++ b/fpy2/transform/while_bundling.py
@@ -68,7 +68,7 @@ class _WhileBundlingInstance(DefaultTransformVisitor):
             rename = { var: self.gensym.refresh(var) for var in mutated }
 
             # create a tuple of mutated variables
-            s: Stmt = Assign(t, TupleExpr([Var(var, None) for var in mutated], None), None, None)
+            s: Stmt = Assign(t, None, TupleExpr([Var(var, None) for var in mutated], None), None)
             stmts.append(s)
 
             # apply substitution to the condition
@@ -80,11 +80,11 @@ class _WhileBundlingInstance(DefaultTransformVisitor):
             body = RenameTarget.apply_block(body, rename)
 
             # unpack the tuple at the start of the body
-            s = TupleUnpack(TupleBinding([rename[v] for v in mutated], None), Var(t, None), None)
+            s = Assign(TupleBinding([rename[v] for v in mutated], None), None, Var(t, None), None)
             body.stmts.insert(0, s)
 
             # repack the tuple at the end of the body
-            s = Assign(t, TupleExpr([Var(rename[v], None) for v in mutated], None), None, None)
+            s = Assign(t, None, TupleExpr([Var(rename[v], None) for v in mutated], None), None)
             body.stmts.append(s)
 
             # append the while statement
@@ -92,7 +92,7 @@ class _WhileBundlingInstance(DefaultTransformVisitor):
             stmts.append(s)
 
             # unpack the tuple after the loop
-            s = TupleUnpack(TupleBinding(mutated, None), Var(t, None), None)
+            s = Assign(TupleBinding(mutated, None), None, Var(t, None), None)
             stmts.append(s)
 
             return StmtBlock(stmts)

--- a/fpy2/transform/while_bundling.py
+++ b/fpy2/transform/while_bundling.py
@@ -68,7 +68,7 @@ class _WhileBundlingInstance(DefaultTransformVisitor):
             rename = { var: self.gensym.refresh(var) for var in mutated }
 
             # create a tuple of mutated variables
-            s: Stmt = SimpleAssign(t, TupleExpr([Var(var, None) for var in mutated], None), None, None)
+            s: Stmt = Assign(t, TupleExpr([Var(var, None) for var in mutated], None), None, None)
             stmts.append(s)
 
             # apply substitution to the condition
@@ -84,7 +84,7 @@ class _WhileBundlingInstance(DefaultTransformVisitor):
             body.stmts.insert(0, s)
 
             # repack the tuple at the end of the body
-            s = SimpleAssign(t, TupleExpr([Var(rename[v], None) for v in mutated], None), None, None)
+            s = Assign(t, TupleExpr([Var(rename[v], None) for v in mutated], None), None, None)
             body.stmts.append(s)
 
             # append the while statement

--- a/fpy2/utils/identifier.py
+++ b/fpy2/utils/identifier.py
@@ -18,10 +18,17 @@ class Id(ABC):
         """
         Return a set of all named identifiers contained in this identifier.
 
-        This method is mainly for compability with other AST methods.
+        This method is for compability with AST classes.
         """
         ...
 
+    def is_equiv(self, other) -> bool:
+        """
+        Check if this identifier is equivalent to another identifier.
+
+        This method is for compability with AST classes.
+        """
+        return self == other
 
 class UnderscoreId(Id):
     """
@@ -45,7 +52,6 @@ class UnderscoreId(Id):
 
     def names(self) -> set['NamedId']:
         return set()
-
 
 class NamedId(Id):
     """

--- a/fpy2/utils/identifier.py
+++ b/fpy2/utils/identifier.py
@@ -5,12 +5,23 @@ Strings are not sufficient as identifiers, especially when (re)-generating
 unique identifiers.
 """
 
+from abc import ABC, abstractmethod
 from typing import Optional
 
 from .location import Location
 
-class Id(object):
+class Id(ABC):
     """Abstract base class for identifiers."""
+
+    @abstractmethod
+    def names(self) -> set['NamedId']:
+        """
+        Return a set of all named identifiers contained in this identifier.
+
+        This method is mainly for compability with other AST methods.
+        """
+        ...
+
 
 class UnderscoreId(Id):
     """
@@ -31,6 +42,10 @@ class UnderscoreId(Id):
 
     def __hash__(self):
         return hash(())
+
+    def names(self) -> set['NamedId']:
+        return set()
+
 
 class NamedId(Id):
     """
@@ -65,6 +80,9 @@ class NamedId(Id):
 
     def __hash__(self):
         return hash((self.base, self.count))
+
+    def names(self) -> set['NamedId']:
+        return { self }
 
 
 class SourceId(NamedId):

--- a/tests/rewrite/test_applier.py
+++ b/tests/rewrite/test_applier.py
@@ -98,6 +98,8 @@ class ApplierStmtTestCase(_ApplierTestCase):
             StmtBlock([
                 Assign(
                     NamedId('sum'),
-                    Call('sum', [Var(NamedId('lst'), None)], None), None, None),
+                    None,
+                    Call('sum', [Var(NamedId('lst'), None)], None),
+                    None),
             ])
         )

--- a/tests/rewrite/test_applier.py
+++ b/tests/rewrite/test_applier.py
@@ -1,7 +1,7 @@
 import unittest
 
 from fpy2 import fpy, pattern, Function
-from fpy2.ast import Expr, Stmt, StmtBlock, FuncDef, Fma, Var, NamedId, SimpleAssign, Call
+from fpy2.ast import Expr, Stmt, StmtBlock, FuncDef, Fma, Var, NamedId, Assign, Call
 from fpy2.rewrite.applier import Applier
 from fpy2.rewrite.matcher import Matcher
 from fpy2.typing import *
@@ -96,7 +96,7 @@ class ApplierStmtTestCase(_ApplierTestCase):
         self.assertAstEqual(
             h2, 
             StmtBlock([
-                SimpleAssign(
+                Assign(
                     NamedId('sum'),
                     Call('sum', [Var(NamedId('lst'), None)], None), None, None),
             ])


### PR DESCRIPTION
Yet another round of cleaning up and tweaks:
 - added `names()` and `is_equiv()` methods to `Id`
 - merged `SimpleAssign` and `UnpackTuple` AST nodes into `Assign`
 - renamed` IndexAssign` into `IndexedAssign`
 - remove "AST" from visitor class names