### PR TITLE
Rename rounding contexts

### DIFF
--- a/fpy2/__init__.py
+++ b/fpy2/__init__.py
@@ -8,9 +8,9 @@ under different number systems and compilers to other languages.
 
 The numbers library supports many different number types including:
 
- - multiprecision floating point (`MPContext`)
- - multiprecision floatingpoint with subnormalization (`MPSContext`)
- - bounded, multiprecision floating point (`MPBContext`)
+ - multiprecision floating point (`MPFloatContext`)
+ - multiprecision floatingpoint with subnormalization (`MPSFloatContext`)
+ - bounded, multiprecision floating point (`MPBFloatContext`)
  - IEEE 754 floating point (`IEEEContext`)
 
 These number systems guarantee correct rounding via MPFR.
@@ -26,18 +26,18 @@ from .number import (
     SizedContext,
     EncodableContext,
     # concrete context types
-    ExtContext,
-    MPContext,
-    MPBContext,
-    MPFContext,
-    MPSContext,
+    ExtFloatContext,
+    MPFloatContext,
+    MPBFloatContext,
+    MPFixedContext,
+    MPSFloatContext,
     IEEEContext,
     RealContext,
     # rounding utilities
     RoundingMode,
     RoundingDirection, RM,
     # encoding utilities
-    ExtNanKind,
+    ExtFloatNanKind,
     # type aliases
     FP256, FP128, FP64, FP32, FP16,
     TF32, BF16,

--- a/fpy2/fpc_context.py
+++ b/fpy2/fpc_context.py
@@ -7,7 +7,7 @@ from typing import Any
 from .number import (
     Context,
     IEEEContext,
-    MPFContext,
+    MPFixedContext,
     RealContext,
     RM,
     FP128, FP64, FP32, FP16,
@@ -134,7 +134,7 @@ class FPCoreContext:
                         return FPCoreContext(precision='binary16', round=rm)
                     case _:
                         return FPCoreContext(precision=['float', ctx.es, ctx.nbits], round=rm)
-            case MPFContext() if ctx.nmin == -1:
+            case MPFixedContext() if ctx.nmin == -1:
                 rm = _round_mode_from_fpc(ctx.rm)
                 return FPCoreContext(precision='integer', round=rm)
             case RealContext():

--- a/fpy2/number/__init__.py
+++ b/fpy2/number/__init__.py
@@ -5,12 +5,12 @@ from .number import RealFloat, Float
 
 # Contexts
 from .context import Context, OrdinalContext, SizedContext, EncodableContext
-from .ext import ExtContext, ExtNanKind
+from .ext_float import ExtFloatContext, ExtFloatNanKind
 from .ieee754 import IEEEContext
-from .mp import MPContext
-from .mpb import MPBContext
-from .mpf import MPFContext
-from .mps import MPSContext
+from .mp_float import MPFloatContext
+from .mpb_float import MPBFloatContext
+from .mp_fixed import MPFixedContext
+from .mps_float import MPSFloatContext
 from .real import RealContext
 
 # Rounding
@@ -72,7 +72,7 @@ Alias for Google's Brain Floating Point (BF16) floating point format
 with round nearest, ties-to-even rounding mode.
 """
 
-S1E5M2 = ExtContext(5, 8, False, ExtNanKind.NEG_ZERO, -1, RM.RNE)
+S1E5M2 = ExtFloatContext(5, 8, False, ExtFloatNanKind.NEG_ZERO, -1, RM.RNE)
 """
 Alias for Graphcore's FP8 format with 5 bits of exponent
 with round nearest, ties-to-even rounding mode.
@@ -80,7 +80,7 @@ with round nearest, ties-to-even rounding mode.
 See Graphcore's FP8 proposal for more information: https://arxiv.org/pdf/2206.02915.
 """
 
-S1E4M3 = ExtContext(4, 8, False, ExtNanKind.NEG_ZERO, -1, RM.RNE)
+S1E4M3 = ExtFloatContext(4, 8, False, ExtFloatNanKind.NEG_ZERO, -1, RM.RNE)
 """
 Alias for Graphcore's FP8 format with 4 bits of exponent
 with round nearest, ties-to-even rounding mode.
@@ -98,7 +98,7 @@ See the OCP MX specification for more information:
 https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 """
 
-MX_E4M3 = ExtContext(4, 8, False, ExtNanKind.MAX_VAL, 0, RM.RNE)
+MX_E4M3 = ExtFloatContext(4, 8, False, ExtFloatNanKind.MAX_VAL, 0, RM.RNE)
 """
 Alias for the FP8 format with 4 bits of exponent in
 the Open Compute Project (OCP) Microscaling Formats (MX) specification
@@ -108,7 +108,7 @@ See the OCP MX specification for more information:
 https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 """
 
-MX_E3M2 = ExtContext(3, 6, False, ExtNanKind.NONE, 0, RM.RNE)
+MX_E3M2 = ExtFloatContext(3, 6, False, ExtFloatNanKind.NONE, 0, RM.RNE)
 """
 Alias for the FP6 format with 3 bits of exponent in
 the Open Compute Project (OCP) Microscaling Formats (MX) specification
@@ -118,7 +118,7 @@ See the OCP MX specification for more information:
 https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 """
 
-MX_E2M3 = ExtContext(2, 6, False, ExtNanKind.NONE, 0, RM.RNE)
+MX_E2M3 = ExtFloatContext(2, 6, False, ExtFloatNanKind.NONE, 0, RM.RNE)
 """
 Alias for the FP6 format with 2 bits of exponent in
 the Open Compute Project (OCP) Microscaling Formats (MX) specification
@@ -128,7 +128,7 @@ See the OCP MX specification for more information:
 https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf
 """
 
-MX_E2M1 = ExtContext(2, 4, False, ExtNanKind.NONE, 0, RM.RNE)
+MX_E2M1 = ExtFloatContext(2, 4, False, ExtFloatNanKind.NONE, 0, RM.RNE)
 """
 Alias for the FP4 format with 2 bits of exponent in
 the Open Compute Project (OCP) Microscaling Formats (MX) specification
@@ -140,7 +140,7 @@ https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-fina
 
 # TODO: MX_INT8
 
-FP8P1 = ExtContext(7, 8, True, ExtNanKind.NEG_ZERO, 0, RM.RNE)
+FP8P1 = ExtFloatContext(7, 8, True, ExtFloatNanKind.NEG_ZERO, 0, RM.RNE)
 """
 Alias for the FP8 format with 7 bits of exponent found in
 a draft proposal by the IEEE P3109 working group
@@ -151,7 +151,7 @@ See the IEEE P3109 working group for more information:
 https://github.com/P3109/Public/blob/main/IEEE%20WG%20P3109%20Interim%20Report.pdf
 """
 
-FP8P2 = ExtContext(6, 8, True, ExtNanKind.NEG_ZERO, -1, RM.RNE)
+FP8P2 = ExtFloatContext(6, 8, True, ExtFloatNanKind.NEG_ZERO, -1, RM.RNE)
 """
 Alias for the FP8 format with 6 bits of exponent found in
 a draft proposal by the IEEE P3109 working group
@@ -162,7 +162,7 @@ See the IEEE P3109 working group for more information:
 https://github.com/P3109/Public/blob/main/IEEE%20WG%20P3109%20Interim%20Report.pdf
 """
 
-FP8P3 = ExtContext(5, 8, True, ExtNanKind.NEG_ZERO, -1, RM.RNE)
+FP8P3 = ExtFloatContext(5, 8, True, ExtFloatNanKind.NEG_ZERO, -1, RM.RNE)
 """
 Alias for the FP8 format with 5 bits of exponent found in
 a draft proposal by the IEEE P3109 working group
@@ -173,7 +173,7 @@ See the IEEE P3109 working group for more information:
 https://github.com/P3109/Public/blob/main/IEEE%20WG%20P3109%20Interim%20Report.pdf
 """
 
-FP8P4 = ExtContext(4, 8, True, ExtNanKind.NEG_ZERO, -1, RM.RNE)
+FP8P4 = ExtFloatContext(4, 8, True, ExtFloatNanKind.NEG_ZERO, -1, RM.RNE)
 """
 Alias for the FP8 format with 4 bits of exponent found in
 a draft proposal by the IEEE P3109 working group
@@ -184,7 +184,7 @@ See the IEEE P3109 working group for more information:
 https://github.com/P3109/Public/blob/main/IEEE%20WG%20P3109%20Interim%20Report.pdf
 """
 
-FP8P5 = ExtContext(3, 8, True, ExtNanKind.NEG_ZERO, -1, RM.RNE)
+FP8P5 = ExtFloatContext(3, 8, True, ExtFloatNanKind.NEG_ZERO, -1, RM.RNE)
 """
 Alias for the FP8 format with 3 bits of exponent found in
 a draft proposal by the IEEE P3109 working group
@@ -195,7 +195,7 @@ See the IEEE P3109 working group for more information:
 https://github.com/P3109/Public/blob/main/IEEE%20WG%20P3109%20Interim%20Report.pdf
 """
 
-FP8P6 = ExtContext(2, 8, True, ExtNanKind.NEG_ZERO, -1, RM.RNE)
+FP8P6 = ExtFloatContext(2, 8, True, ExtFloatNanKind.NEG_ZERO, -1, RM.RNE)
 """
 Alias for the FP8 format with 2 bits of exponent found in
 a draft proposal by the IEEE P3109 working group
@@ -206,7 +206,7 @@ See the IEEE P3109 working group for more information:
 https://github.com/P3109/Public/blob/main/IEEE%20WG%20P3109%20Interim%20Report.pdf
 """
 
-FP8P7 = ExtContext(1, 8, True, ExtNanKind.NEG_ZERO, -1, RM.RNE)
+FP8P7 = ExtFloatContext(1, 8, True, ExtFloatNanKind.NEG_ZERO, -1, RM.RNE)
 """
 Alias for the FP8 format with 1 bit of exponent found in
 a draft proposal by the IEEE P3109 working group
@@ -217,7 +217,7 @@ See the IEEE P3109 working group for more information:
 https://github.com/P3109/Public/blob/main/IEEE%20WG%20P3109%20Interim%20Report.pdf
 """
 
-INTEGER = MPFContext(-1, RoundingMode.RTZ)
+INTEGER = MPFixedContext(-1, RoundingMode.RTZ)
 """
 Alias for an arbitrary-precision integer context with
 round towards zero rounding mode.

--- a/fpy2/number/ieee754.py
+++ b/fpy2/number/ieee754.py
@@ -3,10 +3,10 @@ This module defines floating-point numbers as defined
 by the IEEE 754 standard.
 """
 
-from .ext import ExtContext, ExtNanKind
+from .ext_float import ExtFloatContext, ExtFloatNanKind
 from .round import RoundingMode
 
-class IEEEContext(ExtContext):
+class IEEEContext(ExtFloatContext):
     """
     Rounding context for IEEE 754 floating-point values.
 
@@ -14,13 +14,13 @@ class IEEEContext(ExtContext):
     the exponent field `es`, the size of the total
     representation `nbits`, and the rounding mode `rm`.
 
-    This context is implemented as a subclass of `ExtContext` which is
+    This context is implemented as a subclass of `ExtFloatContext` which is
     a more general definition of IEEE 754-like floating-point numbers.
     By inheritance, `IEEEContext` implements `EncodingContext`.
     """
 
     def __init__(self, es: int, nbits: int, rm: RoundingMode):
-        super().__init__(es, nbits, True, ExtNanKind.IEEE_754, 0, rm)
+        super().__init__(es, nbits, True, ExtFloatNanKind.IEEE_754, 0, rm)
 
     def __repr__(self):
         return self.__class__.__name__ + f'(es={self.es}, nbits={self.nbits}, rm={self.rm!r})'

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -16,7 +16,7 @@ from .round import RoundingMode
 from .gmp import mpfr_value
 
 @default_repr
-class MPFContext(Context):
+class MPFixedContext(Context):
     """
     Rounding context for mulit-precision fixed-point numbers.
 
@@ -109,7 +109,7 @@ class MPFContext(Context):
 
 
     def with_rm(self, rm: RoundingMode):
-        return MPFContext(
+        return MPFixedContext(
             self.nmin,
             rm,
             enable_nan=self.enable_nan,

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -14,7 +14,7 @@ from .round import RoundingMode
 from .gmp import mpfr_value
 
 @default_repr
-class MPContext(Context):
+class MPFloatContext(Context):
     """
     Rounding context for multi-precision floating-point numbers.
 
@@ -41,7 +41,7 @@ class MPContext(Context):
         self.rm = rm
 
     def with_rm(self, rm: RoundingMode):
-        return MPContext(self.pmax, rm)
+        return MPFloatContext(self.pmax, rm)
 
     def is_representable(self, x: RealFloat | Float) -> bool:
         if not isinstance(x, RealFloat | Float):

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -11,13 +11,13 @@ from ..utils import default_repr
 
 from .context import SizedContext
 from .number import RealFloat, Float
-from .mps import MPSContext
+from .mps_float import MPSFloatContext
 from .round import RoundingMode, RoundingDirection
 from .gmp import mpfr_value
 
 
 @default_repr
-class MPBContext(SizedContext):
+class MPBFloatContext(SizedContext):
     """
     Rounding context for multi-precision floating-point numbers with
     a minimum exponent (and subnormalization) and a maximum value.
@@ -28,7 +28,7 @@ class MPBContext(SizedContext):
     may be specified as well, but by default it is set to the negative
     of `maxval`.
 
-    Unlike `MPContext`, the `MPBContext` is inherits from `SizedContext`
+    Unlike `MPFloatContext`, the `MPBFloatContext` is inherits from `SizedContext`
     since the set of representable values may be encoded in
     a finite amount of space.
     """
@@ -48,7 +48,7 @@ class MPBContext(SizedContext):
     rm: RoundingMode
     """rounding mode"""
 
-    _mps_ctx: MPSContext
+    _mps_ctx: MPSFloatContext
     """this context without maximum values"""
 
     _pos_maxval_ord: int
@@ -96,7 +96,7 @@ class MPBContext(SizedContext):
         self.neg_maxval = neg_maxval
         self.rm = rm
 
-        self._mps_ctx = MPSContext(pmax, emin, rm)
+        self._mps_ctx = MPSFloatContext(pmax, emin, rm)
         pos_maxval_mps = Float(x=self.pos_maxval, ctx=self._mps_ctx)
         neg_maxval_mps = Float(x=self.neg_maxval, ctx=self._mps_ctx)
         self._pos_maxval_ord = self._mps_ctx.to_ordinal(pos_maxval_mps)
@@ -128,7 +128,7 @@ class MPBContext(SizedContext):
         return self._mps_ctx.nmin
 
     def with_rm(self, rm: RoundingMode):
-        return MPBContext(self.pmax, self.emin, self.pos_maxval, rm, neg_maxval=self.neg_maxval)
+        return MPBFloatContext(self.pmax, self.emin, self.pos_maxval, rm, neg_maxval=self.neg_maxval)
 
     def is_representable(self, x: RealFloat | Float) -> bool:
         if not isinstance(x, RealFloat | Float):

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -11,12 +11,12 @@ from ..utils import default_repr, bitmask
 
 from .context import OrdinalContext
 from .number import RealFloat, Float
-from .mp import MPContext
+from .mp_float import MPFloatContext
 from .round import RoundingMode
 from .gmp import mpfr_value
 
 @default_repr
-class MPSContext(OrdinalContext):
+class MPSFloatContext(OrdinalContext):
     """
     Rounding context for multi-precision floating-point numbers with
     a minimum exponent (and subnormalization).
@@ -26,7 +26,7 @@ class MPSContext(OrdinalContext):
     It emulates floating-point numbers as implemented by MPFR
     with subnormalization.
 
-    Unlike `MPContext`, the `MPSContext` is inherits from `OrdinalContext`
+    Unlike `MPFloatContext`, the `MPSFloatContext` is inherits from `OrdinalContext`
     since each representable value can be mapped to the ordinals.
     """
 
@@ -36,7 +36,7 @@ class MPSContext(OrdinalContext):
     emin: int
     """minimum (normalized exponent)"""
 
-    _mp_ctx: MPContext
+    _mp_ctx: MPFloatContext
     """this context without subnormalization"""
 
     rm: RoundingMode
@@ -55,7 +55,7 @@ class MPSContext(OrdinalContext):
         self.pmax = pmax
         self.emin = emin
         self.rm = rm
-        self._mp_ctx = MPContext(pmax, rm)
+        self._mp_ctx = MPFloatContext(pmax, rm)
 
     @property
     def expmin(self):
@@ -70,7 +70,7 @@ class MPSContext(OrdinalContext):
         return self.expmin - 1
 
     def with_rm(self, rm: RoundingMode):
-        return MPSContext(self.pmax, self.emin, rm)
+        return MPSFloatContext(self.pmax, self.emin, rm)
 
     def is_representable(self, x: RealFloat | Float) -> bool:
         if not isinstance(x, RealFloat | Float):

--- a/tests/unit/math/test_ops.py
+++ b/tests/unit/math/test_ops.py
@@ -1,7 +1,7 @@
 import random
 import unittest
 
-from fpy2 import IEEEContext, MPFContext, RM, FP64, FP32, FP16
+from fpy2 import IEEEContext, MPFixedContext, RM, FP64, FP32, FP16
 from fpy2.math import *
 
 _unary_ops = [
@@ -150,7 +150,7 @@ class MathIntegerNoExceptTestCase(unittest.TestCase):
         for op in _unary_ops:
             max_value = self._max_integer.get(op, self._default_max_integer)
             for rm in _rms:
-                ctx = MPFContext(-1, rm, enable_nan=True, enable_inf=True)
+                ctx = MPFixedContext(-1, rm, enable_nan=True, enable_inf=True)
                 for _ in range(num_inputs):
                     # sample point
                     i = random.randint(0, max_value) * random.choice([-1, 1])
@@ -163,7 +163,7 @@ class MathIntegerNoExceptTestCase(unittest.TestCase):
         for op in _binary_ops:
             max_value = self._max_integer.get(op, self._default_max_integer)
             for rm in _rms:
-                ctx = MPFContext(-1, rm, enable_nan=True, enable_inf=True)
+                ctx = MPFixedContext(-1, rm, enable_nan=True, enable_inf=True)
                 for _ in range(num_inputs):
                     # sample point
                     i = random.randint(0, max_value) * random.choice([-1, 1])
@@ -177,7 +177,7 @@ class MathIntegerNoExceptTestCase(unittest.TestCase):
         for op in _ternary_ops:
             max_value = self._max_integer.get(op, self._default_max_integer)
             for rm in _rms:
-                ctx = MPFContext(-1, rm, enable_nan=True, enable_inf=True)
+                ctx = MPFixedContext(-1, rm, enable_nan=True, enable_inf=True)
                 for _ in range(num_inputs):
                     # sample point
                     i = random.randint(0, max_value) * random.choice([-1, 1])

--- a/tests/unit/number/mp/test_normalize.py
+++ b/tests/unit/number/mp/test_normalize.py
@@ -1,7 +1,7 @@
 import random
 import unittest
 
-from fpy2 import Float, MPContext, RM
+from fpy2 import Float, MPFloatContext, RM
 
 class NormalizeTestCase(unittest.TestCase):
     """Testing `IEEEContext.normalize()`"""
@@ -11,7 +11,7 @@ class NormalizeTestCase(unittest.TestCase):
         for _ in range(num_values):
             # sample maximum starting precision
             p_init = random.randint(2, p_max)
-            ctx = MPContext(p_max, RM.RNE)
+            ctx = MPFloatContext(p_max, RM.RNE)
 
             # sample random value
             s = random.choice([False, True])

--- a/tests/unit/number/mp/test_round.py
+++ b/tests/unit/number/mp/test_round.py
@@ -2,7 +2,7 @@ import gmpy2 as gmp
 import random
 import unittest
 
-from fpy2 import RealFloat, MPContext, RM
+from fpy2 import RealFloat, MPFloatContext, RM
 
 def _mpfr_rm(rm: RM):
     match rm:
@@ -20,7 +20,7 @@ def _mpfr_rm(rm: RM):
             raise ValueError(f'unsupported rounding mode {rm}')
 
 
-def _round_mpfr(x: RealFloat, ctx: MPContext) -> RealFloat:
+def _round_mpfr(x: RealFloat, ctx: MPFloatContext) -> RealFloat:
     s_str = '-' if x.s else '+'
     xf = gmp.mpfr(f'{s_str}{hex(x.c)}p{x.exp}', precision=x.p, base=16)
     with gmp.context(
@@ -57,7 +57,7 @@ class RoundTestCase(unittest.TestCase):
             # sample rounding mode
             p = random.randint(2, p_max)
             rm = random.choice([RM.RNE, RM.RTP, RM.RTN, RM.RTZ, RM.RAZ])
-            ctx = MPContext(p, rm)
+            ctx = MPFloatContext(p, rm)
 
             # round value
             y = ctx.round(x)


### PR DESCRIPTION
Renames most of the rounding contexts:
 - `MPContext` -> `MPFloatContext`
 - `MPSContext` -> `MPSFloatContext`