### PR TITLE
Support slicing

### DIFF
--- a/docs/notes/TODO.md
+++ b/docs/notes/TODO.md
@@ -10,8 +10,7 @@ Frontend:
  - float:
    - context type parameter
  - arrays:
-   - support slicing
-   - remove NumPy style indexing
+   - enumerate
  - language:
    - support for vector addition/multiplication
  - formatter:

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -95,8 +95,7 @@ class LiveVarsInstance(Visitor):
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: None) -> _LiveSet:
         live = self._visit_expr(e.value, ctx)
-        for s in e.slices:
-            live |= self._visit_expr(s, ctx)
+        live |= self._visit_expr(e.index, ctx)
         return live
 
     def _visit_tuple_set(self, e: TupleSet, ctx: None) -> _LiveSet:

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -98,6 +98,14 @@ class LiveVarsInstance(Visitor):
         live |= self._visit_expr(e.index, ctx)
         return live
 
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: None) -> _LiveSet:
+        live = self._visit_expr(e.value, ctx)
+        if e.start is not None:
+            live |= self._visit_expr(e.start, ctx)
+        if e.stop is not None:
+            live |= self._visit_expr(e.stop, ctx)
+        return live
+
     def _visit_tuple_set(self, e: TupleSet, ctx: None) -> _LiveSet:
         live = self._visit_expr(e.array, ctx)
         for s in e.slices:

--- a/fpy2/analysis/syntax_check.py
+++ b/fpy2/analysis/syntax_check.py
@@ -199,6 +199,15 @@ class SyntaxCheckInstance(Visitor):
         self._visit_expr(e.index, ctx)
         return env
 
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: _Ctx):
+        env, _ = ctx
+        self._visit_expr(e.value, ctx)
+        if e.start is not None:
+            self._visit_expr(e.start, ctx)
+        if e.stop is not None:
+            self._visit_expr(e.stop, ctx)
+        return env
+
     def _visit_tuple_set(self, e: TupleSet, ctx: _Ctx):
         env, _ = ctx
         self._visit_expr(e.array, ctx)

--- a/fpy2/analysis/syntax_check.py
+++ b/fpy2/analysis/syntax_check.py
@@ -196,8 +196,7 @@ class SyntaxCheckInstance(Visitor):
     def _visit_tuple_ref(self, e: TupleRef, ctx: _Ctx):
         env, _ = ctx
         self._visit_expr(e.value, ctx)
-        for s in e.slices:
-            self._visit_expr(s, ctx)
+        self._visit_expr(e.index, ctx)
         return env
 
     def _visit_tuple_set(self, e: TupleSet, ctx: _Ctx):

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -156,9 +156,8 @@ class _FormatterInstance(Visitor):
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: _Ctx):
         value = self._visit_expr(e.value, ctx)
-        slices = [self._visit_expr(slice, ctx) for slice in e.slices]
-        ref_str = ''.join(f'[{slice}]' for slice in slices)
-        return f'{value}{ref_str}'
+        index = self._visit_expr(e.index, ctx)
+        return f'{value}[{index}]'
 
     def _visit_tuple_set(self, e: TupleSet, ctx: _Ctx):
         array = self._visit_expr(e.array, ctx)

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -159,6 +159,12 @@ class _FormatterInstance(Visitor):
         index = self._visit_expr(e.index, ctx)
         return f'{value}[{index}]'
 
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: _Ctx):
+        value = self._visit_expr(e.value, ctx)
+        start = '' if e.start is None else self._visit_expr(e.start, ctx)
+        stop = '' if e.stop is None else self._visit_expr(e.stop, ctx)
+        return f'{value}[{start}:{stop}]'
+
     def _visit_tuple_set(self, e: TupleSet, ctx: _Ctx):
         array = self._visit_expr(e.array, ctx)
         slices = [self._visit_expr(slice, ctx) for slice in e.slices]

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -797,6 +797,40 @@ class TupleRef(Expr):
             and self.index.is_equiv(other.index)
         )
 
+class TupleSlice(Expr):
+    """FPy AST: tuple slicing expression"""
+    value: Expr
+    start: Expr | None
+    stop: Expr | None
+
+    def __init__(
+        self,
+        value: Expr,
+        start: Optional[Expr],
+        stop: Optional[Expr],
+        loc: Optional[Location]
+    ):
+        super().__init__(loc)
+        self.value = value
+        self.start = start
+        self.stop = stop
+
+    def is_equiv(self, other) -> bool:
+        if not isinstance(other, TupleSlice):
+            return False
+
+        if not self.value.is_equiv(other.value):
+            return False
+
+        match self.start, other.start:
+            case Expr(), Expr():
+                return self.start.is_equiv(other.start)
+            case None, None:
+                return True
+            case _:
+                return False
+
+
 class IfExpr(Expr):
     """FPy AST: if expression"""
     cond: Expr

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -783,19 +783,18 @@ class TupleSet(Expr):
 class TupleRef(Expr):
     """FPy AST: tuple indexing expression"""
     value: Expr
-    slices: list[Expr]
+    index: Expr
 
-    def __init__(self, value: Expr, slices: Sequence[Expr], loc: Optional[Location]):
+    def __init__(self, value: Expr, index: Expr, loc: Optional[Location]):
         super().__init__(loc)
         self.value = value
-        self.slices = list(slices)
+        self.index = index
 
     def is_equiv(self, other) -> bool:
         return (
             isinstance(other, TupleRef)
             and self.value.is_equiv(other.value)
-            and len(self.slices) == len(other.slices)
-            and all(slice.is_equiv(other_slice) for slice, other_slice in zip(self.slices, other.slices))
+            and self.index.is_equiv(other.index)
         )
 
 class IfExpr(Expr):

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -86,6 +86,10 @@ class Visitor(ABC):
         ...
 
     @abstractmethod
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: Any) -> Any:
+        ...
+
+    @abstractmethod
     def _visit_tuple_set(self, e: TupleSet, ctx: Any) -> Any:
         ...
 
@@ -197,6 +201,8 @@ class Visitor(ABC):
                 return self._visit_comp_expr(e, ctx)
             case TupleRef():
                 return self._visit_tuple_ref(e, ctx)
+            case TupleSlice():
+                return self._visit_tuple_slice(e, ctx)
             case TupleSet():
                 return self._visit_tuple_set(e, ctx)
             case IfExpr():
@@ -296,6 +302,13 @@ class DefaultVisitor(Visitor):
     def _visit_tuple_ref(self, e: TupleRef, ctx: Any):
         self._visit_expr(e.value, ctx)
         self._visit_expr(e.index, ctx)
+
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: Any):
+        self._visit_expr(e.value, ctx)
+        if e.start is not None:
+            self._visit_expr(e.start, ctx)
+        if e.stop is not None:
+            self._visit_expr(e.stop, ctx)
 
     def _visit_tuple_set(self, e: TupleSet, ctx: Any):
         self._visit_expr(e.array, ctx)
@@ -431,6 +444,12 @@ class DefaultTransformVisitor(Visitor):
         value = self._visit_expr(e.value, ctx)
         index = self._visit_expr(e.index, ctx)
         return TupleRef(value, index, e.loc)
+
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: Any):
+        value = self._visit_expr(e.value, ctx)
+        start = None if e.start is None else self._visit_expr(e.start, ctx)
+        stop = None if e.stop is None else self._visit_expr(e.stop, ctx)
+        return TupleSlice(value, start, stop, e.loc)
 
     def _visit_tuple_set(self, e: TupleSet, ctx: Any):
         array = self._visit_expr(e.array, ctx)

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -295,8 +295,7 @@ class DefaultVisitor(Visitor):
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: Any):
         self._visit_expr(e.value, ctx)
-        for s in e.slices:
-            self._visit_expr(s, ctx)
+        self._visit_expr(e.index, ctx)
 
     def _visit_tuple_set(self, e: TupleSet, ctx: Any):
         self._visit_expr(e.array, ctx)
@@ -430,8 +429,8 @@ class DefaultTransformVisitor(Visitor):
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: Any):
         value = self._visit_expr(e.value, ctx)
-        slices = [self._visit_expr(s, ctx) for s in e.slices]
-        return TupleRef(value, slices, e.loc)
+        index = self._visit_expr(e.index, ctx)
+        return TupleRef(value, index, e.loc)
 
     def _visit_tuple_set(self, e: TupleSet, ctx: Any):
         array = self._visit_expr(e.array, ctx)

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -356,6 +356,9 @@ class FPCoreCompileInstance(Visitor):
         index = self._visit_expr(e.index, ctx)
         return fpc.Ref(value, index)
 
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: None) -> fpc.Expr:
+        raise NotImplementedError(e)
+
     def _generate_tuple_set(self, tuple_id: str, iter_id: str, idx_ids: list[str], val_id: str):
         # dimension bindings
         idx_id = idx_ids[0]

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -353,8 +353,8 @@ class FPCoreCompileInstance(Visitor):
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: None) -> fpc.Expr:
         value = self._visit_expr(e.value, ctx)
-        slices = [self._visit_expr(s, ctx) for s in e.slices]
-        return fpc.Ref(value, *slices)
+        index = self._visit_expr(e.index, ctx)
+        return fpc.Ref(value, index)
 
     def _generate_tuple_set(self, tuple_id: str, iter_id: str, idx_ids: list[str], val_id: str):
         # dimension bindings

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -251,8 +251,8 @@ class _FPCore2FPy:
 
     def _visit_ref(self, e: fpc.Ref, ctx: _Ctx) -> Expr:
         value = self._visit(e.children[0], ctx)
-        slices = [self._visit(e, ctx) for e in e.children[1:]]
-        return TupleRef(value, slices, None)
+        index = self._visit(e.children[1], ctx)
+        return TupleRef(value, index, None)
 
     def _visit_if(self, e: fpc.If, ctx: _Ctx) -> Expr:
         # create new blocks

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -370,7 +370,7 @@ class Parser:
 
     def _parse_slice(self, slice: ast.expr, e: ast.expr):
         match slice:
-            case ast.slice():
+            case ast.Slice():
                 loc = self._parse_location(e)
                 raise  FPyParserError(loc, 'Slices unsupported', e, slice)
             case ast.Tuple():
@@ -379,13 +379,14 @@ class Parser:
                 return [self._parse_expr(slice)]
 
     def _parse_subscript(self, e: ast.Subscript):
-        value = self._parse_expr(e.value)
-        slices = self._parse_slice(e.slice, e)
-        while isinstance(value, TupleRef):
-            v_value, v_slices = value.value, value.slices
-            value = v_value
-            slices = v_slices + slices
-        return (value, slices)
+        # value = self._parse_expr(e.value)
+        # slices = self._parse_slice(e.slice, e)
+        raise NotImplementedError(ast.dump(e))
+        # while isinstance(value, TupleRef):
+        #     v_value, v_slices = value.value, value.index
+        #     value = v_value
+        #     slices = v_slices + slices
+        # return (value, slices)
 
     def _is_foreign_val(self, e: ast.expr):
         match e:

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -118,7 +118,7 @@ class _EvalCtx:
     """rounding context for evaluation"""
 
 
-class _Interpreter(DefaultVisitor):
+class _Interpreter(Visitor):
     """Single-use interpreter for a function"""
 
     foreign: ForeignEnv
@@ -447,6 +447,9 @@ class _Interpreter(DefaultVisitor):
         if not idx.is_integer():
             raise TypeError(f'expected an integer index, got {idx}')
         return arr[int(idx)]
+
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: _EvalCtx):
+        raise NotImplementedError(e)
 
     def _visit_tuple_set(self, e: TupleSet, ctx: _EvalCtx):
         value = self._visit_expr(e.array, ctx)

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -543,6 +543,8 @@ class _Interpreter(DefaultVisitor):
                 raise TypeError(f'expected an integer slice, got {val}')
             slices.append(int(val))
 
+        print(slices)
+
         # evaluate and update array
         val = self._visit_expr(stmt.expr, ctx)
         array[slices] = val

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -437,20 +437,16 @@ class _Interpreter(DefaultVisitor):
         return NDArray([self._visit_expr(x, ctx) for x in e.args])
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: _EvalCtx):
-        value = self._visit_expr(e.value, ctx)
-        if not isinstance(value, NDArray):
-            raise TypeError(f'expected a tensor, got {value}')
+        arr = self._visit_expr(e.value, ctx)
+        if not isinstance(arr, NDArray):
+            raise TypeError(f'expected a tensor, got {arr}')
 
-        slices: list[int] = []
-        for s in e.slices:
-            val = self._visit_expr(s, ctx)
-            if not isinstance(val, Float):
-                raise TypeError(f'expected a real number slice, got {val}')
-            if not val.is_integer():
-                raise TypeError(f'expected an integer slice, got {val}')
-            slices.append(int(val))
-
-        return value[slices]
+        idx = self._visit_expr(e.index, ctx)
+        if not isinstance(idx, Float):
+            raise TypeError(f'expected a real number index, got {idx}')
+        if not idx.is_integer():
+            raise TypeError(f'expected an integer index, got {idx}')
+        return arr[int(idx)]
 
     def _visit_tuple_set(self, e: TupleSet, ctx: _EvalCtx):
         value = self._visit_expr(e.array, ctx)

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -416,6 +416,9 @@ class _Interpreter(Visitor):
             raise TypeError(f'expected an integer index, got {idx}')
         return arr[int(idx)]
 
+    def _visit_tuple_slice(self, e: TupleSlice, ctx: _EvalCtx):
+        raise NotImplementedError(e)
+
     def _visit_tuple_set(self, e: TupleSet, ctx: _EvalCtx):
         raise NotImplementedError
 

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -405,20 +405,16 @@ class _Interpreter(Visitor):
         return list([self._visit_expr(x, ctx) for x in e.args])
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: _EvalCtx):
-        value = self._visit_expr(e.value, ctx)
-        if not isinstance(value, list):
-            raise TypeError(f'expected a tensor, got {value}')
+        arr = self._visit_expr(e.value, ctx)
+        if not isinstance(arr, list):
+            raise TypeError(f'expected a tensor, got {arr}')
 
-        elt = value
-        for s in e.slices:
-            val = self._visit_expr(s, ctx)
-            if not isinstance(val, float):
-                raise TypeError(f'expected a real number slice, got {val}')
-            if not val.is_integer():
-                raise TypeError(f'expected an integer slice, got {val}')
-            elt = elt[int(val)]
-
-        return elt
+        idx = self._visit_expr(e.index, ctx)
+        if not isinstance(idx, float):
+            raise TypeError(f'expected a real number index, got {idx}')
+        if not idx.is_integer():
+            raise TypeError(f'expected an integer index, got {idx}')
+        return arr[int(idx)]
 
     def _visit_tuple_set(self, e: TupleSet, ctx: _EvalCtx):
         raise NotImplementedError

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -443,6 +443,9 @@ class _Interpreter(Visitor):
 
         return arr[start:stop]
 
+    def _visit_tuple_set(self, e: TupleSet, ctx: _EvalCtx):
+        raise NotImplementedError(e)
+
     def _apply_comp(
         self,
         bindings: list[tuple[Id | TupleBinding, Expr]],

--- a/fpy2/interpret/native.py
+++ b/fpy2/interpret/native.py
@@ -417,10 +417,31 @@ class _Interpreter(Visitor):
         return arr[int(idx)]
 
     def _visit_tuple_slice(self, e: TupleSlice, ctx: _EvalCtx):
-        raise NotImplementedError(e)
+        arr = self._visit_expr(e.value, ctx)
+        if not isinstance(arr, list):
+            raise TypeError(f'expected a tensor, got {arr}')
 
-    def _visit_tuple_set(self, e: TupleSet, ctx: _EvalCtx):
-        raise NotImplementedError
+        if e.start is None:
+            start = 0
+        else:
+            val = self._visit_expr(e.start, ctx)
+            if not isinstance(val, float):
+                raise TypeError(f'expected a real number start index, got {val}')
+            if not val.is_integer():
+                raise TypeError(f'expected an integer start index, got {val}')
+            start = int(val)
+
+        if e.stop is None:
+            stop = len(arr)
+        else:
+            val = self._visit_expr(e.stop, ctx)
+            if not isinstance(val, float):
+                raise TypeError(f'expected a real number stop index, got {val}')
+            if not val.is_integer():
+                raise TypeError(f'expected an integer stop index, got {val}')
+            stop = int(val)
+
+        return arr[start:stop]
 
     def _apply_comp(
         self,

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -212,11 +212,8 @@ class _MatcherInst(Visitor):
             self._visit_expr(c1, c2)
 
     def _visit_tuple_ref(self, e: TupleRef, pat: TupleRef):
-        if len(e.slices) != len(pat.slices):
-            raise _MatchFailure(f'matching {pat} against {e}')
         self._visit_expr(e.value, pat.value)
-        for s1, s2 in zip(e.slices, pat.slices):
-            self._visit_expr(s1, s2)
+        self._visit_expr(e.index, pat.index)
 
     def _visit_tuple_set(self, e: TupleSet, pat: TupleSet):
         if len(e.slices) != len(pat.slices):

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -215,6 +215,23 @@ class _MatcherInst(Visitor):
         self._visit_expr(e.value, pat.value)
         self._visit_expr(e.index, pat.index)
 
+    def _visit_tuple_slice(self, e: TupleSlice, pat: TupleSlice):
+        self._visit_expr(e.value, pat.value)
+        match e.start, pat.start:
+            case None, None:
+                pass
+            case Expr(), Expr():
+                self._visit_expr(e.start, pat.start)
+            case _:
+                raise _MatchFailure(f'matching {pat} against {e}')
+        match e.stop, pat.stop:
+            case None, None:
+                pass
+            case Expr(), Expr():
+                self._visit_expr(e.stop, pat.stop)
+            case _:
+                raise _MatchFailure(f'matching {pat} against {e}')
+
     def _visit_tuple_set(self, e: TupleSet, pat: TupleSet):
         if len(e.slices) != len(pat.slices):
             raise _MatchFailure(f'matching {pat} against {e}')

--- a/fpy2/transform/if_bundling.py
+++ b/fpy2/transform/if_bundling.py
@@ -71,7 +71,7 @@ class _IfBundlingInstance(DefaultTransformVisitor):
             stmts.append(s)
 
             # apply substitution to the condition
-            cond_ctx = { var: TupleRef(Var(t, None), (Integer(i, None),), None) for i, var in enumerate(mutated) }
+            cond_ctx = { var: TupleRef(Var(t, None), Integer(i, None), None) for i, var in enumerate(mutated) }
             cond = self._visit_expr(stmt.cond, cond_ctx)
 
             # compile the body and apply the renaming
@@ -170,7 +170,7 @@ class _IfBundlingInstance(DefaultTransformVisitor):
             stmts.append(s)
 
             # apply substitution to the condition
-            cond_ctx = { var: TupleRef(Var(t, None), (Integer(i, None),), None) for i, var in enumerate(mutated) }
+            cond_ctx = { var: TupleRef(Var(t, None), Integer(i, None), None) for i, var in enumerate(mutated) }
             cond = self._visit_expr(stmt.cond, cond_ctx)
 
             # unpack the tuple at the start of each body

--- a/fpy2/transform/while_bundling.py
+++ b/fpy2/transform/while_bundling.py
@@ -72,7 +72,7 @@ class _WhileBundlingInstance(DefaultTransformVisitor):
             stmts.append(s)
 
             # apply substitution to the condition
-            cond_ctx = { var: TupleRef(Var(t, None), (Integer(i, None),), None) for i, var in enumerate(mutated) }
+            cond_ctx = { var: TupleRef(Var(t, None), Integer(i, None), None) for i, var in enumerate(mutated) }
             cond = self._visit_expr(stmt.cond, cond_ctx)
 
             # compile the body and apply the renaming

--- a/tests/infra/unit/defs.py
+++ b/tests/infra/unit/defs.py
@@ -214,28 +214,33 @@ def test_list_comp2():
 def test_list_comp3():
     return [x + y for x, y in zip([0, 1, 2], [3, 4, 5])]
 
-@fpy(name='Test list ref (1/5)')
+@fpy(name='Test list ref (1/6)')
 def test_list_ref1():
     x = [1.0, 2.0, 3.0]
     return x[0]
 
-@fpy(name='Test list ref (2/5)')
+@fpy(name='Test list ref (2/6)')
 def test_list_ref2():
     x = [[1.0, 2.0, 3.0]]
     return x[0][0]
 
-@fpy(name='Test list ref (3/5)')
+@fpy(name='Test list ref (3/6)')
 def test_list_ref3():
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    return x[:]
+
+@fpy(name='Test list ref (4/6)')
+def test_list_ref4():
     x = [1.0, 2.0, 3.0, 4.0, 5.0]
     return x[1:]
 
-@fpy(name='Test list ref (4/5)')
-def test_list_ref4():
+@fpy(name='Test list ref (5/6)')
+def test_list_ref5():
     x = [1.0, 2.0, 3.0, 4.0, 5.0]
     return x[:3]
 
-@fpy(name='Test list ref (5/5)')
-def test_list_ref5():
+@fpy(name='Test list ref (6/6)')
+def test_list_ref6():
     x = [1.0, 2.0, 3.0, 4.0, 5.0]
     return x[1:3]
 
@@ -609,6 +614,7 @@ tests = [
     test_list_ref3,
     test_list_ref4,
     test_list_ref5,
+    test_list_ref6,
     test_list_set1,
     test_list_set2,
     test_list_set3,

--- a/tests/infra/unit/defs.py
+++ b/tests/infra/unit/defs.py
@@ -224,11 +224,6 @@ def test_list_ref2():
     x = [[1.0, 2.0, 3.0]]
     return x[0][0]
 
-@fpy(name='Test list ref (3/3)')
-def test_list_ref3():
-    x = [[1.0, 2.0], [3.0, 4.0]]
-    return x[0, 1]
-
 @fpy(name='Test list set (1/3)')
 def test_list_set1():
     x = [1.0, 2.0, 3.0]
@@ -596,7 +591,6 @@ tests = [
     test_list_comp3,
     test_list_ref1,
     test_list_ref2,
-    test_list_ref3,
     test_list_set1,
     test_list_set2,
     test_list_set3,

--- a/tests/infra/unit/defs.py
+++ b/tests/infra/unit/defs.py
@@ -214,15 +214,30 @@ def test_list_comp2():
 def test_list_comp3():
     return [x + y for x, y in zip([0, 1, 2], [3, 4, 5])]
 
-@fpy(name='Test list ref (1/3)')
+@fpy(name='Test list ref (1/5)')
 def test_list_ref1():
     x = [1.0, 2.0, 3.0]
     return x[0]
 
-@fpy(name='Test list ref (2/3)')
+@fpy(name='Test list ref (2/5)')
 def test_list_ref2():
     x = [[1.0, 2.0, 3.0]]
     return x[0][0]
+
+@fpy(name='Test list ref (3/5)')
+def test_list_ref3():
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    return x[1:]
+
+@fpy(name='Test list ref (4/5)')
+def test_list_ref4():
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    return x[:3]
+
+@fpy(name='Test list ref (5/5)')
+def test_list_ref5():
+    x = [1.0, 2.0, 3.0, 4.0, 5.0]
+    return x[1:3]
 
 @fpy(name='Test list set (1/3)')
 def test_list_set1():
@@ -591,6 +606,9 @@ tests = [
     test_list_comp3,
     test_list_ref1,
     test_list_ref2,
+    test_list_ref3,
+    test_list_ref4,
+    test_list_ref5,
     test_list_set1,
     test_list_set2,
     test_list_set3,


### PR DESCRIPTION
This PR adds support for array slicing, e.g., `x[1:3]`, and removes NumPy style indexing, e.g., `x[1, 2]`.