### PR TITLE
Cleanup and release v0.0.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,8 @@
    - support Python-style slicing
    - function identifiers are resolved to the objects they map to in Python
    - FPy builtins are objects
+   - cannot call arbitrary Python functions
+   - renamed `@fpy_prim` to `@fpy_primitive`
 
 ### Fixes
  - Numbers library

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,19 @@
 # Version History
 
+## [0.0.5] - 2025-07-02
+### Features
+ - Frontend
+   - support for `enumerate`
+   - remove support for `shape`
+   - support Python-style slicing
+   - function identifiers are resolved to the objects they map to in Python
+   - FPy builtins are objects
+
+### Fixes
+ - Numbers library
+   - removed `__round__` (and friends) from `RealFloat
+   - fixed `round()` for `MPFloatContext` and `MPSFloatContext`
+
 ## [0.0.4] - 2025-06-12
 ### Features
  - Numbers library

--- a/fpy2/__init__.py
+++ b/fpy2/__init__.py
@@ -57,7 +57,7 @@ from .ops import *
 
 from .fpc_context import FPCoreContext, NoSuchContextError
 
-from .decorator import fpy, pattern, fpy_prim
+from .decorator import fpy, pattern, fpy_primitive
 
 from .backend import (
     Backend,

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -1155,7 +1155,7 @@ class StmtBlock(Ast):
     """FPy AST: list of statements"""
     stmts: list[Stmt]
 
-    def __init__(self, stmts: list[Stmt]):
+    def __init__(self, stmts: Sequence[Stmt]):
         if stmts == []:
             loc = None
         else:
@@ -1173,7 +1173,7 @@ class StmtBlock(Ast):
                 )
 
         super().__init__(loc)
-        self.stmts = stmts
+        self.stmts = list(stmts)
 
     def is_equiv(self, other):
         return (

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -1155,7 +1155,7 @@ class StmtBlock(Ast):
     """FPy AST: list of statements"""
     stmts: list[Stmt]
 
-    def __init__(self, stmts: Sequence[Stmt]):
+    def __init__(self, stmts: list[Stmt]):
         if stmts == []:
             loc = None
         else:
@@ -1173,7 +1173,7 @@ class StmtBlock(Ast):
                 )
 
         super().__init__(loc)
-        self.stmts = list(stmts)
+        self.stmts = stmts
 
     def is_equiv(self, other):
         return (

--- a/fpy2/decorator.py
+++ b/fpy2/decorator.py
@@ -31,11 +31,11 @@ R = TypeVar('R')
 # @fpy decorator
 
 @overload
-def fpy(func: Callable[P, R]) -> Function:
+def fpy(func: Callable[P, R]) -> Function[P, R]:
     ...
 
 @overload
-def fpy(**kwargs) -> Callable[[Callable[P, R]], Function]:
+def fpy(**kwargs) -> Callable[[Callable[P, R]], Function[P, R]]:
     ...
 
 def fpy(
@@ -77,14 +77,14 @@ def pattern(func: Callable[P, R]):
         return StmtPattern(fn.ast)
 
 ############################################################
-# @fpy_prim decorator
+# @fpy_primitive decorator
 
 @overload
-def fpy_primitive(func: Callable[P, R]) -> Primitive:
+def fpy_primitive(func: Callable[P, R]) -> Primitive[P, R]:
     ...
 
 @overload
-def fpy_primitive(**kwargs) -> Callable[[Callable[P, R]], Primitive]:
+def fpy_primitive(**kwargs) -> Callable[[Callable[P, R]], Primitive[P, R]]:
     ...
 
 def fpy_primitive(

--- a/fpy2/decorator.py
+++ b/fpy2/decorator.py
@@ -80,14 +80,14 @@ def pattern(func: Callable[P, R]):
 # @fpy_prim decorator
 
 @overload
-def fpy_prim(func: Callable[P, R]) -> Primitive:
+def fpy_primitive(func: Callable[P, R]) -> Primitive:
     ...
 
 @overload
-def fpy_prim(**kwargs) -> Callable[[Callable[P, R]], Primitive]:
+def fpy_primitive(**kwargs) -> Callable[[Callable[P, R]], Primitive]:
     ...
 
-def fpy_prim(
+def fpy_primitive(
     func: Optional[Callable[P, R]] = None,
     **kwargs
 ):

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -214,15 +214,22 @@ class Parser:
                     raise FPyParserError(loc, f'name \'{ident.base}\' not defined:', ann)
                 ty = self.env[ident.base]
             case _:
-                raise RuntimeError('unreachable')
+                # TODO: implement
+                return AnyTypeAnn(loc)
 
-        if ty == bool:
-            return BoolTypeAnn(loc)
-        elif ty == int or ty == float:
-            # TODO: more specific type
+        if ty == Real:
             return RealTypeAnn(loc)
-        elif ty == Float or ty == Real:
-            return RealTypeAnn(loc)
+        elif isinstance(ty, type):
+            if issubclass(ty, bool):
+                return BoolTypeAnn(loc)
+            elif issubclass(ty, int) or issubclass(ty, float):
+                # TODO: more specific type
+                return RealTypeAnn(loc)
+            elif issubclass(ty, Float):
+                return RealTypeAnn(loc)
+            else:
+                # TODO: implement
+                return AnyTypeAnn(loc)
         else:
             # TODO: implement
             return AnyTypeAnn(loc)
@@ -443,6 +450,11 @@ class Parser:
             return self._parse_hexfloat(e, func)
         elif fn == digits:
             return self._parse_digits(e, func)
+        elif fn == len:
+            if len(e.args) != 1:
+                raise FPyParserError(loc, 'FPy expects 1 argument for `len`', e)
+            arg = self._parse_expr(e.args[0])
+            return Size(func, arg, Integer(0, None), loc)
         else:
             args = [self._parse_expr(arg) for arg in e.args]
             return Call(func, fn, args, loc)

--- a/fpy2/function.py
+++ b/fpy2/function.py
@@ -1,6 +1,6 @@
 """FPy functions are the result of `@fpy` decorators."""
 
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import Callable, Generic, Optional, ParamSpec, TypeVar, TYPE_CHECKING
 from titanfp.fpbench.fpcast import FPCore
 from . import ast as fpyast
 
@@ -12,8 +12,11 @@ from .number import Context
 if TYPE_CHECKING:
     from .interpret import Interpreter
 
+P = ParamSpec('P')
+R = TypeVar('R')
 
-class Function:
+
+class Function(Generic[P, R]):
     """
     FPy function.
 
@@ -24,7 +27,7 @@ class Function:
     env: ForeignEnv
     runtime: Optional['Interpreter']
 
-    _func: Optional[Callable]
+    _func: Optional[Callable[P, R]]
     """original native function"""
 
     def __init__(
@@ -32,7 +35,7 @@ class Function:
         ast: fpyast.FuncDef,
         env: ForeignEnv,
         runtime: Optional['Interpreter'] = None,
-        func: Optional[Callable] = None
+        func: Optional[Callable[P, R]] = None
     ):
         self.ast = ast
         self.env = env
@@ -46,7 +49,7 @@ class Function:
     def __str__(self):
         return self.ast.format()
 
-    def __call__(self, *args, ctx: Optional[Context] = None):
+    def __call__(self, *args, ctx: Optional[Context] = None) -> R:
         fn = get_default_function_call()
         return fn(self, *args, ctx=ctx)
 

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -410,9 +410,13 @@ class _Interpreter(Visitor):
                 return fn(*args, ctx=ctx.round_ctx)
             case _:
                 # calling foreign function
-                if not callable(fn):
-                    raise RuntimeError(f'unknown function {e.func}')
-                return fn(*args)
+                # only `print` is allowed
+                if fn == print:
+                    fn(*args)
+                    # TODO: should we allow `None` to return
+                    return None
+                else:
+                    raise RuntimeError(f'attempting to call a Python function: `{fn}` at `{e.format()}`')
 
     def _apply_cmp2(self, op: CompareOp, lhs, rhs):
         match op:

--- a/fpy2/libraries/core.py
+++ b/fpy2/libraries/core.py
@@ -4,7 +4,7 @@ Core numerical functions.
 
 from fpy2 import *
 
-@fpy_prim
+@fpy_primitive
 def split(x: Float, n: Float):
     """
     Splits `x` into two parts:
@@ -52,7 +52,7 @@ def _modf_spec(x: Real) -> tuple[Real, Real]:
 
     return ret
 
-@fpy_prim(spec=_modf_spec)
+@fpy_primitive(spec=_modf_spec)
 def modf(x: Float) -> tuple[Float, Float]:
     """
     Decomposes `x` into its integral and fractional parts.
@@ -93,7 +93,7 @@ def _logb_spec(x: Real):
     """
     return floor(log2(abs(x)))
 
-@fpy_prim(spec=_logb_spec)
+@fpy_primitive(spec=_logb_spec)
 def logb(x: Float, ctx: Context):
     """
     Returns the normalized exponent of `x`.
@@ -135,7 +135,7 @@ def _ldexp_spec(x: Real, n: Real) -> Real:
 
     return ret
 
-@fpy_prim(spec=_ldexp_spec)
+@fpy_primitive(spec=_ldexp_spec)
 def ldexp(x: Float, n: Float, ctx: Context) -> Float:
     """
     Computes `x * 2**n` with correct rounding.
@@ -158,7 +158,7 @@ def ldexp(x: Float, n: Float, ctx: Context) -> Float:
         scale = RealFloat.power_of_2(int(n))
         return ctx.round(xr * scale)
 
-@fpy_prim
+@fpy_primitive
 def frexp(x: Float) -> tuple[Float, Float]:
     """
     Decomposes `x` into its mantissa and exponent.

--- a/fpy2/number/ext_float.py
+++ b/fpy2/number/ext_float.py
@@ -330,10 +330,9 @@ class ExtFloatContext(EncodableContext):
             # Inf: placement of Inf depends on NaN encoding
             match self.nan_kind:
                 case ExtFloatNanKind.IEEE_754:
-                    if self.enable_inf:
-                        # usual IEEE 754 encoding
-                        ebits = bitmask(self.es)
-                        mbits = 0
+                    # usual IEEE 754 encoding
+                    ebits = bitmask(self.es)
+                    mbits = 0
                 case ExtFloatNanKind.MAX_VAL:
                     # Inf one before the maximum encoding
                     if self.pmax == 1:

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -124,7 +124,8 @@ class MPFloatContext(Context):
             return Float(ctx=self)
 
         # step 3. round value based on rounding parameters
-        return x.round(max_p=self.pmax, min_n=n, rm=self.rm)
+        xr = x.round(max_p=self.pmax, min_n=n, rm=self.rm)
+        return Float(x=xr, ctx=self)
 
     def round_params(self):
         return (self.pmax, None)

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -161,7 +161,8 @@ class MPSFloatContext(OrdinalContext):
             n = self.nmin
 
         # step 3. round value based on rounding parameters
-        return x.round(self.pmax, n, self.rm)
+        xr = x.round(self.pmax, n, self.rm)
+        return Float(x=xr, ctx=self)
 
     def _round_at(self, x, n: Optional[int]) -> Float:
         match x:

--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -318,24 +318,17 @@ class RealFloat(numbers.Rational):
         """
         return RealFloat(s=False, x=self)
 
-    def __trunc__(self):
-        return self.round(min_n=-1, rm=RoundingMode.RTZ)
+    def __trunc__(self) -> int:
+        raise NotImplementedError('do not call directly')
 
-    def __floor__(self):
-        return self.round(min_n=-1, rm=RoundingMode.RTN)
+    def __floor__(self) -> int:
+        raise NotImplementedError('do not call directly')
 
-    def __ceil__(self):
-        return self.round(min_n=-1, rm=RoundingMode.RTP)
+    def __ceil__(self) -> int:
+        raise NotImplementedError('do not call directly')
 
-    def __round__(self, ndigits=None):
-        if ndigits is not None:
-            if not isinstance(ndigits, int):
-                raise TypeError(f'Expected \'int\' for ndigits, got {type(ndigits)}')
-            if ndigits != 0:
-                raise ValueError('Non-zero ndigits not supported')
-            return self.round(max_p=ndigits, rm=RoundingMode.RNE)
-
-        return self.round(min_n=-1, rm=RoundingMode.RNE)
+    def __round__(self, ndigits=None) -> int:
+        raise NotImplementedError('do not call directly')
 
     def __floordiv__(self, other):
         raise NotImplementedError('division cannot be implemented exactly')
@@ -939,6 +932,8 @@ class RealFloat(numbers.Rational):
                 # the value is guaranteed to be a power of two
                 kept.c >>= 1
                 kept.exp += 1
+
+                assert interval_size is not None, 'interval_size is None when rounding is exact'
                 interval_size -= 1
 
         # interval direction is opposite of if we incremented

--- a/fpy2/primitive.py
+++ b/fpy2/primitive.py
@@ -5,7 +5,11 @@ from typing import Any, Callable, Generic, ParamSpec, TypeVar
 from .utils import has_keyword
 from .number import Context, FP64
 
-class Primitive():
+P = ParamSpec('P')
+R = TypeVar('R')
+
+
+class Primitive(Generic[P, R]):
     """
     FPy primitive.
 
@@ -14,11 +18,11 @@ class Primitive():
     the FPy runtime.
     """
 
-    func: Callable
+    func: Callable[..., R]
 
     metadata: dict[str, Any]
 
-    def __init__(self, func: Callable, metadata: dict[str, Any]):
+    def __init__(self, func: Callable[P, R], metadata: dict[str, Any]):
         self.func = func
         self.metadata = metadata
 

--- a/fpy2/primitive.py
+++ b/fpy2/primitive.py
@@ -1,11 +1,11 @@
 """FPy primitives are the result of `@fpy_prim` decorators."""
 
-from typing import Any, Callable
+from typing import Any, Callable, Generic, ParamSpec, TypeVar
 
 from .utils import has_keyword
 from .number import Context, FP64
 
-class Primitive:
+class Primitive():
     """
     FPy primitive.
 
@@ -15,7 +15,6 @@ class Primitive:
     """
 
     func: Callable
-    """the function implementing the primitive"""
 
     metadata: dict[str, Any]
 

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -419,7 +419,7 @@ class _StmtMatcherEngine(DefaultVisitor):
         pattern_block = self.pattern.block
         for i, stmts in enumerate(sliding_window(block.stmts, len(pattern_block.stmts))):
             # check if the pattern matches
-            m = _MatcherInst(self.pattern, StmtBlock(stmts))
+            m = _MatcherInst(self.pattern, StmtBlock(list(stmts)))
             pmatch = m.match()
             if pmatch is not None:
                 if not isinstance(pmatch, StmtMatch):

--- a/fpy2/rewrite/rewrite.py
+++ b/fpy2/rewrite/rewrite.py
@@ -115,7 +115,7 @@ class _RewriteEngine(DefaultTransformVisitor):
             try:
                 # termination guaranteed by finitely-sized iterator
                 while True:
-                    stmts = next(iterator)
+                    stmts = list(next(iterator))
                     pmatch = self.matcher.match_exact(StmtBlock(stmts))
                     if pmatch:
                         if not isinstance(pmatch, StmtMatch):

--- a/fpy2/sample/sample.py
+++ b/fpy2/sample/sample.py
@@ -89,7 +89,7 @@ def _sample_rejection_one(
         rt = DefaultInterpreter()
 
         assert 'pre' in fun.ast.metadata, 'missing precondition'
-        pre = Function(fun.ast.metadata['pre'], ForeignEnv.empty())
+        pre: Function[..., bool] = Function(fun.ast.metadata['pre'], ForeignEnv.empty())
 
         start_fuel = fuel
         while fuel > 0:


### PR DESCRIPTION
Minor cleanups:
 - rename `fpy_prim` to `fpy_primtive`
 - add typing hints for primitives and functions
 - ban calling arbitrary Python functions
 - fix parsing of type annotations