### PR TITLE
Removes `NDArray` from the runtime

### DIFF
--- a/fpy2/__init__.py
+++ b/fpy2/__init__.py
@@ -51,8 +51,6 @@ from .number import (
     SINT8, SINT16, SINT32, SINT64,
     UINT8, UINT16, UINT32, UINT64,
     Real,
-    # re-exports
-    NDArray,
 )
 
 from .ops import *

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -321,9 +321,7 @@ class _Interpreter(Visitor):
     def _apply_zip(self, args: Sequence[Expr], ctx: _EvalCtx):
         """Apply the `zip` method to the given n-ary expression."""
         if len(args) == 0:
-            # TODO: how to fix this?
-            # return NDArray([], shape=())
-            raise NotImplementedError('zip() with 0 size not supported')
+            return []
 
         # evaluate all children
         arrays: list[list] = []

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -2,10 +2,10 @@
 FPy runtime backed by the Titanic library.
 """
 
+import copy
+
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Sequence, TypeAlias
-
-from titanfp.titanic.ndarray import NDArray
 
 from .. import ops
 
@@ -21,12 +21,12 @@ from .interpreter import Interpreter, FunctionReturnException
 
 ScalarVal: TypeAlias = bool | Float
 """Type of scalar values in FPy programs."""
-TensorVal: TypeAlias = NDArray
+TensorVal: TypeAlias = list
 """Type of tensor values in FPy programs."""
 
 ScalarArg: TypeAlias = ScalarVal | str | int | float
 """Type of scalar arguments in FPy programs; includes native Python types"""
-TensorArg: TypeAlias = NDArray | tuple | list
+TensorArg: TypeAlias = tuple | list
 """Type of tensor arguments in FPy programs; includes native Python types"""
 
 def _isfinite(x: Float, ctx: Context) -> bool:
@@ -153,7 +153,7 @@ class _Interpreter(Visitor):
             case Float():
                 return arg
             case tuple() | list():
-                return NDArray([self._arg_to_value(x) for x in arg])
+                return [self._arg_to_value(x) for x in arg]
             case _:
                 return arg
 
@@ -188,7 +188,7 @@ class _Interpreter(Visitor):
                 case TensorTypeAnn():
                     # TODO: check shape
                     x = self._arg_to_value(val)
-                    if not isinstance(x, NDArray):
+                    if not isinstance(x, list):
                         raise NotImplementedError(f'argument is a tensor, got data {val}')
                     if isinstance(arg.name, NamedId):
                         eval_ctx.env[arg.name] = x
@@ -290,38 +290,33 @@ class _Interpreter(Visitor):
         if not stop.is_integer():
             raise TypeError(f'expected an integer argument, got {stop}')
         n = int(stop)
-
-        elts: list[Float] = []
-        for i in range(n):
-            elts.append(Float.from_int(i, ctx=ctx.round_ctx))
-        return NDArray(elts, shape=(n,))
+        return [Float.from_int(i, ctx=ctx.round_ctx) for i in range(n)]
 
     def _apply_dim(self, arg: Expr, ctx: _EvalCtx):
         v = self._visit_expr(arg, ctx)
-        if not isinstance(v, NDArray):
+        if not isinstance(v, list):
             raise TypeError(f'expected a tensor, got {v}')
-        return Float.from_int(len(v.shape), ctx=ctx.round_ctx)
+        return ops.dim(v, ctx.round_ctx)
 
     def _apply_enumerate(self, arg: Expr, ctx: _EvalCtx):
         v = self._visit_expr(arg, ctx)
-        if not isinstance(v, NDArray):
+        if not isinstance(v, list):
             raise TypeError(f'expected a tensor, got {v}')
-
-        elts: list[NDArray] = []
-        for i, val in enumerate(v):
-            elts.append(NDArray([Float.from_int(i, ctx=ctx.round_ctx), val], shape=(2,)))
-        return NDArray(elts, shape=(len(elts),))
+        return [
+            [Float.from_int(i, ctx=ctx.round_ctx), val]
+            for i, val in enumerate(v)
+        ]
 
     def _apply_size(self, arr: Expr, idx: Expr, ctx: _EvalCtx):
         v = self._visit_expr(arr, ctx)
-        if not isinstance(v, NDArray):
+        if not isinstance(v, list):
             raise TypeError(f'expected a tensor, got {v}')
         dim = self._visit_expr(idx, ctx)
         if not isinstance(dim, Float):
             raise TypeError(f'expected a real number argument, got {dim}')
         if not dim.is_integer():
             raise TypeError(f'expected an integer argument, got {dim}')
-        return Float.from_int(v.shape[int(dim)], ctx=ctx.round_ctx)
+        return ops.size(v, dim, ctx.round_ctx)
 
     def _apply_zip(self, args: Sequence[Expr], ctx: _EvalCtx):
         """Apply the `zip` method to the given n-ary expression."""
@@ -331,15 +326,15 @@ class _Interpreter(Visitor):
             raise NotImplementedError('zip() with 0 size not supported')
 
         # evaluate all children
-        arrays: list[NDArray] = []
+        arrays: list[list] = []
         for arg in args:
             val = self._visit_expr(arg, ctx)
-            if not isinstance(val, NDArray):
+            if not isinstance(val, list):
                 raise TypeError(f'expected a tensor argument, got {val}')
             arrays.append(val)
 
         # zip the arrays
-        return NDArray(zip(*arrays))
+        return list(zip(*arrays))
 
     def _visit_unaryop(self, e: UnaryOp, ctx: _EvalCtx):
         fn = _unary_table.get(type(e))
@@ -444,11 +439,11 @@ class _Interpreter(Visitor):
         return True
 
     def _visit_tuple_expr(self, e: TupleExpr, ctx: _EvalCtx):
-        return NDArray([self._visit_expr(x, ctx) for x in e.args])
+        return [self._visit_expr(x, ctx) for x in e.args]
 
     def _visit_tuple_ref(self, e: TupleRef, ctx: _EvalCtx):
         arr = self._visit_expr(e.value, ctx)
-        if not isinstance(arr, NDArray):
+        if not isinstance(arr, list):
             raise TypeError(f'expected a tensor, got {arr}')
 
         idx = self._visit_expr(e.index, ctx)
@@ -460,7 +455,7 @@ class _Interpreter(Visitor):
 
     def _visit_tuple_slice(self, e: TupleSlice, ctx: _EvalCtx):
         arr = self._visit_expr(e.value, ctx)
-        if not isinstance(arr, NDArray):
+        if not isinstance(arr, list):
             raise TypeError(f'expected a tensor, got {arr}')
 
         if e.start is None:
@@ -484,19 +479,16 @@ class _Interpreter(Visitor):
             stop = int(val)
 
         if start < 0 or stop > len(arr):
-            return NDArray([])  # empty slice
+            return []
         else:
-            sliced: list = []
-            for i in range(start, stop):
-                sliced.append(arr[i])
-            return NDArray(sliced)
+            return [arr[i] for i in range(start, stop)]
 
     def _visit_tuple_set(self, e: TupleSet, ctx: _EvalCtx):
         value = self._visit_expr(e.array, ctx)
-        if not isinstance(value, NDArray):
+        if not isinstance(value, list):
             raise TypeError(f'expected a tensor, got {value}')
-        value = NDArray(value) # make a copy
 
+        array = copy.deepcopy(value) # make a copy
         slices: list[int] = []
         for s in e.slices:
             val = self._visit_expr(s, ctx)
@@ -507,8 +499,14 @@ class _Interpreter(Visitor):
             slices.append(int(val))
 
         val = self._visit_expr(e.value, ctx)
-        value[slices] = val
-        return value
+        for idx in slices[:-1]:
+            if not isinstance(array, list):
+                raise TypeError(f'index {idx} is out of bounds for `{array}`')
+            array = array[idx]
+
+        array[slices[-1]] = val
+        return array
+
 
     def _apply_comp(
         self,
@@ -522,7 +520,7 @@ class _Interpreter(Visitor):
         else:
             target, iterable = bindings[0]
             array = self._visit_expr(iterable, ctx)
-            if not isinstance(array, NDArray):
+            if not isinstance(array, list):
                 raise TypeError(f'expected a tensor, got {array}')
             for val in array:
                 match target:
@@ -542,7 +540,7 @@ class _Interpreter(Visitor):
         for target in e.targets:
             for name in target.names():
                 del ctx.env[name]
-        return NDArray(elts)
+        return elts
 
     def _visit_if_expr(self, e: IfExpr, ctx: _EvalCtx):
         cond = self._visit_expr(e.cond, ctx)
@@ -550,7 +548,7 @@ class _Interpreter(Visitor):
             raise TypeError(f'expected a boolean, got {cond}')
         return self._visit_expr(e.ift if cond else e.iff, ctx)
 
-    def _unpack_tuple(self, binding: TupleBinding, val: NDArray, ctx: _EvalCtx) -> None:
+    def _unpack_tuple(self, binding: TupleBinding, val: list, ctx: _EvalCtx) -> None:
         if len(binding.elts) != len(val):
             raise NotImplementedError(f'unpacking {len(val)} values into {len(binding.elts)}')
         for elt, v in zip(binding.elts, val):
@@ -588,7 +586,11 @@ class _Interpreter(Visitor):
 
         # evaluate and update array
         val = self._visit_expr(stmt.expr, ctx)
-        array[slices] = val
+        for idx in slices[:-1]:
+            if not isinstance(array, list):
+                raise TypeError(f'index {idx} is out of bounds for `{array}`')
+            array = array[idx]
+        array[slices[-1]] = val
 
     def _visit_if1(self, stmt: If1Stmt, ctx: _EvalCtx):
         cond = self._visit_expr(stmt.cond, ctx)
@@ -639,7 +641,7 @@ class _Interpreter(Visitor):
     def _visit_for(self, stmt: ForStmt, ctx: _EvalCtx) -> None:
         # evaluate the iterable data
         iterable = self._visit_expr(stmt.iterable, ctx)
-        if not isinstance(iterable, NDArray):
+        if not isinstance(iterable, list):
             raise TypeError(f'expected a tensor, got {iterable}')
         # iterate over each element
         for val in iterable:
@@ -754,8 +756,8 @@ class DefaultInterpreter(Interpreter):
 
     Values:
      - booleans are Python `bool` values,
-     - real numbers are FPy `float` values,
-     - tensors are Titanic `NDArray` values.
+     - real numbers are FPy `Float` values,
+     - tensors are Python `list` values.
 
     All operations are correctly-rounded.
     """

--- a/fpy2/libraries/core.py
+++ b/fpy2/libraries/core.py
@@ -33,12 +33,12 @@ def split(x: Float, n: Float):
         raise ValueError("n must be an integer")
 
     if x.isnan:
-        return NDArray((Float(isnan=True, ctx=x.ctx), Float(isnan=True, ctx=x.ctx)))
+        return [Float(isnan=True, ctx=x.ctx), Float(isnan=True, ctx=x.ctx)]
     elif x.isinf:
-        return NDArray((Float(s=x.s, isinf=True, ctx=x.ctx), Float(s=x.s, isinf=True, ctx=x.ctx)))
+        return [Float(s=x.s, isinf=True, ctx=x.ctx), Float(s=x.s, isinf=True, ctx=x.ctx)]
     else:
         hi, lo = x.as_real().split(int(n))
-        return NDArray((Float.from_real(hi, ctx=x.ctx), Float.from_real(lo, ctx=x.ctx)))
+        return [Float.from_real(hi, ctx=x.ctx), Float.from_real(lo, ctx=x.ctx)]
 
 @fpy
 def _modf_spec(x: Real) -> tuple[Real, Real]:
@@ -63,7 +63,7 @@ def _modf_spec(x: Real) -> tuple[Real, Real]:
     return ret
 
 @fpy_primitive(spec=_modf_spec)
-def modf(x: Float) -> tuple[Float, Float]:
+def modf(x: Float):
     """
     Decomposes `x` into its integral and fractional parts.
     The operation is performed exactly.
@@ -74,14 +74,14 @@ def modf(x: Float) -> tuple[Float, Float]:
     - if `x` is NaN, the result is `(NaN, NaN)`
     """
     if x.isnan:
-        return NDArray((Float(x=x, ctx=x.ctx), Float(x=x, ctx=x.ctx)))
+        return [Float(x=x, ctx=x.ctx), Float(x=x, ctx=x.ctx)]
     elif x.isinf:
-        return NDArray((Float(s=x.s, ctx=x.ctx), Float(s=x.s, isinf=True, ctx=x.ctx)))
+        return [Float(s=x.s, ctx=x.ctx), Float(s=x.s, isinf=True, ctx=x.ctx)]
     elif x.is_zero():
-        return NDArray((Float(s=x.s, ctx=x.ctx), Float(s=x.s, ctx=x.ctx)))
+        return [(Float(s=x.s, ctx=x.ctx), Float(s=x.s, ctx=x.ctx))]
     else:
         hi, lo = x.as_real().split(-1)
-        return NDArray((Float.from_real(hi, ctx=x.ctx), Float.from_real(lo, ctx=x.ctx)))
+        return [Float.from_real(hi, ctx=x.ctx), Float.from_real(lo, ctx=x.ctx)]
 
 @fpy
 def isinteger(x: Real) -> bool:

--- a/fpy2/libraries/core.py
+++ b/fpy2/libraries/core.py
@@ -78,7 +78,7 @@ def modf(x: Float):
     elif x.isinf:
         return [Float(s=x.s, ctx=x.ctx), Float(s=x.s, isinf=True, ctx=x.ctx)]
     elif x.is_zero():
-        return [(Float(s=x.s, ctx=x.ctx), Float(s=x.s, ctx=x.ctx))]
+        return [Float(s=x.s, ctx=x.ctx), Float(s=x.s, ctx=x.ctx)]
     else:
         hi, lo = x.as_real().split(-1)
         return [Float.from_real(hi, ctx=x.ctx), Float.from_real(lo, ctx=x.ctx)]

--- a/fpy2/number/__init__.py
+++ b/fpy2/number/__init__.py
@@ -22,11 +22,6 @@ from .round import RoundingMode, RoundingDirection
 from .native import default_float_convert, default_str_convert
 
 ###########################################################
-# Re-exports
-
-from titanfp.titanic.ndarray import NDArray
-
-###########################################################
 # Type aliases
 
 RM: TypeAlias = RoundingMode

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -603,7 +603,7 @@ def signbit(x: Real) -> bool:
 # Tensor
 # TODO: should these be implemented
 
-def dim(x: list | tuple, ctx: Optional[Context] = None) -> int:
+def dim(x: list | tuple, ctx: Optional[Context] = None):
     """
     Returns the number of dimensions of the tensor `x`.
 
@@ -613,19 +613,20 @@ def dim(x: list | tuple, ctx: Optional[Context] = None) -> int:
     while isinstance(x, (list, tuple)):
         dim += 1
         x = x[0]
-    return dim
+    return Float.from_int(dim, ctx=ctx)
 
-def size(x: list | tuple, dim: Float, ctx: Optional[Context] = None) -> int:
+def size(x: list | tuple, dim: Real, ctx: Optional[Context] = None):
     """
     Returns the size of the dimension `dim` of the tensor `x`.
 
     Assumes that `x` is not a ragged tensor.
     """
+    dim = _real_to_float(dim)
     for _ in range(int(dim)):
         x = x[0]
         if not isinstance(x, (list, tuple)):
             raise ValueError(f'dimension `{dim}` is out of bounds for the tensor `{x}`')
-    return len(x)
+    return Float.from_int(len(x), ctx=ctx)
 
 #############################################################################
 # Constants

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -604,10 +604,28 @@ def signbit(x: Real) -> bool:
 # TODO: should these be implemented
 
 def dim(x: list | tuple, ctx: Optional[Context] = None) -> int:
-    raise NotImplementedError('FPy runtime: do not call directly')
+    """
+    Returns the number of dimensions of the tensor `x`.
 
-def size(x: list | tuple, idx: Float, ctx: Optional[Context] = None) -> int:
-    raise NotImplementedError('FPy runtime: do not call directly')
+    Assumes that `x` is not a ragged tensor.
+    """
+    dim = 0
+    while isinstance(x, (list, tuple)):
+        dim += 1
+        x = x[0]
+    return dim
+
+def size(x: list | tuple, dim: Float, ctx: Optional[Context] = None) -> int:
+    """
+    Returns the size of the dimension `dim` of the tensor `x`.
+
+    Assumes that `x` is not a ragged tensor.
+    """
+    for _ in range(int(dim)):
+        x = x[0]
+        if not isinstance(x, (list, tuple)):
+            raise ValueError(f'dimension `{dim}` is out of bounds for the tensor `{x}`')
+    return len(x)
 
 #############################################################################
 # Constants

--- a/tests/infra/fpbench/eval.py
+++ b/tests/infra/fpbench/eval.py
@@ -46,7 +46,7 @@ def eval(
         return
 
     # sample inputs
-    if core.inputs == []:
+    if len(core.inputs) == 0:
         inputs: list[list] = [[]]
     else:
         inputs = []
@@ -63,7 +63,7 @@ def eval(
                         if isinstance(dim, int):
                             dims.append(dim)
                         else:
-                            dims.append(3)
+                            dims.append(2)
                     def make_tensor(dims):
                         if not dims:
                             return Float.from_float(1.0, FP64)
@@ -71,13 +71,14 @@ def eval(
                     input.append(make_tensor(dims))
             inputs.append(input)
 
-    print('evaluating', core.name, 'with', len(inputs), 'inputs', end='')
+    print('evaluating', core.name, 'with', len(inputs), 'inputs', end='', flush=True)
 
     # evaluate both FPy and FPCore functions
     for input in inputs:
         # evaluate functions on point
         try:
-            fpcore = mpmf_to_fpy(rt.interpret(core, list(map(fpy_to_mpmf, input))))
+            fpcore_args = [fpy_to_mpmf(arg) for arg in input]
+            fpcore = mpmf_to_fpy(rt.interpret(core, fpcore_args))
             fpy = fun(*input)
         except NoSuchContextError:
             # TODO: implement integer contexts

--- a/tests/infra/fpbench/eval.py
+++ b/tests/infra/fpbench/eval.py
@@ -1,7 +1,6 @@
 from fpy2 import Function, ForeignEnv, Float, FP64, NoSuchContextError
 from titanfp.arithmetic.mpmf import Interpreter
 from titanfp.fpbench.fpcast import FPCore
-from titanfp.titanic.ndarray import NDArray
 
 from .fetch import fetch_cores
 from .shim import fpy_to_mpmf, mpmf_to_fpy, mpmf_interpreter, compare

--- a/tests/infra/fpbench/eval.py
+++ b/tests/infra/fpbench/eval.py
@@ -68,7 +68,7 @@ def eval(
                     def make_tensor(dims):
                         if not dims:
                             return Float.from_float(1.0, FP64)
-                        return NDArray([make_tensor(dims[1:]) for _ in range(dims[0])])
+                        return [make_tensor(dims[1:]) for _ in range(dims[0])]
                     input.append(make_tensor(dims))
             inputs.append(input)
 

--- a/tests/infra/fpbench/round_trip.py
+++ b/tests/infra/fpbench/round_trip.py
@@ -1,7 +1,6 @@
 from fpy2 import Function, ForeignEnv, Float, NoSuchContextError, FPCoreCompiler
 from titanfp.arithmetic.mpmf import Interpreter
 from titanfp.fpbench.fpcast import FPCore
-from titanfp.titanic.ndarray import NDArray
 
 from .fetch import fetch_cores, read_file
 from .shim import fpy_to_mpmf, mpmf_to_fpy, mpmf_interpreter, compare
@@ -83,7 +82,7 @@ def eval(
                     def make_tensor(dims):
                         if not dims:
                             return Float.from_float(1.0, None)
-                        return NDArray([make_tensor(dims[1:]) for _ in range(dims[0])])
+                        return [make_tensor(dims[1:]) for _ in range(dims[0])]
                     input.append(make_tensor(dims))
             inputs.append(input)
 

--- a/tests/unit/libraries/test_core.py
+++ b/tests/unit/libraries/test_core.py
@@ -13,20 +13,20 @@ class TestCore(unittest.TestCase):
         else:
             self.assertEqual(a, b, f"Expected {a} to be equal to {b}")
 
-    def assertArrayEqual(self, a: NDArray, b: NDArray):
+    def assertArrayEqual(self, a: list, b: list):
         """Assert that two arrays are equal, handling NaN and Inf"""
-        return a.shape == b.shape and all(self.assertNumEqual(x, y) for x, y in zip(a, b))
+        return len(a) == len(b) and all(self.assertNumEqual(x, y) for x, y in zip(a, b))
 
     def test_split(self):
         """Testing `split` function"""
-        self.assertArrayEqual(split(Float.from_int(0), Float.from_int(-1)), NDArray((Float.from_int(0), Float.from_int(0))))
-        self.assertArrayEqual(split(Float.from_float(-0.0), Float.from_int(-1)), NDArray((Float.from_float(-0.0), Float.from_float(-0.0))))
-        self.assertArrayEqual(split(Float.from_int(1), Float.from_int(-1)), NDArray((Float.from_int(1), Float.from_int(0))))
-        self.assertArrayEqual(split(Float.from_float(1.5), Float.from_int(-1)), NDArray((Float.from_int(1), Float.from_float(0.5))))
+        self.assertArrayEqual(split(Float.from_int(0), Float.from_int(-1)), [Float.from_int(0), Float.from_int(0)])
+        self.assertArrayEqual(split(Float.from_float(-0.0), Float.from_int(-1)), [Float.from_float(-0.0), Float.from_float(-0.0)])
+        self.assertArrayEqual(split(Float.from_int(1), Float.from_int(-1)), [Float.from_int(1), Float.from_int(0)])
+        self.assertArrayEqual(split(Float.from_float(1.5), Float.from_int(-1)), [Float.from_int(1), Float.from_float(0.5)])
 
-        self.assertArrayEqual(split(Float(isnan=True), Float.from_int(0)), NDArray((Float(isnan=True), Float(isnan=True))))
-        self.assertArrayEqual(split(Float(isinf=True), Float.from_int(0)), NDArray((Float(isinf=True), Float(isinf=True))))
-        self.assertArrayEqual(split(Float(s=True, isinf=True), Float.from_int(0)), NDArray((Float(s=True, isinf=True), Float(isinf=True, s=True))))
+        self.assertArrayEqual(split(Float(isnan=True), Float.from_int(0)), [Float(isnan=True), Float(isnan=True)])
+        self.assertArrayEqual(split(Float(isinf=True), Float.from_int(0)), [Float(isinf=True), Float(isinf=True)])
+        self.assertArrayEqual(split(Float(s=True, isinf=True), Float.from_int(0)), [Float(s=True, isinf=True), Float(isinf=True, s=True)])
 
     def test_logb(self):
         """Testing `logb` function"""
@@ -42,15 +42,15 @@ class TestCore(unittest.TestCase):
 
     def test_modf(self):
         """Testing `modf` function"""
-        self.assertArrayEqual(modf(Float.from_int(0)), NDArray((Float.from_int(0), Float.from_int(0))))
-        self.assertArrayEqual(modf(Float.from_float(-0.0)), NDArray((Float.from_float(-0.0), Float.from_float(-0.0))))
-        self.assertArrayEqual(modf(Float.from_int(1)), NDArray((Float.from_int(1), Float.from_int(0))))
-        self.assertArrayEqual(modf(Float.from_float(1.5)), NDArray((Float.from_int(1), Float.from_float(0.5))))
+        self.assertArrayEqual(modf(Float.from_int(0)), [Float.from_int(0), Float.from_int(0)])
+        self.assertArrayEqual(modf(Float.from_float(-0.0)), [Float.from_float(-0.0), Float.from_float(-0.0)])
+        self.assertArrayEqual(modf(Float.from_int(1)), [Float.from_int(1), Float.from_int(0)])
+        self.assertArrayEqual(modf(Float.from_float(1.5)), [Float.from_int(1), Float.from_float(0.5)])
 
-        self.assertArrayEqual(modf(Float(isnan=True)), NDArray((Float(isnan=True), Float(isnan=True))))
-        self.assertArrayEqual(modf(Float(isinf=True, s=True)), NDArray((Float(s=True), Float(isinf=True, s=True))))
-        self.assertArrayEqual(modf(Float(s=True, isinf=True)), NDArray((Float(s=True), Float(isinf=True, s=True))))
-        self.assertArrayEqual(modf(Float(s=False, isinf=True)), NDArray((Float(s=False), Float(isinf=True, s=False))))
+        self.assertArrayEqual(modf(Float(isnan=True)), [Float(isnan=True), Float(isnan=True)])
+        self.assertArrayEqual(modf(Float(isinf=True, s=True)), [Float(s=True), Float(isinf=True, s=True)])
+        self.assertArrayEqual(modf(Float(s=True, isinf=True)), [Float(s=True), Float(isinf=True, s=True)])
+        self.assertArrayEqual(modf(Float(s=False, isinf=True)), [Float(s=False), Float(isinf=True, s=False)])
 
     def test_ldexp(self):
         """Testing `ldexp` function"""


### PR DESCRIPTION
FPy interpreters used Titanic's `NDArray` to represent values. The `NDArray` type is not well documented, without helpful type suggestions, and likely incomplete (as suggested by `pyright`). This PR switches to the Python native list type so that FPy users will have an easier time.