### PR TITLE
Add saturation mode for floating-point contexts

### DIFF
--- a/fpy2/fpc_context.py
+++ b/fpy2/fpc_context.py
@@ -156,18 +156,18 @@ class FPCoreContext:
                     return IEEEContext(int(es), int(nbits), _round_mode_to_fpy(rnd))
                 # IEEE 754 shorthands
                 case 'binary128':
-                    return FP128.with_rm(_round_mode_to_fpy(rnd))
+                    return FP128.with_params(rm=_round_mode_to_fpy(rnd))
                 case 'binary80':
                     return IEEEContext(15, 79, _round_mode_to_fpy(rnd))
                 case 'binary64':
-                    return FP64.with_rm(_round_mode_to_fpy(rnd))
+                    return FP64.with_params(rm=_round_mode_to_fpy(rnd))
                 case 'binary32':
-                    return FP32.with_rm(_round_mode_to_fpy(rnd))
+                    return FP32.with_params(rm=_round_mode_to_fpy(rnd))
                 case 'binary16':
-                    return FP16.with_rm(_round_mode_to_fpy(rnd))
+                    return FP16.with_params(rm=_round_mode_to_fpy(rnd))
                 # integer context
                 case 'integer':
-                    return INTEGER.with_rm(_round_mode_to_fpy(rnd))
+                    return INTEGER.with_params(rm=_round_mode_to_fpy(rnd))
                 # real context
                 case 'real':
                     return RealContext()

--- a/fpy2/libraries/base.py
+++ b/fpy2/libraries/base.py
@@ -34,7 +34,7 @@ from ..number import (
     RoundingDirection, RM,
     # encoding utilities
     ExtFloatNanKind,
-    FixedOverflowKind, OV,
+    OverflowMode, OV,
     # type aliases
     REAL,
     FP256, FP128, FP64, FP32, FP16,

--- a/fpy2/libraries/base.py
+++ b/fpy2/libraries/base.py
@@ -34,7 +34,7 @@ from ..number import (
     RoundingDirection, RM,
     # encoding utilities
     ExtFloatNanKind,
-    FixedOverflowKind, OF,
+    FixedOverflowKind, OV,
     # type aliases
     REAL,
     FP256, FP128, FP64, FP32, FP16,

--- a/fpy2/number/__init__.py
+++ b/fpy2/number/__init__.py
@@ -27,7 +27,7 @@ from .native import default_float_convert, default_str_convert
 RM: TypeAlias = RoundingMode
 """alias for `RoundingMode`"""
 
-OF: TypeAlias = FixedOverflowKind
+OV: TypeAlias = FixedOverflowKind
 """alias for `FixedOverflowKind`"""
 
 ###########################################################
@@ -38,7 +38,6 @@ REAL = RealContext()
 Alias for exact computation.
 Operations are never rounded under this context.
 """
-
 
 FP256 = IEEEContext(19, 256, RM.RNE)
 """
@@ -237,7 +236,7 @@ round towards zero rounding mode.
 Numbers rounded under this context behave like Python's native `int` type.
 """
 
-SINT8 = FixedContext(True, 0, 8, RM.RTZ, OF.WRAP)
+SINT8 = FixedContext(True, 0, 8, RM.RTZ, OV.WRAP)
 """
 Alias for a signed 8-bit integer context with
 round towards zero rounding mode and wrapping overflow behavior.
@@ -245,7 +244,7 @@ round towards zero rounding mode and wrapping overflow behavior.
 Rounding infinity or NaN under this context produces an OverflowError.
 """
 
-SINT16 = FixedContext(True, 0, 16, RM.RTZ, OF.WRAP)
+SINT16 = FixedContext(True, 0, 16, RM.RTZ, OV.WRAP)
 """
 Alias for a signed 16-bit integer context with
 round towards zero rounding mode and wrapping overflow behavior.
@@ -253,7 +252,7 @@ round towards zero rounding mode and wrapping overflow behavior.
 Rounding infinity or NaN under this context produces an OverflowError.
 """
 
-SINT32 = FixedContext(True, 0, 32, RM.RTZ, OF.WRAP)
+SINT32 = FixedContext(True, 0, 32, RM.RTZ, OV.WRAP)
 """
 Alias for a signed 32-bit integer context with
 round towards zero rounding mode and wrapping overflow behavior.
@@ -261,7 +260,7 @@ round towards zero rounding mode and wrapping overflow behavior.
 Rounding infinity or NaN under this context produces an OverflowError.
 """
 
-SINT64 = FixedContext(True, 0, 64, RM.RTZ, OF.WRAP)
+SINT64 = FixedContext(True, 0, 64, RM.RTZ, OV.WRAP)
 """
 Alias for a signed 64-bit integer context with
 round towards zero rounding mode and wrapping overflow behavior.
@@ -269,7 +268,7 @@ round towards zero rounding mode and wrapping overflow behavior.
 Rounding infinity or NaN under this context produces an OverflowError.
 """
 
-UINT8 = FixedContext(False, 0, 8, RM.RTZ, OF.WRAP)
+UINT8 = FixedContext(False, 0, 8, RM.RTZ, OV.WRAP)
 """
 Alias for an unsigned 8-bit integer context with
 round towards zero rounding mode and wrapping overflow behavior.
@@ -277,7 +276,7 @@ round towards zero rounding mode and wrapping overflow behavior.
 Rounding infinity or NaN under this context produces an OverflowError.
 """
 
-UINT16 = FixedContext(False, 0, 16, RM.RTZ, OF.WRAP)
+UINT16 = FixedContext(False, 0, 16, RM.RTZ, OV.WRAP)
 """
 Alias for an unsigned 16-bit integer context with
 round towards zero rounding mode and wrapping overflow behavior.
@@ -285,7 +284,7 @@ round towards zero rounding mode and wrapping overflow behavior.
 Rounding infinity or NaN under this context produces an OverflowError.
 """
 
-UINT32 = FixedContext(False, 0, 32, RM.RTZ, OF.WRAP)
+UINT32 = FixedContext(False, 0, 32, RM.RTZ, OV.WRAP)
 """
 Alias for an unsigned 32-bit integer context with
 round towards zero rounding mode and wrapping overflow behavior.
@@ -293,7 +292,7 @@ round towards zero rounding mode and wrapping overflow behavior.
 Rounding infinity or NaN under this context produces an OverflowError.
 """
 
-UINT64 = FixedContext(False, 0, 64, RM.RTZ, OF.WRAP)
+UINT64 = FixedContext(False, 0, 64, RM.RTZ, OV.WRAP)
 """
 Alias for an unsigned 64-bit integer context with
 round towards zero rounding mode and wrapping overflow behavior.

--- a/fpy2/number/__init__.py
+++ b/fpy2/number/__init__.py
@@ -10,13 +10,13 @@ from .fixed import FixedContext
 from .ieee754 import IEEEContext
 from .mp_fixed import MPFixedContext
 from .mp_float import MPFloatContext
-from .mpb_fixed import MPBFixedContext, FixedOverflowKind
+from .mpb_fixed import MPBFixedContext
 from .mpb_float import MPBFloatContext
 from .mps_float import MPSFloatContext
 from .real import RealContext
 
 # Rounding
-from .round import RoundingMode, RoundingDirection
+from .round import RoundingMode, RoundingDirection, OverflowMode
 
 # Miscellaneous
 from .native import default_float_convert, default_str_convert
@@ -27,8 +27,8 @@ from .native import default_float_convert, default_str_convert
 RM: TypeAlias = RoundingMode
 """alias for `RoundingMode`"""
 
-OV: TypeAlias = FixedOverflowKind
-"""alias for `FixedOverflowKind`"""
+OV: TypeAlias = OverflowMode
+"""alias for `OverflowMode`"""
 
 ###########################################################
 # Format aliases

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -39,8 +39,8 @@ class Context(ABC):
         raise RuntimeError('do not call directly')
 
     @abstractmethod
-    def with_rm(self, rm: RoundingMode) -> Self:
-        """Returns `self` but with rounding mode `rm`."""
+    def with_params(self, **kwargs) -> Self:
+        """Returns `self` but with updated parameters."""
         ...
 
     @abstractmethod

--- a/fpy2/number/ext_float.py
+++ b/fpy2/number/ext_float.py
@@ -170,7 +170,7 @@ class ExtFloatContext(EncodableContext):
         return self.emax - self.eoffset
 
     def with_rm(self, rm):
-        return ExtFloatContext(self.es, self.nbits, self.enable_inf, self.nan_kind, self.eoffset, rm)
+        return ExtFloatContext(self.es, self.nbits, self.enable_inf, self.nan_kind, self.eoffset, rm, self.overflow)
 
     def is_equiv(self, other):
         if not isinstance(other, Context):

--- a/fpy2/number/ext_float.py
+++ b/fpy2/number/ext_float.py
@@ -66,7 +66,7 @@ class ExtFloatContext(EncodableContext):
         enable_inf: bool,
         nan_kind: ExtFloatNanKind,
         eoffset: int,
-        rm: RoundingMode,
+        rm: RoundingMode = RoundingMode.RNE,
     ):
         if not isinstance(es, int):
             raise TypeError(f'Expected \'int\', got \'{type(es)}\' for es={es}')

--- a/fpy2/number/ext_float.py
+++ b/fpy2/number/ext_float.py
@@ -169,8 +169,34 @@ class ExtFloatContext(EncodableContext):
         """The exponent "bias" when encoding / decoding values."""
         return self.emax - self.eoffset
 
-    def with_rm(self, rm):
-        return ExtFloatContext(self.es, self.nbits, self.enable_inf, self.nan_kind, self.eoffset, rm, self.overflow)
+    def with_params(
+        self, *,
+        es: int | None = None,
+        nbits: int | None = None,
+        enable_inf: bool | None = None,
+        nan_kind: ExtFloatNanKind | None = None,
+        eoffset: int | None = None,
+        rm: RoundingMode | None = None,
+        overflow: OverflowMode | None = None,
+        **kwargs
+    ) -> 'ExtFloatContext':
+        if es is None:
+            es = self.es
+        if nbits is None:
+            nbits = self.nbits
+        if enable_inf is None:
+            enable_inf = self.enable_inf
+        if nan_kind is None:
+            nan_kind = self.nan_kind
+        if eoffset is None:
+            eoffset = self.eoffset
+        if rm is None:
+            rm = self.rm
+        if overflow is None:
+            overflow = self.overflow
+        if kwargs:
+            raise TypeError(f'Unexpected parameters {kwargs} for ExtFloatContext')
+        return ExtFloatContext(es, nbits, enable_inf, nan_kind, eoffset, rm, overflow)
 
     def is_equiv(self, other):
         if not isinstance(other, Context):

--- a/fpy2/number/fixed.py
+++ b/fpy2/number/fixed.py
@@ -7,9 +7,9 @@ from typing import Optional
 from ..utils import bitmask, default_repr
 
 from .context import EncodableContext
-from .mpb_fixed import MPBFixedContext, FixedOverflowKind
+from .mpb_fixed import MPBFixedContext
 from .number import RealFloat, Float
-from .round import RoundingMode
+from .round import RoundingMode, OverflowMode
 
 @default_repr
 class FixedContext(MPBFixedContext, EncodableContext):
@@ -45,8 +45,8 @@ class FixedContext(MPBFixedContext, EncodableContext):
         signed: bool,
         scale: int,
         nbits: int,
-        rm: RoundingMode,
-        overflow: FixedOverflowKind,
+        rm: RoundingMode = RoundingMode.RNE,
+        overflow: OverflowMode = OverflowMode.WRAP,
         *,
         nan_value: Optional[Float] = None,
         inf_value: Optional[Float] = None

--- a/fpy2/number/fixed.py
+++ b/fpy2/number/fixed.py
@@ -70,16 +70,37 @@ class FixedContext(MPBFixedContext, EncodableContext):
         self.scale = scale
         self.nbits = nbits
 
-
-    def with_rm(self, rm: RoundingMode) -> 'FixedContext':
+    def with_params(
+        self, *,
+        signed: Optional[bool] = None,
+        scale: Optional[int] = None,
+        nbits: Optional[int] = None,
+        rm: Optional[RoundingMode] = None,
+        overflow: Optional[OverflowMode] = None,
+        nan_value: Optional[Float] = None,
+        inf_value: Optional[Float] = None,
+        **kwargs
+    ) -> 'FixedContext':
+        if signed is None:
+            signed = self.signed
+        if scale is None:
+            scale = self.scale
+        if nbits is None:
+            nbits = self.nbits
+        if rm is None:
+            rm = self.rm
+        if overflow is None:
+            overflow = self.overflow
+        if kwargs:
+            raise TypeError(f'Unexpected keyword arguments: {kwargs}')
         return FixedContext(
-            self.signed,
-            self.scale,
-            self.nbits,
+            signed,
+            scale,
+            nbits,
             rm,
-            self.overflow,
-            nan_value=self.nan_value,
-            inf_value=self.inf_value
+            overflow,
+            nan_value=nan_value,
+            inf_value=inf_value
         )
 
     def normalize(self, x: Float):

--- a/fpy2/number/ieee754.py
+++ b/fpy2/number/ieee754.py
@@ -24,12 +24,29 @@ class IEEEContext(ExtFloatContext):
         es: int,
         nbits: int,
         rm: RoundingMode = RoundingMode.RNE,
-        overflow: OverflowMode.OVERFLOW = OverflowMode.OVERFLOW
+        overflow: OverflowMode = OverflowMode.OVERFLOW
     ):
         super().__init__(es, nbits, True, ExtFloatNanKind.IEEE_754, 0, rm, overflow)
 
     def __repr__(self):
         return self.__class__.__name__ + f'(es={self.es}, nbits={self.nbits}, rm={self.rm!r}, overflow={self.overflow!r})'
 
-    def with_rm(self, rm: RoundingMode):
-        return IEEEContext(self.es, self.nbits, rm, self.overflow)
+    def with_params(
+        self, *,
+        es: int | None = None,
+        nbits: int | None = None,
+        rm: RoundingMode | None = None,
+        overflow: OverflowMode | None = None,
+        **kwargs
+    ) -> 'IEEEContext':
+        if es is None:
+            es = self.es
+        if nbits is None:
+            nbits = self.nbits
+        if rm is None:
+            rm = self.rm
+        if overflow is None:
+            overflow = self.overflow
+        if kwargs:
+            raise TypeError(f'Unexpected parameters {kwargs} for IEEEContext')
+        return IEEEContext(es, nbits, rm, overflow)

--- a/fpy2/number/ieee754.py
+++ b/fpy2/number/ieee754.py
@@ -4,7 +4,7 @@ by the IEEE 754 standard.
 """
 
 from .ext_float import ExtFloatContext, ExtFloatNanKind
-from .round import RoundingMode
+from .round import RoundingMode, OverflowMode
 
 class IEEEContext(ExtFloatContext):
     """
@@ -19,11 +19,17 @@ class IEEEContext(ExtFloatContext):
     By inheritance, `IEEEContext` implements `EncodingContext`.
     """
 
-    def __init__(self, es: int, nbits: int, rm: RoundingMode = RoundingMode.RNE):
-        super().__init__(es, nbits, True, ExtFloatNanKind.IEEE_754, 0, rm)
+    def __init__(
+        self,
+        es: int,
+        nbits: int,
+        rm: RoundingMode = RoundingMode.RNE,
+        overflow: OverflowMode.OVERFLOW = OverflowMode.OVERFLOW
+    ):
+        super().__init__(es, nbits, True, ExtFloatNanKind.IEEE_754, 0, rm, overflow)
 
     def __repr__(self):
-        return self.__class__.__name__ + f'(es={self.es}, nbits={self.nbits}, rm={self.rm!r})'
+        return self.__class__.__name__ + f'(es={self.es}, nbits={self.nbits}, rm={self.rm!r}, overflow={self.overflow!r})'
 
     def with_rm(self, rm: RoundingMode):
-        return IEEEContext(self.es, self.nbits, rm)
+        return IEEEContext(self.es, self.nbits, rm, self.overflow)

--- a/fpy2/number/ieee754.py
+++ b/fpy2/number/ieee754.py
@@ -19,7 +19,7 @@ class IEEEContext(ExtFloatContext):
     By inheritance, `IEEEContext` implements `EncodingContext`.
     """
 
-    def __init__(self, es: int, nbits: int, rm: RoundingMode):
+    def __init__(self, es: int, nbits: int, rm: RoundingMode = RoundingMode.RNE):
         super().__init__(es, nbits, True, ExtFloatNanKind.IEEE_754, 0, rm)
 
     def __repr__(self):

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -141,14 +141,37 @@ class MPFixedContext(OrdinalContext):
         """
         return self.nmin + 1
 
-    def with_rm(self, rm: RoundingMode):
+    def with_params(
+        self, *,
+        nmin: Optional[int] = None,
+        rm: Optional[RoundingMode] = None,
+        enable_nan: Optional[bool] = None,
+        enable_inf: Optional[bool] = None,
+        nan_value: Optional[Float] = None,
+        inf_value: Optional[Float] = None,
+        **kwargs
+    ) -> 'MPFixedContext':
+        if nmin is None:
+            nmin = self.nmin
+        if rm is None:
+            rm = self.rm
+        if enable_nan is None:
+            enable_nan = self.enable_nan
+        if enable_inf is None:
+            enable_inf = self.enable_inf
+        if nan_value is None:
+            nan_value = self.nan_value
+        if inf_value is None:
+            inf_value = self.inf_value
+        if kwargs:
+            raise TypeError(f'Unexpected parameters {kwargs} for MPFixedContext')
         return MPFixedContext(
-            self.nmin,
+            nmin,
             rm,
-            enable_nan=self.enable_nan,
-            enable_inf=self.enable_inf,
-            nan_value=self.nan_value,
-            inf_value=self.inf_value
+            enable_nan=enable_nan,
+            enable_inf=enable_inf,
+            nan_value=nan_value,
+            inf_value=inf_value
         )
 
     def is_equiv(self, other):

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -64,7 +64,7 @@ class MPFixedContext(OrdinalContext):
     def __init__(
         self,
         nmin: int,
-        rm: RoundingMode,
+        rm: RoundingMode = RoundingMode.RNE,
         *,
         enable_nan: bool = False,
         enable_inf: bool = False,

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -29,7 +29,7 @@ class MPFloatContext(Context):
     rm: RoundingMode
     """rounding mode"""
 
-    def __init__(self, pmax: int, rm: RoundingMode):
+    def __init__(self, pmax: int, rm: RoundingMode = RoundingMode.RNE):
         if not isinstance(pmax, int):
             raise TypeError(f'Expected \'int\' for pmax={pmax}, got {type(pmax)}')
         if pmax < 1:

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -50,8 +50,19 @@ class MPFloatContext(Context):
     def __hash__(self):
         return hash((self.__class__, self.pmax, self.rm))
 
-    def with_rm(self, rm: RoundingMode):
-        return MPFloatContext(self.pmax, rm)
+    def with_params(
+        self, *, 
+        pmax: Optional[int] = None,
+        rm: Optional[RoundingMode] = None,
+        **kwargs
+    ) -> 'MPFloatContext':
+        if pmax is None:
+            pmax = self.pmax
+        if rm is None:
+            rm = self.rm
+        if kwargs:
+            raise TypeError(f'Unexpected keyword arguments: {kwargs}')
+        return MPFloatContext(pmax, rm)
 
     def is_equiv(self, other):
         if not isinstance(other, Context):

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -190,17 +190,49 @@ class MPBFixedContext(SizedContext):
             self.inf_value
         ))
 
-    def with_rm(self, rm: RoundingMode):
+    def with_params(
+        self, *,
+        nmin: Optional[int] = None,
+        maxval: Optional[RealFloat] = None,
+        rm: Optional[RoundingMode] = None,
+        overflow: Optional[OverflowMode] = None,
+        neg_maxval: Optional[RealFloat] = None,
+        enable_nan: Optional[bool] = None,
+        enable_inf: Optional[bool] = None,
+        nan_value: Optional[Float] = None,
+        inf_value: Optional[Float] = None,
+        **kwargs
+    ) -> 'MPBFixedContext':
+        if nmin is None:
+            nmin = self.nmin
+        if maxval is None:
+            maxval = self.pos_maxval
+        if rm is None:
+            rm = self.rm
+        if overflow is None:
+            overflow = self.overflow
+        if neg_maxval is None:
+            neg_maxval = self.neg_maxval
+        if enable_nan is None:
+            enable_nan = self.enable_nan
+        if enable_inf is None:
+            enable_inf = self.enable_inf
+        if nan_value is None:
+            nan_value = self.nan_value
+        if inf_value is None:
+            inf_value = self.inf_value
+        if kwargs:
+            raise TypeError(f'Unexpected keyword arguments: {kwargs}')
         return MPBFixedContext(
-            nmin=self.nmin,
-            maxval=self.pos_maxval,
+            nmin=nmin,
+            maxval=maxval,
             rm=rm,
-            overflow=self.overflow,
-            neg_maxval=self.neg_maxval,
-            enable_nan=self.enable_nan,
-            enable_inf=self.enable_inf,
-            nan_value=self.nan_value,
-            inf_value=self.inf_value
+            overflow=overflow,
+            neg_maxval=neg_maxval,
+            enable_nan=enable_nan,
+            enable_inf=enable_inf,
+            nan_value=nan_value,
+            inf_value=inf_value
         )
 
     def is_equiv(self, other):

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -150,8 +150,31 @@ class MPBFloatContext(SizedContext):
         """
         return self._mps_ctx.nmin
 
-    def with_rm(self, rm: RoundingMode):
-        return MPBFloatContext(self.pmax, self.emin, self.pos_maxval, rm, self.overflow, neg_maxval=self.neg_maxval)
+    def with_params(
+        self, *,
+        pmax: Optional[int] = None,
+        emin: Optional[int] = None,
+        maxval: Optional[RealFloat] = None,
+        rm: Optional[RoundingMode] = None,
+        overflow: Optional[OverflowMode] = None,
+        neg_maxval: Optional[RealFloat] = None,
+        **kwargs
+    ) -> 'MPBFloatContext':
+        if pmax is None:
+            pmax = self.pmax
+        if emin is None:
+            emin = self.emin
+        if maxval is None:
+            maxval = self.pos_maxval
+        if rm is None:
+            rm = self.rm
+        if overflow is None:
+            overflow = self.overflow
+        if neg_maxval is None:
+            neg_maxval = self.neg_maxval
+        if kwargs:
+            raise TypeError(f'Unexpected keyword arguments: {kwargs}')
+        return MPBFloatContext(pmax, emin, maxval, rm, overflow, neg_maxval=neg_maxval)
 
     def is_equiv(self, other):
         if not isinstance(other, Context):

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -62,7 +62,8 @@ class MPBFloatContext(SizedContext):
         pmax: int,
         emin: int,
         maxval: RealFloat, 
-        rm: RoundingMode, *,
+        rm: RoundingMode = RoundingMode.RNE,
+        *,
         neg_maxval: Optional[RealFloat] = None
     ):
         if not isinstance(pmax, int):

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -151,7 +151,7 @@ class MPBFloatContext(SizedContext):
         return self._mps_ctx.nmin
 
     def with_rm(self, rm: RoundingMode):
-        return MPBFloatContext(self.pmax, self.emin, self.pos_maxval, rm, neg_maxval=self.neg_maxval)
+        return MPBFloatContext(self.pmax, self.emin, self.pos_maxval, rm, self.overflow, neg_maxval=self.neg_maxval)
 
     def is_equiv(self, other):
         if not isinstance(other, Context):

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -88,8 +88,22 @@ class MPSFloatContext(OrdinalContext):
         """
         return self.expmin - 1
 
-    def with_rm(self, rm: RoundingMode):
-        return MPSFloatContext(self.pmax, self.emin, rm)
+    def with_params(
+        self, *,
+        pmax: Optional[int] = None,
+        emin: Optional[int] = None,
+        rm: Optional[RoundingMode] = None,
+        **kwargs
+    ) -> 'MPSFloatContext':
+        if pmax is None:
+            pmax = self.pmax
+        if emin is None:
+            emin = self.emin
+        if rm is None:
+            rm = self.rm
+        if kwargs:
+            raise TypeError(f'Unexpected keyword arguments: {kwargs}')
+        return MPSFloatContext(pmax, emin, rm)
 
     def is_equiv(self, other):
         if not isinstance(other, Context):

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -48,7 +48,7 @@ class MPSFloatContext(OrdinalContext):
     rm: RoundingMode
     """rounding mode"""
 
-    def __init__(self, pmax: int, emin: int, rm: RoundingMode):
+    def __init__(self, pmax: int, emin: int, rm: RoundingMode = RoundingMode.RNE):
         if not isinstance(pmax, int):
             raise TypeError(f'Expected \'int\' for pmax={pmax}, got {type(pmax)}')
         if pmax < 1:

--- a/fpy2/number/real.py
+++ b/fpy2/number/real.py
@@ -25,8 +25,10 @@ class RealContext(Context):
     def __hash__(self):
         return hash(self.__class__)
 
-    def with_rm(self, rm: RoundingMode):
-        raise RuntimeError('cannot set rounding mode for real context')
+    def with_params(self, **kwargs) -> 'RealContext':
+        if kwargs:
+            raise TypeError(f'Unexpected parameters {kwargs} for RealContext')
+        return self
 
     def is_equiv(self, other: Context) -> bool:
         if not isinstance(other, Context):

--- a/fpy2/number/round.py
+++ b/fpy2/number/round.py
@@ -63,3 +63,18 @@ class RoundingMode(Enum):
                 return False, RoundingDirection.RTE
             case _:
                 raise ValueError('unsupported rounding mode', self)
+
+@enum_repr
+class OverflowMode(Enum):
+    """
+    Overflow behavior for rounding under bounded formats.
+
+    This is used to specify what value to produce when
+    a value is larger (in magnitude) than the maximum value.
+    - `OVERFLOW`: produces infinity or raise an OverflowError
+    - `SATURATE`: produce the (correctly signed) maximum value
+    - `WRAP`: produce the modulus over the ordinals
+    """
+    OVERFLOW = 0
+    SATURATE = 1
+    WRAP = 2

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -562,7 +562,7 @@ def ceil(x: Real, ctx: Optional[Context] = None):
             # use rounding primitives
             return real_ceil(x)
         case _:
-            return ctx.with_rm(RoundingMode.RTP).round_integer(x)
+            return ctx.with_params(rm=RoundingMode.RTP).round_integer(x)
 
 def floor(x: Real, ctx: Optional[Context] = None):
     """
@@ -579,7 +579,7 @@ def floor(x: Real, ctx: Optional[Context] = None):
             # use rounding primitives
             return real_floor(x)
         case _:
-            return ctx.with_rm(RoundingMode.RTN).round_integer(x)
+            return ctx.with_params(rm=RoundingMode.RTN).round_integer(x)
 
 def trunc(x: Real, ctx: Optional[Context] = None):
     """
@@ -597,7 +597,7 @@ def trunc(x: Real, ctx: Optional[Context] = None):
             # use rounding primitives
             return real_trunc(x)
         case _:
-            return ctx.with_rm(RoundingMode.RTZ).round_integer(x)
+            return ctx.with_params(rm=RoundingMode.RTZ).round_integer(x)
 
 def nearbyint(x: Real, ctx: Optional[Context] = None):
     """
@@ -630,7 +630,7 @@ def roundint(x: Real, ctx: Optional[Context] = None):
             # use rounding primitives
             return real_roundint(x)
         case _:
-            return ctx.with_rm(RoundingMode.RNA).round_integer(x)
+            return ctx.with_params(rm=RoundingMode.RNA).round_integer(x)
 
 #############################################################################
 # Classification

--- a/tests/unit/math/test_mpfr.py
+++ b/tests/unit/math/test_mpfr.py
@@ -151,7 +151,7 @@ class MPFREquivTestCase(unittest.TestCase):
         for op, mpfr in _unary_ops.items():
             for ctx_base in _ctxs:
                 for rm in _rms:
-                    ctx = ctx_base.with_rm(rm)
+                    ctx = ctx_base.with_params(rm=rm)
                     for _ in range(num_inputs):
                         # sample point
                         i = random.randint(0, 1 << ctx.nbits - 1)
@@ -173,7 +173,7 @@ class MPFREquivTestCase(unittest.TestCase):
         for op, mpfr in _binary_ops.items():
             for ctx_base in _ctxs:
                 for rm in _rms:
-                    ctx = ctx_base.with_rm(rm)
+                    ctx = ctx_base.with_params(rm=rm)
                     for _ in range(num_inputs):
                         # sample point
                         i = random.randint(0, 1 << ctx.nbits - 1)
@@ -197,7 +197,7 @@ class MPFREquivTestCase(unittest.TestCase):
         for op, mpfr in _ternary_ops.items():
             for ctx_base in _ctxs:
                 for rm in _rms:
-                    ctx = ctx_base.with_rm(rm)
+                    ctx = ctx_base.with_params(rm=rm)
                     for _ in range(num_inputs):
                         # sample point
                         i = random.randint(0, 1 << ctx.nbits - 1)

--- a/tests/unit/math/test_ops.py
+++ b/tests/unit/math/test_ops.py
@@ -1,7 +1,7 @@
 import random
 import unittest
 
-from fpy2 import IEEEContext, MPFixedContext, FixedContext, Float, RM, OF, FP64, FP32, FP16
+from fpy2 import IEEEContext, MPFixedContext, FixedContext, Float, RM, OV, FP64, FP32, FP16
 from fpy2.ops import *
 
 _unary_ops = [
@@ -210,8 +210,8 @@ class MathInt64NoExceptTestCase(unittest.TestCase):
     }
 
     def test_fuzz_unary(self, num_inputs: int = 256):
-        INT64 = FixedContext(True, 0, 64, RM.RTZ, OF.WRAP)
-        INT64 = FixedContext(True, 0, 64, RM.RTZ, OF.WRAP, nan_value=INT64.maxval(s=True), inf_value=INT64.maxval(s=True))
+        INT64 = FixedContext(True, 0, 64, RM.RTZ, OV.WRAP)
+        INT64 = FixedContext(True, 0, 64, RM.RTZ, OV.WRAP, nan_value=INT64.maxval(s=True), inf_value=INT64.maxval(s=True))
         for op in _unary_ops:
             max_value = self._max_integer.get(op, self._default_max_integer)
             for rm in _rms:
@@ -224,8 +224,8 @@ class MathInt64NoExceptTestCase(unittest.TestCase):
                     op(x, ctx=INT64)
 
     def test_fuzz_binary(self, num_inputs: int = 256):
-        INT64 = FixedContext(True, 0, 64, RM.RTZ, OF.WRAP)
-        INT64 = FixedContext(True, 0, 64, RM.RTZ, OF.WRAP, nan_value=INT64.maxval(s=True), inf_value=INT64.maxval(s=True))
+        INT64 = FixedContext(True, 0, 64, RM.RTZ, OV.WRAP)
+        INT64 = FixedContext(True, 0, 64, RM.RTZ, OV.WRAP, nan_value=INT64.maxval(s=True), inf_value=INT64.maxval(s=True))
         for op in _binary_ops:
             max_value = self._max_integer.get(op, self._default_max_integer)
             for rm in _rms:
@@ -240,8 +240,8 @@ class MathInt64NoExceptTestCase(unittest.TestCase):
                     op(x, y, ctx=ctx)
 
     def test_fuzz_ternary(self, num_inputs: int = 256):
-        INT64 = FixedContext(True, 0, 64, RM.RTZ, OF.WRAP)
-        INT64 = FixedContext(True, 0, 64, RM.RTZ, OF.WRAP, nan_value=INT64.maxval(s=True), inf_value=INT64.maxval(s=True))
+        INT64 = FixedContext(True, 0, 64, RM.RTZ, OV.WRAP)
+        INT64 = FixedContext(True, 0, 64, RM.RTZ, OV.WRAP, nan_value=INT64.maxval(s=True), inf_value=INT64.maxval(s=True))
         for op in _ternary_ops:
             max_value = self._max_integer.get(op, self._default_max_integer)
             for rm in _rms:

--- a/tests/unit/math/test_ops.py
+++ b/tests/unit/math/test_ops.py
@@ -87,7 +87,7 @@ class MathIEEENoExceptTestCase(unittest.TestCase):
         for op in _unary_ops:
             for ctx_base in _ctxs:
                 for rm in _rms:
-                    ctx = ctx_base.with_rm(rm)
+                    ctx = ctx_base.with_params(rm=rm)
                     for _ in range(num_inputs):
                         # sample point
                         i = random.randint(0, 1 << ctx.nbits - 1)
@@ -100,7 +100,7 @@ class MathIEEENoExceptTestCase(unittest.TestCase):
         for op in _binary_ops:
             for ctx_base in _ctxs:
                 for rm in _rms:
-                    ctx = ctx_base.with_rm(rm)
+                    ctx = ctx_base.with_params(rm=rm)
                     for _ in range(num_inputs):
                         # sample point
                         i = random.randint(0, 1 << ctx.nbits - 1)
@@ -114,7 +114,7 @@ class MathIEEENoExceptTestCase(unittest.TestCase):
         for op in _ternary_ops:
             for ctx_base in _ctxs:
                 for rm in _rms:
-                    ctx = ctx_base.with_rm(rm)
+                    ctx = ctx_base.with_params(rm=rm)
                     for _ in range(num_inputs):
                         # sample point
                         i = random.randint(0, 1 << ctx.nbits - 1)

--- a/tests/unit/number/ext/test_params.py
+++ b/tests/unit/number/ext/test_params.py
@@ -1,7 +1,5 @@
 import unittest
 
-import unittest
-
 from fpy2 import (
     S1E5M2, S1E4M3,
     MX_E5M2, MX_E4M3, MX_E3M2, MX_E2M3, MX_E2M1,

--- a/tests/unit/number/ext/test_round.py
+++ b/tests/unit/number/ext/test_round.py
@@ -1,0 +1,15 @@
+import unittest
+
+import fpy2 as fp
+
+
+class TestRoundSaturate(unittest.TestCase):
+    """Test saturation behavior."""
+
+    def test_saturate(self):
+        ctx = fp.IEEEContext(5, 8, overflow=fp.OV.SATURATE)
+        maxval = ctx.maxval()
+        eps = fp.Float(c=1, exp=maxval.exp)
+
+        self.assertEqual(ctx.round(maxval), maxval)
+        self.assertEqual(ctx.round(fp.add(maxval, eps)), maxval)

--- a/tests/unit/number/mpb_fixed/test_round.py
+++ b/tests/unit/number/mpb_fixed/test_round.py
@@ -1,7 +1,7 @@
 import random
 import unittest
 
-from fpy2 import MPBFixedContext, RealFloat, RM, OF
+from fpy2 import MPBFixedContext, RealFloat, RM, OV
 
 class RoundTestCase(unittest.TestCase):
     """Testing `MPBFixedContext.round()`"""
@@ -11,7 +11,7 @@ class RoundTestCase(unittest.TestCase):
         seed = 1
 
         # saturation
-        sat_ctx = MPBFixedContext(-1, limit, RM.RTZ, OF.SATURATE)
+        sat_ctx = MPBFixedContext(-1, limit, RM.RTZ, OV.SATURATE)
         random.seed(seed)
         for _ in range(num_values):
             s = random.choice([False, True])
@@ -21,7 +21,7 @@ class RoundTestCase(unittest.TestCase):
             sat_ctx.round(x)
 
         # wrap
-        wrap_ctx = MPBFixedContext(-1, limit, RM.RTZ, OF.WRAP)
+        wrap_ctx = MPBFixedContext(-1, limit, RM.RTZ, OV.WRAP)
         random.seed(seed)
         for _ in range(num_values):
             s = random.choice([False, True])
@@ -37,12 +37,12 @@ class RoundTestCase(unittest.TestCase):
         neg_x = RealFloat.from_int(-(2 ** 8 + 1))
 
         # saturation
-        sat_ctx = MPBFixedContext(-1, limit, RM.RTZ, OF.SATURATE)
+        sat_ctx = MPBFixedContext(-1, limit, RM.RTZ, OV.SATURATE)
         self.assertEqual(sat_ctx.round(x), limit)
         self.assertEqual(sat_ctx.round(neg_x), -limit)
 
         # wrap
-        wrap_ctx = MPBFixedContext(-1, limit, RM.RTZ, OF.WRAP)
+        wrap_ctx = MPBFixedContext(-1, limit, RM.RTZ, OV.WRAP)
         self.assertEqual(wrap_ctx.round(x), -limit)
         self.assertEqual(wrap_ctx.round(neg_x), limit)
 

--- a/tests/unit/number/test_round.py
+++ b/tests/unit/number/test_round.py
@@ -16,7 +16,7 @@ def _all_contexts():
         fp.MPSFloatContext(24, -127, fp.RM.RNE),
         fp.MPBFloatContext(24, -127, fp.RealFloat.from_int(2 ** 100).normalize(24), fp.RM.RNE),
         fp.MPFixedContext(-8, fp.RM.RNE),
-        fp.MPBFixedContext(-8, fp.RealFloat.from_int(2 ** 30), fp.RM.RNE, fp.OF.SATURATE),
+        fp.MPBFixedContext(-8, fp.RealFloat.from_int(2 ** 30), fp.RM.RNE, fp.OV.SATURATE),
         fp.RealContext()
     ]
 


### PR DESCRIPTION
This PR contains a number of changes:
- all dynamic rounding properties are optional arguments
- added `overflow` argument for floating-point contexts to support saturation
- replaced `with_rm` with more general `with_params`