### PR TITLE
Add stochastic rounding

### DIFF
--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -17,16 +17,16 @@ class Context(ABC):
     """
     Rounding context type.
 
-    Most mathematical operators on digital numbers
+    Most mathematical operators on numbers
     can be decomposed into two steps:
 
     1. a mathematically-correct operation over real numbers,
-    interpreting digital numbers as real numbers;
+    interpreting numbers as real numbers;
 
     2. a rounding operation to limit the number significant digits
     and decide how the "lost" digits will affect the final output.
 
-    Thus, rounding enforces a particular "format" for digital numbers,
+    Thus, rounding enforces a particular "format" for numbers,
     but they should just be considered unbounded real numbers
     when in isolation. The characteristics of the rounding operation are
     summarized by this type.
@@ -108,7 +108,7 @@ class Context(ABC):
     @abstractmethod
     def round(self, x, *, exact: bool = False) -> Float:
         """
-        Rounds any digital number according to this context.
+        Rounds any number according to this context.
 
         If `exact=True`, then the rounding operation will raise a `ValueError`
         if rounding produces an inexact result.
@@ -118,7 +118,7 @@ class Context(ABC):
     @abstractmethod
     def round_at(self, x, n: int, *, exact: bool = False) -> Float:
         """
-        Rounding any digital number of a representable value with
+        Rounding any number of a representable value with
         an unnormalized exponent of at minimum `n + 1`.
 
         Rounding is done by the following rules:
@@ -137,7 +137,7 @@ class Context(ABC):
 
     def round_integer(self, x) -> Float:
         """
-        Rounds any digital number to an integer according to this context.
+        Rounds any number to an integer according to this context.
 
         Rounding is done by the following rules:
 
@@ -163,7 +163,7 @@ class OrdinalContext(Context):
     @abstractmethod
     def to_ordinal(self, x: Float, infval: bool = False) -> int:
         """
-        Maps a digital number to an ordinal number.
+        Maps a number to an ordinal number.
 
         When `infval=True`, infinities are mapped to the next (or previous)
         logical ordinal value after +/-MAX_VAL. This option is only
@@ -174,7 +174,7 @@ class OrdinalContext(Context):
     @abstractmethod
     def from_ordinal(self, x: int, infval: bool = False) -> Float:
         """
-        Maps an ordinal number to a digital number.
+        Maps an ordinal number to a number.
 
         When `infval=True`, infinities are mapped to the next (or previous)
         logical ordinal value after +/-MAX_VAL. This option is only
@@ -221,7 +221,7 @@ class EncodableContext(SizedContext):
     @abstractmethod
     def encode(self, x: Float) -> int:
         """
-        Encodes a digital number constructed under this context as a bitstring.
+        Encodes a number constructed under this context as a bitstring.
         This operation is context dependent.
         """
         ...
@@ -229,7 +229,7 @@ class EncodableContext(SizedContext):
     @abstractmethod
     def decode(self, x: int) -> Float:
         """
-        Decodes a bitstring as a a digital number constructed under this context.
+        Decodes a bitstring as a a number constructed under this context.
         This operation is context dependent.
         """
         ...

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -62,7 +62,7 @@ class Context(ABC):
         ...
 
     @abstractmethod
-    def is_representable(self, x: Union[Float, RealFloat]) -> bool:
+    def representable_under(self, x: Union[Float, RealFloat]) -> bool:
         """
         Returns if `x` is representable under this context.
 
@@ -72,7 +72,7 @@ class Context(ABC):
         ...
 
     @abstractmethod
-    def is_canonical(self, x: Float) -> bool:
+    def canonical_under(self, x: Float) -> bool:
         """
         Returns if `x` is canonical under this context.
 
@@ -84,18 +84,18 @@ class Context(ABC):
         ...
 
     @abstractmethod
-    def normalize(self, x: Float) -> Float:
-        """Returns the canonical form of `x` under this context."""
-        ...
-
-    @abstractmethod
-    def is_normal(self, x: Float) -> bool:
+    def normal_under(self, x: Float) -> bool:
         """
         Returns if `x` is "normal" under this context.
 
         For IEEE-style contexts, this means that `x` is finite, non-zero,
         and `x.normalize()` has full precision.
         """
+        ...
+
+    @abstractmethod
+    def normalize(self, x: Float) -> Float:
+        """Returns the canonical form of `x` under this context."""
         ...
 
     @abstractmethod

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -44,6 +44,15 @@ class Context(ABC):
         ...
 
     @abstractmethod
+    def is_stochastic(self) -> bool:
+        """
+        Returns if this context is stochastic.
+
+        Stochastic contexts are used for probabilistic rounding.
+        """
+        ...
+
+    @abstractmethod
     def is_equiv(self, other: 'Context') -> bool:
         """
         Returns if this context and another context round values to

--- a/fpy2/number/ext_float.py
+++ b/fpy2/number/ext_float.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 from typing import Optional
 
-from ..utils import default_repr, enum_repr, bitmask
+from ..utils import default_repr, enum_repr, bitmask, DefaultOr, DEFAULT
 
 from .context import Context, EncodableContext
 from .number import RealFloat, Float
@@ -181,31 +181,31 @@ class ExtFloatContext(EncodableContext):
 
     def with_params(
         self, *,
-        es: int | None = None,
-        nbits: int | None = None,
-        enable_inf: bool | None = None,
-        nan_kind: ExtFloatNanKind | None = None,
-        eoffset: int | None = None,
-        rm: RoundingMode | None = None,
-        overflow: OverflowMode | None = None,
-        num_randbits: Optional[int] = 0,
+        es: DefaultOr[int] = DEFAULT,
+        nbits: DefaultOr[int] = DEFAULT,
+        enable_inf: DefaultOr[bool] = DEFAULT,
+        nan_kind: DefaultOr[ExtFloatNanKind] = DEFAULT,
+        eoffset: DefaultOr[int] = DEFAULT,
+        rm: DefaultOr[RoundingMode] = DEFAULT,
+        overflow: DefaultOr[OverflowMode] = DEFAULT,
+        num_randbits: DefaultOr[Optional[int]] = DEFAULT,
         **kwargs
     ) -> 'ExtFloatContext':
-        if es is None:
+        if es is DEFAULT:
             es = self.es
-        if nbits is None:
+        if nbits is DEFAULT:
             nbits = self.nbits
-        if enable_inf is None:
+        if enable_inf is DEFAULT:
             enable_inf = self.enable_inf
-        if nan_kind is None:
+        if nan_kind is DEFAULT:
             nan_kind = self.nan_kind
-        if eoffset is None:
+        if eoffset is DEFAULT:
             eoffset = self.eoffset
-        if rm is None:
+        if rm is DEFAULT:
             rm = self.rm
-        if overflow is None:
+        if overflow is DEFAULT:
             overflow = self.overflow
-        if num_randbits is None:
+        if num_randbits is DEFAULT:
             num_randbits = self.num_randbits
         if kwargs:
             raise TypeError(f'Unexpected parameters {kwargs} for ExtFloatContext')

--- a/fpy2/number/ext_float.py
+++ b/fpy2/number/ext_float.py
@@ -211,6 +211,9 @@ class ExtFloatContext(EncodableContext):
             raise TypeError(f'Unexpected parameters {kwargs} for ExtFloatContext')
         return ExtFloatContext(es, nbits, enable_inf, nan_kind, eoffset, rm, overflow, num_randbits)
 
+    def is_stochastic(self) -> bool:
+        return self.num_randbits != 0
+
     def is_equiv(self, other):
         if not isinstance(other, Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')

--- a/fpy2/number/ext_float.py
+++ b/fpy2/number/ext_float.py
@@ -226,7 +226,7 @@ class ExtFloatContext(EncodableContext):
             and self.eoffset == other.eoffset
         )
 
-    def is_representable(self, x: RealFloat | Float) -> bool:
+    def representable_under(self, x: RealFloat | Float) -> bool:
         match x:
             case Float():
                 if x.ctx is not None and self.is_equiv(x.ctx):
@@ -237,7 +237,7 @@ class ExtFloatContext(EncodableContext):
             case _:
                 raise TypeError(f'Expected \'RealFloat\' or \'Float\', got \'{type(x)}\' for x={x}')
 
-        if not self._mpb_ctx.is_representable(x):
+        if not self._mpb_ctx.representable_under(x):
             return False
         elif self.nan_kind == ExtFloatNanKind.NEG_ZERO and x.s and x.is_zero():
             # -0 is not representable in this context
@@ -246,23 +246,23 @@ class ExtFloatContext(EncodableContext):
             # otherwise, it is representable
             return True
 
-    def is_canonical(self, x: Float) -> bool:
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def canonical_under(self, x: Float) -> bool:
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
-        return self._mpb_ctx.is_canonical(x)
+        return self._mpb_ctx.canonical_under(x)
 
     def _normalize(self, x: Float) -> Float:
         return self._mpb_ctx._normalize(x)
 
     def normalize(self, x: Float) -> Float:
-        if not isinstance(x, Float) or not self.is_representable(x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return Float(x=self._normalize(x), ctx=self)
 
-    def is_normal(self, x: Float) -> bool:
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def normal_under(self, x: Float) -> bool:
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
-        return self._mpb_ctx.is_normal(x)
+        return self._mpb_ctx.normal_under(x)
 
     def round_params(self):
         return self._mpb_ctx.round_params()
@@ -274,7 +274,7 @@ class ExtFloatContext(EncodableContext):
         return Float(x=self._mpb_ctx.round_at(x, n, exact=exact), ctx=self)
 
     def to_ordinal(self, x: Float, infval = False) -> int:
-        if not isinstance(x, Float) or not self.is_representable(x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return self._mpb_ctx.to_ordinal(x, infval=infval)
 
@@ -290,7 +290,7 @@ class ExtFloatContext(EncodableContext):
         if not isinstance(s, bool):
             raise TypeError(f'Expected \'bool\' for s={s}, got {type(s)}')
         x = Float(x=self._mpb_ctx.zero(s), ctx=self)
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'not representable in this context: x={x}')
         return x
 
@@ -303,7 +303,7 @@ class ExtFloatContext(EncodableContext):
         if not isinstance(s, bool):
             raise TypeError(f'Expected \'bool\' for s={s}, got {type(s)}')
         x = self._mpb_ctx.minval(s)
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'not representable in this context: x={x}')
         return Float(x=x, ctx=self)
 
@@ -316,7 +316,7 @@ class ExtFloatContext(EncodableContext):
         if not isinstance(s, bool):
             raise TypeError(f'Expected \'bool\' for s={s}, got {type(s)}')
         x = self._mpb_ctx.min_subnormal(s)
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'not representable in this context: x={x}')
         return Float(x=x, ctx=self)
 
@@ -329,7 +329,7 @@ class ExtFloatContext(EncodableContext):
         if not isinstance(s, bool):
             raise TypeError(f'Expected \'bool\' for s={s}, got {type(s)}')
         x = self._mpb_ctx.max_subnormal(s)
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'not representable in this context: x={x}')
         return Float(x=x, ctx=self)
 
@@ -342,7 +342,7 @@ class ExtFloatContext(EncodableContext):
         if not isinstance(s, bool):
             raise TypeError(f'Expected \'bool\' for s={s}, got {type(s)}')
         x = self._mpb_ctx.min_normal(s)
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'not representable in this context: x={x}')
         return Float(x=x, ctx=self)
 
@@ -355,7 +355,7 @@ class ExtFloatContext(EncodableContext):
         if not isinstance(s, bool):
             raise TypeError(f'Expected \'bool\' for s={s}, got {type(s)}')
         x = self._mpb_ctx.max_normal(s)
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'not representable in this context: x={x}')
         return Float(x=x, ctx=self)
 
@@ -368,7 +368,7 @@ class ExtFloatContext(EncodableContext):
         if not isinstance(s, bool):
             raise TypeError(f'Expected \'bool\' for s={s}, got {type(s)}')
         x = self._mpb_ctx.maxval(s)
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'Not representable in this context: x={x}')
         return Float(x=x, ctx=self)
 
@@ -384,7 +384,7 @@ class ExtFloatContext(EncodableContext):
     def encode(self, x: Float) -> int:
         if not isinstance(x, Float):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x!r}')
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'not representable under this context: x={x!r}, ctx={self!r}')
 
         # sign bit

--- a/fpy2/number/fixed.py
+++ b/fpy2/number/fixed.py
@@ -47,6 +47,7 @@ class FixedContext(MPBFixedContext, EncodableContext):
         nbits: int,
         rm: RoundingMode = RoundingMode.RNE,
         overflow: OverflowMode = OverflowMode.WRAP,
+        num_randbits: Optional[int] = 0,
         *,
         nan_value: Optional[Float] = None,
         inf_value: Optional[Float] = None
@@ -59,6 +60,7 @@ class FixedContext(MPBFixedContext, EncodableContext):
             pos_maxval,
             rm,
             overflow,
+            num_randbits,
             neg_maxval=neg_maxval,
             enable_nan=False,
             enable_inf=False,
@@ -77,6 +79,7 @@ class FixedContext(MPBFixedContext, EncodableContext):
         nbits: Optional[int] = None,
         rm: Optional[RoundingMode] = None,
         overflow: Optional[OverflowMode] = None,
+        num_randbits: Optional[int] = None,
         nan_value: Optional[Float] = None,
         inf_value: Optional[Float] = None,
         **kwargs
@@ -91,6 +94,8 @@ class FixedContext(MPBFixedContext, EncodableContext):
             rm = self.rm
         if overflow is None:
             overflow = self.overflow
+        if num_randbits is None:
+            num_randbits = self.num_randbits
         if kwargs:
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')
         return FixedContext(
@@ -99,6 +104,7 @@ class FixedContext(MPBFixedContext, EncodableContext):
             nbits,
             rm,
             overflow,
+            num_randbits,
             nan_value=nan_value,
             inf_value=inf_value
         )

--- a/fpy2/number/fixed.py
+++ b/fpy2/number/fixed.py
@@ -4,7 +4,7 @@ This module defines the usual fixed-width fixed-point numbers.
 
 from typing import Optional
 
-from ..utils import bitmask, default_repr
+from ..utils import bitmask, default_repr, DefaultOr, DEFAULT
 
 from .context import EncodableContext
 from .mpb_fixed import MPBFixedContext
@@ -74,28 +74,32 @@ class FixedContext(MPBFixedContext, EncodableContext):
 
     def with_params(
         self, *,
-        signed: Optional[bool] = None,
-        scale: Optional[int] = None,
-        nbits: Optional[int] = None,
-        rm: Optional[RoundingMode] = None,
-        overflow: Optional[OverflowMode] = None,
-        num_randbits: Optional[int] = None,
-        nan_value: Optional[Float] = None,
-        inf_value: Optional[Float] = None,
+        signed: DefaultOr[bool] = DEFAULT,
+        scale: DefaultOr[int] = DEFAULT,
+        nbits: DefaultOr[int] = DEFAULT,
+        rm: DefaultOr[RoundingMode] = DEFAULT,
+        overflow: DefaultOr[OverflowMode] = DEFAULT,
+        num_randbits: DefaultOr[Optional[int]] = DEFAULT,
+        nan_value: DefaultOr[Optional[Float]] = DEFAULT,
+        inf_value: DefaultOr[Optional[Float]] = DEFAULT,
         **kwargs
     ) -> 'FixedContext':
-        if signed is None:
+        if signed is DEFAULT:
             signed = self.signed
-        if scale is None:
+        if scale is DEFAULT:
             scale = self.scale
-        if nbits is None:
+        if nbits is DEFAULT:
             nbits = self.nbits
-        if rm is None:
+        if rm is DEFAULT:
             rm = self.rm
-        if overflow is None:
+        if overflow is DEFAULT:
             overflow = self.overflow
-        if num_randbits is None:
+        if num_randbits is DEFAULT:
             num_randbits = self.num_randbits
+        if nan_value is DEFAULT:
+            nan_value = self.nan_value
+        if inf_value is DEFAULT:
+            inf_value = self.inf_value
         if kwargs:
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')
         return FixedContext(

--- a/fpy2/number/fixed.py
+++ b/fpy2/number/fixed.py
@@ -144,7 +144,7 @@ class FixedContext(MPBFixedContext, EncodableContext):
     def encode(self, x: Float) -> int:
         if not isinstance(x, Float):
             raise TypeError(f'Expected \'Float\', got x={x}')
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'Expected representable value, got x={x} for self={self}')
         raise NotImplementedError
 

--- a/fpy2/number/ieee754.py
+++ b/fpy2/number/ieee754.py
@@ -3,6 +3,8 @@ This module defines floating-point numbers as defined
 by the IEEE 754 standard.
 """
 
+from typing import Optional
+
 from .ext_float import ExtFloatContext, ExtFloatNanKind
 from .round import RoundingMode, OverflowMode
 
@@ -24,12 +26,13 @@ class IEEEContext(ExtFloatContext):
         es: int,
         nbits: int,
         rm: RoundingMode = RoundingMode.RNE,
-        overflow: OverflowMode = OverflowMode.OVERFLOW
+        overflow: OverflowMode = OverflowMode.OVERFLOW,
+        num_randbits: Optional[int] = 0
     ):
-        super().__init__(es, nbits, True, ExtFloatNanKind.IEEE_754, 0, rm, overflow)
+        super().__init__(es, nbits, True, ExtFloatNanKind.IEEE_754, 0, rm, overflow, num_randbits)
 
     def __repr__(self):
-        return self.__class__.__name__ + f'(es={self.es}, nbits={self.nbits}, rm={self.rm!r}, overflow={self.overflow!r})'
+        return self.__class__.__name__ + f'(es={self.es}, nbits={self.nbits}, rm={self.rm!r}, overflow={self.overflow!r}, num_randbits={self.num_randbits!r})'
 
     def with_params(
         self, *,
@@ -37,6 +40,7 @@ class IEEEContext(ExtFloatContext):
         nbits: int | None = None,
         rm: RoundingMode | None = None,
         overflow: OverflowMode | None = None,
+        num_randbits: Optional[int] = 0,
         **kwargs
     ) -> 'IEEEContext':
         if es is None:
@@ -47,6 +51,8 @@ class IEEEContext(ExtFloatContext):
             rm = self.rm
         if overflow is None:
             overflow = self.overflow
+        if num_randbits is None:
+            num_randbits = self.num_randbits
         if kwargs:
             raise TypeError(f'Unexpected parameters {kwargs} for IEEEContext')
-        return IEEEContext(es, nbits, rm, overflow)
+        return IEEEContext(es, nbits, rm, overflow, num_randbits)

--- a/fpy2/number/ieee754.py
+++ b/fpy2/number/ieee754.py
@@ -5,6 +5,7 @@ by the IEEE 754 standard.
 
 from typing import Optional
 
+from ..utils import DEFAULT, DefaultOr
 from .ext_float import ExtFloatContext, ExtFloatNanKind
 from .round import RoundingMode, OverflowMode
 
@@ -36,22 +37,22 @@ class IEEEContext(ExtFloatContext):
 
     def with_params(
         self, *,
-        es: int | None = None,
-        nbits: int | None = None,
-        rm: RoundingMode | None = None,
-        overflow: OverflowMode | None = None,
-        num_randbits: Optional[int] = 0,
+        es: DefaultOr[int] = DEFAULT,
+        nbits: DefaultOr[int] = DEFAULT,
+        rm: DefaultOr[RoundingMode] = DEFAULT,
+        overflow: DefaultOr[OverflowMode] = DEFAULT,
+        num_randbits: DefaultOr[Optional[int]] = DEFAULT,
         **kwargs
     ) -> 'IEEEContext':
-        if es is None:
+        if es is DEFAULT:
             es = self.es
-        if nbits is None:
+        if nbits is DEFAULT:
             nbits = self.nbits
-        if rm is None:
+        if rm is DEFAULT:
             rm = self.rm
-        if overflow is None:
+        if overflow is DEFAULT:
             overflow = self.overflow
-        if num_randbits is None:
+        if num_randbits is DEFAULT:
             num_randbits = self.num_randbits
         if kwargs:
             raise TypeError(f'Unexpected parameters {kwargs} for IEEEContext')

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -315,7 +315,8 @@ class MPFixedContext(OrdinalContext):
             case int():
                 xr = RealFloat.from_int(x)
             case str() | Fraction():
-                xr = mpfr_value(x, n=self.nmin)
+                p, n = self.round_params()
+                xr = mpfr_value(x, prec=p, n=n)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -200,7 +200,7 @@ class MPFixedContext(OrdinalContext):
             and self.enable_inf == other.enable_inf
         )
 
-    def is_representable(self, x: RealFloat | Float) -> bool:
+    def representable_under(self, x: RealFloat | Float) -> bool:
         match x:
             case Float():
                 if x.ctx is not None and self.is_equiv(x.ctx):
@@ -226,13 +226,13 @@ class MPFixedContext(OrdinalContext):
 
         return xr.is_more_significant(self.nmin)
 
-    def is_canonical(self, x: Float):
-        if not isinstance(x, Float) and self.is_representable(x):
+    def canonical_under(self, x: Float):
+        if not isinstance(x, Float) and self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return x.exp == self.expmin
 
     def normalize(self, x: Float):
-        if not isinstance(x, Float) and self.is_representable(x):
+        if not isinstance(x, Float) and self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
 
         offset = x.exp - self.expmin
@@ -250,7 +250,7 @@ class MPFixedContext(OrdinalContext):
 
         return Float(exp=exp, c=c, x=x, ctx=self)
 
-    def is_normal(self, x: Float) -> bool:
+    def normal_under(self, x: Float) -> bool:
         if not isinstance(x, Float):
             raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
         return x.is_nonzero()
@@ -336,7 +336,7 @@ class MPFixedContext(OrdinalContext):
     def to_ordinal(self, x: Float, infval: bool = False) -> int:
         if not isinstance(x, Float):
             raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'Expected representable \'Float\', got x={x}')
         if infval:
             raise ValueError('infvalue=True is invalid for contexts without maximum value')

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -317,7 +317,7 @@ class MPFixedContext(OrdinalContext):
                 xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
-            case Fraction() if x.is_integer():
+            case Fraction() if x.denominator == 1:
                 xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -7,7 +7,7 @@ Hence, "MP-F".
 from fractions import Fraction
 from typing import Optional
 
-from ..utils import default_repr
+from ..utils import default_repr, DEFAULT, DefaultOr
 
 from .context import Context, OrdinalContext
 from .number import Float
@@ -152,28 +152,28 @@ class MPFixedContext(OrdinalContext):
 
     def with_params(
         self, *,
-        nmin: Optional[int] = None,
-        rm: Optional[RoundingMode] = None,
-        enable_nan: Optional[bool] = None,
-        enable_inf: Optional[bool] = None,
-        nan_value: Optional[Float] = None,
-        inf_value: Optional[Float] = None,
-        num_randbits: Optional[int] = None,
+        nmin: DefaultOr[int] = DEFAULT,
+        rm: DefaultOr[RoundingMode] = DEFAULT,
+        enable_nan: DefaultOr[bool] = DEFAULT,
+        enable_inf: DefaultOr[bool] = DEFAULT,
+        nan_value: DefaultOr[Optional[Float]] = DEFAULT,
+        inf_value: DefaultOr[Optional[Float]] = DEFAULT,
+        num_randbits: DefaultOr[Optional[int]] = DEFAULT,
         **kwargs
     ) -> 'MPFixedContext':
-        if nmin is None:
+        if nmin is DEFAULT:
             nmin = self.nmin
-        if rm is None:
+        if rm is DEFAULT:
             rm = self.rm
-        if enable_nan is None:
+        if enable_nan is DEFAULT:
             enable_nan = self.enable_nan
-        if enable_inf is None:
+        if enable_inf is DEFAULT:
             enable_inf = self.enable_inf
-        if nan_value is None:
+        if nan_value is DEFAULT:
             nan_value = self.nan_value
-        if inf_value is None:
+        if inf_value is DEFAULT:
             inf_value = self.inf_value
-        if num_randbits is None:
+        if num_randbits is DEFAULT:
             num_randbits = self.num_randbits
         if kwargs:
             raise TypeError(f'Unexpected parameters {kwargs} for MPFixedContext')

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -310,15 +310,12 @@ class MPFixedContext(OrdinalContext):
         match x:
             case Float() | RealFloat():
                 xr = x
+            case float():
+                xr = RealFloat.from_float(x)
             case int():
-                xr = RealFloat(m=x)
-            case float() | str():
+                xr = RealFloat.from_int(x)
+            case str() | Fraction():
                 xr = mpfr_value(x, n=self.nmin)
-            case Fraction():
-                if x.denominator == 1:
-                    xr = RealFloat(m=int(x))
-                else:
-                    xr = mpfr_value(x, n=self.nmin)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -187,6 +187,9 @@ class MPFixedContext(OrdinalContext):
             inf_value=inf_value
         )
 
+    def is_stochastic(self) -> bool:
+        return self.num_randbits != 0
+
     def is_equiv(self, other):
         if not isinstance(other, Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -311,9 +311,11 @@ class MPFixedContext(OrdinalContext):
             case Float() | RealFloat():
                 xr = x
             case float():
-                xr = RealFloat.from_float(x)
+                xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
+            case Fraction() if x.is_integer():
+                xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()
                 xr = mpfr_value(x, prec=p, n=n)

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -193,7 +193,7 @@ class MPFloatContext(Context):
                 xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
-            case Fraction() if x.is_integer():
+            case Fraction() if x.denominator == 1:
                 xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -87,7 +87,7 @@ class MPFloatContext(Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')
         return isinstance(other, MPFloatContext) and self.pmax == other.pmax
 
-    def is_representable(self, x: RealFloat | Float) -> bool:
+    def representable_under(self, x: RealFloat | Float) -> bool:
         match x:
             case Float():
                 if x.ctx is not None and self.is_equiv(x.ctx):
@@ -113,8 +113,8 @@ class MPFloatContext(Context):
             c_lost = x.c & bitmask(p_over) # bits that would be lost via normalization
             return c_lost == 0
 
-    def is_canonical(self, x: Float) -> bool:
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def canonical_under(self, x: Float) -> bool:
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
 
         # case split on class
@@ -129,7 +129,7 @@ class MPFloatContext(Context):
             return x.p == self.pmax
 
     def normalize(self, x: Float) -> Float:
-        if not isinstance(x, Float) or not self.is_representable(x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
 
         # case split by class
@@ -147,7 +147,7 @@ class MPFloatContext(Context):
             xr = x._real.normalize(self.pmax, None)
             return Float(x=x, exp=xr.exp, c=xr.c, ctx=self)
 
-    def is_normal(self, x: Float) -> bool:
+    def normal_under(self, x: Float) -> bool:
         if not isinstance(x, Float):
             raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
         return x.is_nonzero()

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -191,7 +191,8 @@ class MPFloatContext(Context):
             case int():
                 xr = RealFloat.from_int(x)
             case str() | Fraction():
-                xr = mpfr_value(x, prec=self.pmax)
+                p, n = self.round_params()
+                xr = mpfr_value(x, prec=p, n=n)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -6,7 +6,7 @@ that is, multi-precision floating-point numbers. Hence, "MP."
 from fractions import Fraction
 from typing import Optional
 
-from ..utils import default_repr, bitmask
+from ..utils import bitmask, default_repr, DefaultOr, DEFAULT
 
 from .context import Context
 from .number import RealFloat, Float
@@ -64,16 +64,16 @@ class MPFloatContext(Context):
 
     def with_params(
         self, *, 
-        pmax: Optional[int] = None,
-        rm: Optional[RoundingMode] = None,
-        num_randbits: Optional[int] = None,
+        pmax: DefaultOr[int] = DEFAULT,
+        rm: DefaultOr[RoundingMode] = DEFAULT,
+        num_randbits: DefaultOr[Optional[int]] = DEFAULT,
         **kwargs
     ) -> 'MPFloatContext':
-        if pmax is None:
+        if pmax is DEFAULT:
             pmax = self.pmax
-        if rm is None:
+        if rm is DEFAULT:
             rm = self.rm
-        if num_randbits is None:
+        if num_randbits is DEFAULT:
             num_randbits = self.num_randbits
         if kwargs:
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -79,6 +79,9 @@ class MPFloatContext(Context):
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')
         return MPFloatContext(pmax, rm, num_randbits)
 
+    def is_stochastic(self) -> bool:
+        return self.num_randbits != 0
+
     def is_equiv(self, other):
         if not isinstance(other, Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -186,15 +186,12 @@ class MPFloatContext(Context):
         match x:
             case Float() | RealFloat():
                 xr = x
+            case float():
+                xr = RealFloat.from_float(x)
             case int():
-                xr = RealFloat(m=x)
-            case float() | str():
+                xr = RealFloat.from_int(x)
+            case str() | Fraction():
                 xr = mpfr_value(x, prec=self.pmax)
-            case Fraction():
-                if x.denominator == 1:
-                    xr = RealFloat(m=int(x))
-                else:
-                    xr = mpfr_value(x, prec=self.pmax)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -187,9 +187,11 @@ class MPFloatContext(Context):
             case Float() | RealFloat():
                 xr = x
             case float():
-                xr = RealFloat.from_float(x)
+                xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
+            case Fraction() if x.is_integer():
+                xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()
                 xr = mpfr_value(x, prec=p, n=n)

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -383,9 +383,11 @@ class MPBFixedContext(SizedContext):
             case Float() | RealFloat():
                 xr = x
             case float():
-                xr = RealFloat.from_float(x)
+                xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
+            case Fraction() if x.is_integer():
+                xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()
                 xr = mpfr_value(x, prec=p, n=n)

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -264,7 +264,7 @@ class MPBFixedContext(SizedContext):
             and self.enable_nan == other.enable_nan
         )
 
-    def is_representable(self, x: RealFloat | Float) -> bool:
+    def representable_under(self, x: RealFloat | Float) -> bool:
         match x:
             case Float():
                 if x.ctx is not None and self.is_equiv(x.ctx):
@@ -275,7 +275,7 @@ class MPBFixedContext(SizedContext):
             case _:
                 raise TypeError(f'Expected \'RealFloat\' or \'Float\', got \'{type(x)}\' for x={x}')
 
-        if not self._mp_ctx.is_representable(x):
+        if not self._mp_ctx.representable_under(x):
             # not representable even without a maximum value
             return False
         elif not x.is_nonzero():
@@ -288,20 +288,20 @@ class MPBFixedContext(SizedContext):
             # check bounded (positive values)
             return x <= self.pos_maxval
 
-    def is_canonical(self, x: Float):
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def canonical_under(self, x: Float):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
-        return self._mp_ctx.is_canonical(x)
+        return self._mp_ctx.canonical_under(x)
 
     def normalize(self, x: Float) -> Float:
-        if not isinstance(x, Float) or not self.is_representable(x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return Float(x=self._mp_ctx.normalize(x), ctx=self)
 
-    def is_normal(self, x: Float) -> bool:
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def normal_under(self, x: Float) -> bool:
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
-        return self._mp_ctx.is_normal(x)
+        return self._mp_ctx.normal_under(x)
 
     def round_params(self):
         return self._mp_ctx.round_params()
@@ -408,7 +408,7 @@ class MPBFixedContext(SizedContext):
         return self._round_at(x, n, exact)
 
     def to_ordinal(self, x: Float, infval: bool = False) -> int:
-        if not isinstance(x, Float) or not self.is_representable(x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected \'Float\' for x={x}, got {type(x)}')
 
         # case split by class

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -389,7 +389,7 @@ class MPBFixedContext(SizedContext):
                 xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
-            case Fraction() if x.is_integer():
+            case Fraction() if x.denominator == 1:
                 xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -6,7 +6,7 @@ that is, multiprecision and bounded. Hence "MP-B".
 from fractions import Fraction
 from typing import Optional
 
-from ..utils import default_repr
+from ..utils import default_repr, DefaultOr, DEFAULT
 
 from .context import Context, SizedContext
 from .mp_fixed import MPFixedContext
@@ -200,39 +200,39 @@ class MPBFixedContext(SizedContext):
 
     def with_params(
         self, *,
-        nmin: Optional[int] = None,
-        maxval: Optional[RealFloat] = None,
-        rm: Optional[RoundingMode] = None,
-        overflow: Optional[OverflowMode] = None,
-        num_randbits: Optional[int] = None,
-        neg_maxval: Optional[RealFloat] = None,
-        enable_nan: Optional[bool] = None,
-        enable_inf: Optional[bool] = None,
-        nan_value: Optional[Float] = None,
-        inf_value: Optional[Float] = None,
+        nmin: DefaultOr[int] = DEFAULT,
+        maxval: DefaultOr[RealFloat] = DEFAULT,
+        rm: DefaultOr[RoundingMode] = DEFAULT,
+        overflow: DefaultOr[OverflowMode] = DEFAULT,
+        num_randbits: DefaultOr[Optional[int]] = DEFAULT,
+        neg_maxval: DefaultOr[RealFloat] = DEFAULT,
+        enable_nan: DefaultOr[bool] = DEFAULT,
+        enable_inf: DefaultOr[bool] = DEFAULT,
+        nan_value: DefaultOr[Float | None] = DEFAULT,
+        inf_value: DefaultOr[Float | None] = DEFAULT,
         **kwargs
     ) -> 'MPBFixedContext':
-        if nmin is None:
+        if nmin is DEFAULT:
             nmin = self.nmin
-        if maxval is None:
+        if maxval is DEFAULT:
             maxval = self.pos_maxval
-        if rm is None:
+        if rm is DEFAULT:
             rm = self.rm
-        if overflow is None:
+        if overflow is DEFAULT:
             overflow = self.overflow
-        if num_randbits is None:
+        if num_randbits is DEFAULT:
             num_randbits = self.num_randbits
-        if neg_maxval is None:
+        if neg_maxval is DEFAULT:
             neg_maxval = self.neg_maxval
-        if neg_maxval is None:
+        if neg_maxval is DEFAULT:
             neg_maxval = self.neg_maxval
-        if enable_nan is None:
+        if enable_nan is DEFAULT:
             enable_nan = self.enable_nan
-        if enable_inf is None:
+        if enable_inf is DEFAULT:
             enable_inf = self.enable_inf
-        if nan_value is None:
+        if nan_value is DEFAULT:
             nan_value = self.nan_value
-        if inf_value is None:
+        if inf_value is DEFAULT:
             inf_value = self.inf_value
         if kwargs:
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')
@@ -352,7 +352,6 @@ class MPBFixedContext(SizedContext):
             return Float(ctx=self)
 
         # step 3. round value based on rounding parameters
-        print(self.num_randbits)
         xr = xr.round(min_n=n, rm=self.rm, num_randbits=self.num_randbits, exact=exact)
 
         # step 4. check for overflow

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -249,6 +249,9 @@ class MPBFixedContext(SizedContext):
             inf_value=inf_value
         )
 
+    def is_stochastic(self) -> bool:
+        return self.num_randbits != 0
+
     def is_equiv(self, other):
         if not isinstance(other, Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -380,15 +380,12 @@ class MPBFixedContext(SizedContext):
         match x:
             case Float() | RealFloat():
                 xr = x
+            case float():
+                xr = RealFloat.from_float(x)
             case int():
-                xr = RealFloat(m=x)
-            case float() | str():
+                xr = RealFloat.from_int(x)
+            case str() | Fraction():
                 xr = mpfr_value(x, n=self.nmin)
-            case Fraction():
-                if x.denominator == 1:
-                    xr = RealFloat(m=int(x))
-                else:
-                    xr = mpfr_value(x, n=self.nmin)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -220,6 +220,8 @@ class MPBFixedContext(SizedContext):
             rm = self.rm
         if overflow is None:
             overflow = self.overflow
+        if num_randbits is None:
+            num_randbits = self.num_randbits
         if neg_maxval is None:
             neg_maxval = self.neg_maxval
         if neg_maxval is None:
@@ -350,6 +352,7 @@ class MPBFixedContext(SizedContext):
             return Float(ctx=self)
 
         # step 3. round value based on rounding parameters
+        print(self.num_randbits)
         xr = xr.round(min_n=n, rm=self.rm, num_randbits=self.num_randbits, exact=exact)
 
         # step 4. check for overflow
@@ -385,7 +388,8 @@ class MPBFixedContext(SizedContext):
             case int():
                 xr = RealFloat.from_int(x)
             case str() | Fraction():
-                xr = mpfr_value(x, n=self.nmin)
+                p, n = self.round_params()
+                xr = mpfr_value(x, prec=p, n=n)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -201,7 +201,7 @@ class MPBFloatContext(SizedContext):
             and self.neg_maxval == other.neg_maxval
         )
 
-    def is_representable(self, x: RealFloat | Float) -> bool:
+    def representable_under(self, x: RealFloat | Float) -> bool:
         match x:
             case Float():
                 if x.ctx is not None and self.is_equiv(x.ctx):
@@ -212,7 +212,7 @@ class MPBFloatContext(SizedContext):
             case _:
                 raise TypeError(f'Expected \'RealFloat\' or \'Float\', got \'{type(x)}\' for x={x}')
 
-        if not self._mps_ctx.is_representable(x):
+        if not self._mps_ctx.representable_under(x):
             # not representable even without a maximum value
             return False
         elif not x.is_nonzero():
@@ -225,21 +225,21 @@ class MPBFloatContext(SizedContext):
             # check bounded (non-negative values)
             return x <= self.pos_maxval
 
-    def is_canonical(self, x: Float):
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def canonical_under(self, x: Float):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
-        return self._mps_ctx.is_canonical(x)
+        return self._mps_ctx.canonical_under(x)
 
-    def is_normal(self, x: Float):
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def normal_under(self, x: Float):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
-        return self._mps_ctx.is_normal(x)
+        return self._mps_ctx.normal_under(x)
 
     def _normalize(self, x: Float) -> Float:
         return self._mps_ctx._normalize(x)
 
     def normalize(self, x: Float):
-        if not isinstance(x, Float) or not self.is_representable(x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return Float(x=self._normalize(x), ctx=self)
 
@@ -355,7 +355,7 @@ class MPBFloatContext(SizedContext):
     def to_ordinal(self, x: Float, infval = False):
         if not isinstance(x, Float):
             raise TypeError(f'Expected a \'Float\', got \'{type(x)}\' for x={x}')
-        if not self.is_representable(x):
+        if not self.representable_under(x):
             raise ValueError(f'Expected a representable \'Float\', got x={x} (x.ctx={x.ctx})')
 
         # case split by class

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -334,7 +334,8 @@ class MPBFloatContext(SizedContext):
             case int():
                 xr = RealFloat.from_int(x)
             case str() | Fraction():
-                xr = mpfr_value(x, prec=self.pmax)
+                p, n = self.round_params()
+                xr = mpfr_value(x, prec=p, n=n)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -7,7 +7,7 @@ and bounded. Hence, "MP-B."
 from fractions import Fraction
 from typing import Optional
 
-from ..utils import default_repr
+from ..utils import default_repr, DefaultOr, DEFAULT
 
 from .context import Context, SizedContext
 from .number import RealFloat, Float
@@ -161,28 +161,28 @@ class MPBFloatContext(SizedContext):
 
     def with_params(
         self, *,
-        pmax: Optional[int] = None,
-        emin: Optional[int] = None,
-        maxval: Optional[RealFloat] = None,
-        rm: Optional[RoundingMode] = None,
-        overflow: Optional[OverflowMode] = None,
-        neg_maxval: Optional[RealFloat] = None,
-        num_randbits: Optional[int] = None,
+        pmax: DefaultOr[int] = DEFAULT,
+        emin: DefaultOr[int] = DEFAULT,
+        maxval: DefaultOr[RealFloat] = DEFAULT,
+        rm: DefaultOr[RoundingMode] = DEFAULT,
+        overflow: DefaultOr[OverflowMode] = DEFAULT,
+        neg_maxval: DefaultOr[RealFloat] = DEFAULT,
+        num_randbits: DefaultOr[Optional[int]] = DEFAULT,
         **kwargs
     ) -> 'MPBFloatContext':
-        if pmax is None:
+        if pmax is DEFAULT:
             pmax = self.pmax
-        if emin is None:
+        if emin is DEFAULT:
             emin = self.emin
-        if maxval is None:
+        if maxval is DEFAULT:
             maxval = self.pos_maxval
-        if rm is None:
+        if rm is DEFAULT:
             rm = self.rm
-        if overflow is None:
+        if overflow is DEFAULT:
             overflow = self.overflow
-        if neg_maxval is None:
+        if neg_maxval is DEFAULT:
             neg_maxval = self.neg_maxval
-        if num_randbits is None:
+        if num_randbits is DEFAULT:
             num_randbits = self.num_randbits
         if kwargs:
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -330,9 +330,11 @@ class MPBFloatContext(SizedContext):
             case Float() | RealFloat():
                 xr = x
             case float():
-                xr = RealFloat.from_float(x)
+                xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
+            case Fraction() if x.is_integer():
+                xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()
                 xr = mpfr_value(x, prec=p, n=n)

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -188,6 +188,9 @@ class MPBFloatContext(SizedContext):
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')
         return MPBFloatContext(pmax, emin, maxval, rm, overflow, neg_maxval=neg_maxval)
 
+    def is_stochastic(self) -> bool:
+        return self.num_randbits != 0
+
     def is_equiv(self, other):
         if not isinstance(other, Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -336,7 +336,7 @@ class MPBFloatContext(SizedContext):
                 xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
-            case Fraction() if x.is_integer():
+            case Fraction() if x.denominator == 1:
                 xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -329,15 +329,12 @@ class MPBFloatContext(SizedContext):
         match x:
             case Float() | RealFloat():
                 xr = x
+            case float():
+                xr = RealFloat.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
-            case float() | str():
+            case str() | Fraction():
                 xr = mpfr_value(x, prec=self.pmax)
-            case Fraction():
-                if x.denominator == 1:
-                    xr = RealFloat.from_int(int(x))
-                else:
-                    xr = mpfr_value(x, prec=self.pmax)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -242,15 +242,12 @@ class MPSFloatContext(OrdinalContext):
         match x:
             case Float() | RealFloat():
                 xr = x
+            case float():
+                xr = RealFloat.from_float(x)
             case int():
-                xr = RealFloat(m=x)
-            case float() | str():
+                xr = RealFloat.from_int(x)
+            case str() | Fraction():
                 xr = mpfr_value(x, prec=self.pmax)
-            case Fraction():
-                if x.denominator == 1:
-                    xr = RealFloat(m=int(x))
-                else:
-                    xr = mpfr_value(x, prec=self.pmax)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -121,6 +121,9 @@ class MPSFloatContext(OrdinalContext):
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')
         return MPSFloatContext(pmax, emin, rm, num_randbits)
 
+    def is_stochastic(self) -> bool:
+        return self.num_randbits != 0
+
     def is_equiv(self, other):
         if not isinstance(other, Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -7,7 +7,7 @@ numbers with subnormals. Hence, "MP-S."
 from fractions import Fraction
 from typing import Optional
 
-from ..utils import default_repr, bitmask
+from ..utils import bitmask, default_repr, DefaultOr, DEFAULT
 
 from .context import Context, OrdinalContext
 from .number import RealFloat, Float
@@ -103,19 +103,19 @@ class MPSFloatContext(OrdinalContext):
 
     def with_params(
         self, *,
-        pmax: Optional[int] = None,
-        emin: Optional[int] = None,
-        rm: Optional[RoundingMode] = None,
-        num_randbits: Optional[int] = None,
+        pmax: DefaultOr[int] = DEFAULT,
+        emin: DefaultOr[int] = DEFAULT,
+        rm: DefaultOr[RoundingMode] = DEFAULT,
+        num_randbits: DefaultOr[Optional[int]] = DEFAULT,
         **kwargs
     ) -> 'MPSFloatContext':
-        if pmax is None:
+        if pmax is DEFAULT:
             pmax = self.pmax
-        if emin is None:
+        if emin is DEFAULT:
             emin = self.emin
-        if rm is None:
+        if rm is DEFAULT:
             rm = self.rm
-        if num_randbits is None:
+        if num_randbits is DEFAULT:
             num_randbits = self.num_randbits
         if kwargs:
             raise TypeError(f'Unexpected keyword arguments: {kwargs}')

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -56,7 +56,7 @@ class MPSFloatContext(OrdinalContext):
         pmax: int,
         emin: int,
         rm: RoundingMode = RoundingMode.RNE,
-        num_randbits: Optional[int] = None
+        num_randbits: Optional[int] = 0
     ):
         if not isinstance(pmax, int):
             raise TypeError(f'Expected \'int\' for pmax={pmax}, got {type(pmax)}')
@@ -243,9 +243,11 @@ class MPSFloatContext(OrdinalContext):
             case Float() | RealFloat():
                 xr = x
             case float():
-                xr = RealFloat.from_float(x)
+                xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
+            case Fraction() if x.is_integer():
+                xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()
                 xr = mpfr_value(x, prec=p, n=n)

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -247,7 +247,8 @@ class MPSFloatContext(OrdinalContext):
             case int():
                 xr = RealFloat.from_int(x)
             case str() | Fraction():
-                xr = mpfr_value(x, prec=self.pmax)
+                p, n = self.round_params()
+                xr = mpfr_value(x, prec=p, n=n)
             case _:
                 raise TypeError(f'not valid argument x={x}')
 

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -133,7 +133,7 @@ class MPSFloatContext(OrdinalContext):
             and self.emin == other.emin
         )
 
-    def is_representable(self, x: RealFloat | Float) -> bool:
+    def representable_under(self, x: RealFloat | Float) -> bool:
         match x:
             case Float():
                 if x.ctx is not None and self.is_equiv(x.ctx):
@@ -144,7 +144,7 @@ class MPSFloatContext(OrdinalContext):
             case _:
                 raise TypeError(f'Expected \'RealFloat\' or \'Float\', got \'{type(x)}\' for x={x}')
 
-        if not self._mp_ctx.is_representable(x):
+        if not self._mp_ctx.representable_under(x):
             # not representable even without subnormalization
             return False
         elif not x.is_nonzero():
@@ -157,8 +157,8 @@ class MPSFloatContext(OrdinalContext):
             # tight check (non-negative values)
             return self._pos_minval <= x
 
-    def is_canonical(self, x):
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def canonical_under(self, x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
 
         # case split by class
@@ -192,12 +192,12 @@ class MPSFloatContext(OrdinalContext):
             return Float(x=x, exp=xr.exp, c=xr.c, ctx=self)
 
     def normalize(self, x):
-        if not isinstance(x, Float) or not self.is_representable(x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return self._normalize(x)
 
-    def is_normal(self, x: Float):
-        if not isinstance(x, Float) or not self.is_representable(x):
+    def normal_under(self, x: Float):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return x.is_nonzero() and x.e >= self.emin
 
@@ -266,7 +266,7 @@ class MPSFloatContext(OrdinalContext):
         return self._round_at(x, n, exact)
 
     def to_ordinal(self, x: Float, infval = False) -> int:
-        if not isinstance(x, Float) or not self.is_representable(x):
+        if not isinstance(x, Float) or not self.representable_under(x):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         if infval:
             raise ValueError('infval=True is invalid for contexts without a maximum value')

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -249,7 +249,7 @@ class MPSFloatContext(OrdinalContext):
                 xr = Float.from_float(x)
             case int():
                 xr = RealFloat.from_int(x)
-            case Fraction() if x.is_integer():
+            case Fraction() if x.denominator == 1:
                 xr = RealFloat.from_int(int(x))
             case str() | Fraction():
                 p, n = self.round_params()

--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -1514,7 +1514,7 @@ class Float(numbers.Rational):
         the rounding context during its construction.
         Usually just a sanity check.
         """
-        return self._ctx is None or self._ctx.is_representable(self)
+        return self._ctx is None or self._ctx.representable_under(self)
 
     def is_canonical(self) -> bool:
         """
@@ -1529,7 +1529,7 @@ class Float(numbers.Rational):
         """
         if self._ctx is None:
             raise ValueError(f'Float values without a context cannot be normalized: self={self}')
-        return self._ctx.is_canonical(self)
+        return self._ctx.canonical_under(self)
 
     def is_normal(self) -> bool:
         """
@@ -1540,7 +1540,7 @@ class Float(numbers.Rational):
         """
         if self._ctx is None:
             raise ValueError(f'Float values without a context cannot be normalized: self={self}')
-        return self._ctx.is_normal(self)
+        return self._ctx.normal_under(self)
 
     def as_rational(self) -> Fraction:
         """
@@ -1600,7 +1600,7 @@ class Float(numbers.Rational):
         if ctx is None:
             # no context specified, so its rounded exactly
             return Float(x=x, ctx=ctx)
-        elif checked and not ctx.is_representable(x):
+        elif checked and not ctx.representable_under(x):
             # context specified, but `x` is not representable under it
             raise ValueError(f'{x} is not representable under {ctx}')
         else:

--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -1043,6 +1043,8 @@ class RealFloat(numbers.Rational):
         at most `p` bits. If `exact` is `True`, the result must be exact.
         """
 
+        print('stochastic')
+
         # step 1. compute the actual number of rounding bits to use
         if num_randbits is None:
             # use all the bits (in theory, `num_randbits == float('inf')`)

--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -1042,9 +1042,7 @@ class RealFloat(numbers.Rational):
         Optionally, specify `p` to limit the precision of the result to
         at most `p` bits. If `exact` is `True`, the result must be exact.
         """
-
-        print('stochastic')
-
+    
         # step 1. compute the actual number of rounding bits to use
         if num_randbits is None:
             # use all the bits (in theory, `num_randbits == float('inf')`)

--- a/fpy2/number/real.py
+++ b/fpy2/number/real.py
@@ -38,12 +38,12 @@ class RealContext(Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')
         return isinstance(other, RealContext)
 
-    def is_representable(self, x: RealFloat | Float):
+    def representable_under(self, x: RealFloat | Float):
         if not isinstance(x, RealFloat | Float):
             raise TypeError(f'Expected \'RealFloat\' or \'Float\', got \'{type(x)}\' for x={x}')
         return True
 
-    def is_canonical(self, x: Float):
+    def canonical_under(self, x: Float):
         if not isinstance(x, Float):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return True
@@ -51,7 +51,7 @@ class RealContext(Context):
     def normalize(self, x: Float) -> Float:
         return Float(x=x, ctx=self)
 
-    def is_normal(self, x: Float) -> bool:
+    def normal_under(self, x: Float) -> bool:
         if not isinstance(x, Float):
             raise TypeError(f'Expected a representable \'Float\', got \'{type(x)}\' for x={x}')
         return x.is_nonzero()

--- a/fpy2/number/real.py
+++ b/fpy2/number/real.py
@@ -30,6 +30,9 @@ class RealContext(Context):
             raise TypeError(f'Unexpected parameters {kwargs} for RealContext')
         return self
 
+    def is_stochastic(self) -> bool:
+        return False
+
     def is_equiv(self, other: Context) -> bool:
         if not isinstance(other, Context):
             raise TypeError(f'Expected \'Context\', got \'{type(other)}\' for other={other}')

--- a/fpy2/utils/__init__.py
+++ b/fpy2/utils/__init__.py
@@ -3,6 +3,7 @@
 from .bits import bitmask, is_power_of_two, float_to_bits, bits_to_float
 from .compare import CompareOp
 from .decorator import default_repr, rcomparable, enum_repr
+from .default import DefaultOr, DEFAULT
 
 from .float_params import (
     FP64_NBITS,

--- a/fpy2/utils/decorator.py
+++ b/fpy2/utils/decorator.py
@@ -30,7 +30,7 @@ def __default_repr__(x: object):
             value = getattr(x, slot)
             items.append(f'{slot}={value!r}')
 
-    return f'{x.__class__.__name__}({" ".join(items)})'
+    return f'{x.__class__.__name__}({", ".join(items)})'
 
 def default_repr(cls):
     """Default __repr__ implementation for a class."""

--- a/fpy2/utils/default.py
+++ b/fpy2/utils/default.py
@@ -1,0 +1,24 @@
+from typing import TypeVar, Union, Literal, TypeAlias
+from enum import Enum
+
+"""
+Default value instead of `None`
+"""
+
+class Default(Enum):
+    """
+    `None`-like object which is not `None`
+
+    Useful for functions that allow a keyword to be not provided
+    but `None` is a valid "provided" value.
+    """
+    DEFAULT = "DEFAULT"
+
+    def __repr__(self):
+        return "DEFAULT"
+
+DEFAULT = Default.DEFAULT
+
+
+T = TypeVar('T')
+DefaultOr: TypeAlias = Union[T, Literal[Default.DEFAULT]]

--- a/tests/unit/generators.py
+++ b/tests/unit/generators.py
@@ -13,11 +13,48 @@ def rounding_modes(draw):
     return draw(st.sampled_from([fp.RM.RNE, fp.RM.RNA, fp.RM.RTP, fp.RM.RTN, fp.RM.RTZ, fp.RM.RAZ, fp.RM.RTO, fp.RM.RTE]))
 
 @st.composite
-def real_floats(draw, p):
+def real_floats(draw, prec: int, exp_min: int | None = None, exp_max: int | None = None):
     """
     Returns a strategy for generating a RealFloat with some maximum precision `p`.
     """
     s = draw(st.booleans())
-    exp = draw(st.integers())
-    c = draw(st.integers(min_value=0, max_value=2**p - 1))
+    exp = draw(st.integers(min_value=exp_min, max_value=exp_max))
+    c = draw(st.integers(min_value=0, max_value=(1 << prec) - 1))
     return fp.RealFloat(s, exp, c)
+
+@st.composite
+def floats(
+    draw,
+    prec: int,
+    exp_min: int | None = None,
+    exp_max: int | None = None,
+    allow_nan: bool = True,
+    allow_infinity: bool = True,
+    ctx: fp.Context | None = None
+):
+    """
+    Returns a strategy for generating a Float. If ctx is provided,
+    the generated Float must be representable in that context.
+    """
+    # Choose between finite, infinite, or NaN values
+    classes = ['finite']
+    if allow_infinity:
+        classes.append('inf')
+    if allow_nan:
+        classes.append('nan')
+
+    float_type = draw(st.sampled_from(classes))
+    if float_type == 'nan':
+        return fp.Float.nan()
+    elif float_type == 'inf':
+        s = draw(st.booleans())
+        return fp.Float.inf(s)
+    else:  # finite
+        if ctx is not None:
+            # Generate representable finite float
+            x = draw(real_floats(prec, exp_min, exp_max).filter(lambda x: ctx.is_representable(x)))
+            return fp.Float.from_real(x, ctx)
+        else:
+            # Generate arbitrary finite float
+            x = draw(real_floats(prec, exp_min, exp_max))
+            return fp.Float.from_real(x)

--- a/tests/unit/generators.py
+++ b/tests/unit/generators.py
@@ -52,7 +52,7 @@ def floats(
     else:  # finite
         if ctx is not None:
             # Generate representable finite float
-            x = draw(real_floats(prec, exp_min, exp_max).filter(lambda x: ctx.is_representable(x)))
+            x = draw(real_floats(prec, exp_min, exp_max).filter(lambda x: ctx.representable_under(x)))
             return fp.Float.from_real(x, ctx)
         else:
             # Generate arbitrary finite float

--- a/tests/unit/generators.py
+++ b/tests/unit/generators.py
@@ -1,0 +1,23 @@
+"""
+Custom generators for Hypothesis tests.
+"""
+
+import fpy2 as fp
+from hypothesis import strategies as st
+
+@st.composite
+def rounding_modes(draw):
+    """
+    Returns a strategy for generating a rounding mode.
+    """
+    return draw(st.sampled_from([fp.RM.RNE, fp.RM.RNA, fp.RM.RTP, fp.RM.RTN, fp.RM.RTZ, fp.RM.RAZ, fp.RM.RTO, fp.RM.RTE]))
+
+@st.composite
+def real_floats(draw, p):
+    """
+    Returns a strategy for generating a RealFloat with some maximum precision `p`.
+    """
+    s = draw(st.booleans())
+    exp = draw(st.integers())
+    c = draw(st.integers(min_value=0, max_value=2**p - 1))
+    return fp.RealFloat(s, exp, c)

--- a/tests/unit/number/ext/test_encode.py
+++ b/tests/unit/number/ext/test_encode.py
@@ -41,7 +41,7 @@ class EncodeTestCase(unittest.TestCase):
                 for exp in range(ctx.expmin, expmax + 1):
                     for c in range(0, 1 << ctx.pmax - 1):
                         xr = RealFloat(s, exp, c)
-                        if ctx.is_representable(xr):
+                        if ctx.representable_under(xr):
                             xs.append(Float(x=xr, ctx=ctx))
             # run encoding
             for x in xs:

--- a/tests/unit/number/ext/test_ordinal.py
+++ b/tests/unit/number/ext/test_ordinal.py
@@ -25,7 +25,7 @@ class ToOrdinalTestCase(unittest.TestCase):
                 for exp in range(ctx.expmin, ctx.expmax + 1):
                     for c in range(0, 1 << ctx.pmax):
                         xr = RealFloat(s, exp, c)
-                        if ctx.is_representable(xr):
+                        if ctx.representable_under(xr):
                             x = Float(x=xr, ctx=ctx)
                             i = ctx.to_ordinal(x)
                             self.assertIsInstance(i, int, f'x={x}, i={i}')
@@ -44,7 +44,7 @@ class OrdinalRoundTripTestCase(unittest.TestCase):
                 for exp in range(ctx.expmin, ctx.expmax + 1):
                     for c in range(0, 1 << ctx.pmax):
                         xr = RealFloat(s, exp, c)
-                        if ctx.is_representable(xr):
+                        if ctx.representable_under(xr):
                             # run ordinal conversion
                             x = Float(x=xr, ctx=ctx)
                             i = ctx.to_ordinal(x)

--- a/tests/unit/number/ieee754/test_encode.py
+++ b/tests/unit/number/ieee754/test_encode.py
@@ -37,7 +37,7 @@ class EncodeTestCase(unittest.TestCase):
             exp = random.randint(FP64.expmin, FP64.expmax)
             c = random.randint(0, (1 << FP64.pmax) - 1)
             x = Float(s, exp, c, ctx=FP64)
-            assert FP64.is_representable(x)
+            assert FP64.representable_under(x)
             xs.append(x)
         # run encoding
         for x in xs:
@@ -56,7 +56,7 @@ class EncodeTestCase(unittest.TestCase):
                     for exp in range(ctx.expmin, ctx.expmax):
                         for c in range(0, 1 << ctx.pmax):
                             x = Float(s, exp, c, ctx=ctx)
-                            assert ctx.is_representable(x)
+                            assert ctx.representable_under(x)
 
                             i = ctx.encode(x)
                             self.assertIsInstance(i, int, f'x={x}, i={i}')

--- a/tests/unit/number/ieee754/test_ordinal.py
+++ b/tests/unit/number/ieee754/test_ordinal.py
@@ -23,7 +23,7 @@ class ToOrdinalTestCase(unittest.TestCase):
             exp = random.randint(fp64.expmin, fp64.expmax)
             c = random.randint(0, 1 << fp64.pmax)
             x = Float(s, exp, c, ctx=fp64)
-            assert fp64.is_representable(x)
+            assert fp64.representable_under(x)
             xs.append(x)
         # run ordinal conversion
         for x in xs:
@@ -42,7 +42,7 @@ class ToOrdinalTestCase(unittest.TestCase):
                     for exp in range(ctx.expmin, ctx.expmax):
                         for c in range(0, 1 << ctx.pmax):
                             x = Float(s, exp, c, ctx=ctx)
-                            assert ctx.is_representable(x)
+                            assert ctx.representable_under(x)
 
                             i = ctx.to_ordinal(x)
                             self.assertIsInstance(i, int, f'x={x}, i={i}')
@@ -101,7 +101,7 @@ class OrdinalRoundTripTestCase(unittest.TestCase):
             exp = random.randint(fp64.expmin, fp64.expmax)
             c = random.randint(0, 1 << fp64.pmax)
             x = Float(s, exp, c, ctx=fp64)
-            assert fp64.is_representable(x)
+            assert fp64.representable_under(x)
             xs.append(x)
         # run ordinal conversion
         for x in xs:
@@ -120,7 +120,7 @@ class OrdinalRoundTripTestCase(unittest.TestCase):
                     for exp in range(ctx.expmin, ctx.expmax):
                         for c in range(0, 1 << ctx.pmax):
                             x = Float(s, exp, c, ctx=ctx)
-                            assert ctx.is_representable(x)
+                            assert ctx.representable_under(x)
 
                             # run ordinal conversion
                             i = ctx.to_ordinal(x)

--- a/tests/unit/number/real/test_round.py
+++ b/tests/unit/number/real/test_round.py
@@ -55,7 +55,7 @@ class RoundTestCase(unittest.TestCase):
             self.assertEqual(x_rounded, expect, f'x={x}, rm={rm!r}, x_rounded={x_rounded}, expect={expect}')
 
     @given(
-        real_floats(2),
+        real_floats(100),
         st.one_of(st.none(), st.integers(min_value=0)),
         st.one_of(st.none(), st.integers()),
         rounding_modes()
@@ -64,7 +64,6 @@ class RoundTestCase(unittest.TestCase):
         if p is not None or n is not None:
             rounded = x.round(max_p=p, min_n=n, rm=rm)
             self.assertIsInstance(rounded, fp.RealFloat)
-
 
 class RoundStochasticTestCase(unittest.TestCase):
     """Testing `RealFloat.round()` with stochastic rounding"""
@@ -105,7 +104,7 @@ class RoundStochasticTestCase(unittest.TestCase):
             self.assertEqual(x_rounded, expect, f'x={x}, randbits={randbits}, x_rounded={x_rounded}, expect={expect}')
 
     @given(
-        real_floats(2),
+        real_floats(100),
         st.one_of(st.none(), st.integers(min_value=0)),
         st.one_of(st.none(), st.integers()),
         st.integers(min_value=1, max_value=100),
@@ -115,3 +114,112 @@ class RoundStochasticTestCase(unittest.TestCase):
         if p is not None or n is not None:
             rounded = x.round(max_p=p, min_n=n, rm=rm, num_randbits=num_randbits)
             self.assertIsInstance(rounded, fp.RealFloat)
+
+
+class RoundAtTestCase(unittest.TestCase):
+    """Testing `RealFloat.round_at()`"""
+
+    def test_valid(self):
+        inputs = [
+            # 8 * 2 ** -3 (representable)
+            (-3, 8, -1, 2, fp.RM.RNE), # 8 * 2 ** -3 => 1 * 2 ** -1
+            (-3, 8, -1, 2, fp.RM.RNA), # 8 * 2 ** -3 => 1 * 2 ** -1
+            (-3, 8, -1, 2, fp.RM.RTP), # 8 * 2 ** -3 => 1 * 2 ** -1
+            (-3, 8, -1, 2, fp.RM.RTN), # 8 * 2 ** -3 => 1 * 2 ** -1
+            (-3, 8, -1, 2, fp.RM.RTZ), # 8 * 2 ** -3 => 1 * 2 ** -1
+            (-3, 8, -1, 2, fp.RM.RAZ), # 8 * 2 ** -3 => 1 * 2 ** -1
+            # 9 * 2 ** -3 (below halfway)
+            (-3, 9, -1, 2, fp.RM.RNE), # 9 * 2 ** -3 => 1 * 2 ** -1 (down)
+            (-3, 9, -1, 2, fp.RM.RNA), # 9 * 2 ** -3 => 1 * 2 ** -1 (down)
+            (-3, 9, -1, 3, fp.RM.RTP), # 9 * 2 ** -3 => 1 * 3 ** -1 (up)
+            (-3, 9, -1, 2, fp.RM.RTN), # 9 * 2 ** -3 => 1 * 2 ** -1 (down)
+            (-3, 9, -1, 2, fp.RM.RTZ), # 9 * 2 ** -3 => 1 * 2 ** -1 (down)
+            (-3, 9, -1, 3, fp.RM.RAZ), # 9 * 2 ** -3 => 1 * 3 ** -1 (up)
+            # 10 * 2 ** -3 (exactly halfway)
+            (-3, 10, -1, 2, fp.RM.RNE), # 10 * 2 ** -3 => 1 * 2 ** -1 (down)
+            (-3, 10, -1, 3, fp.RM.RNA), # 10 * 2 ** -3 => 1 * 3 ** -1 (up)
+            (-3, 10, -1, 3, fp.RM.RTP), # 10 * 2 ** -3 => 1 * 3 ** -1 (up)
+            (-3, 10, -1, 2, fp.RM.RTN), # 10 * 2 ** -3 => 1 * 2 ** -1 (down)
+            (-3, 10, -1, 2, fp.RM.RTZ), # 10 * 2 ** -3 => 1 * 2 ** -1 (down)
+            (-3, 10, -1, 3, fp.RM.RAZ), # 10 * 2 ** -3 => 1 * 3 ** -1 (up)
+            # 11 * 2 ** -3 (above halfway)
+            (-3, 11, -1, 3, fp.RM.RNE), # 11 * 2 ** -3 => 1 * 3 ** -1 (up)
+            (-3, 11, -1, 3, fp.RM.RNA), # 11 * 2 ** -3 => 1 * 3 ** -1 (up)
+            (-3, 11, -1, 3, fp.RM.RTP), # 11 * 2 ** -3 => 1 * 3 ** -1 (up)
+            (-3, 11, -1, 2, fp.RM.RTN), # 11 * 2 ** -3 => 1 * 2 ** -1 (down)
+            (-3, 11, -1, 2, fp.RM.RTZ), # 11 * 2 ** -3 => 1 * 2 ** -1 (down
+            (-3, 11, -1, 3, fp.RM.RAZ), # 11 * 2 ** -3 => 1 * 3 ** -1 (up)
+            # 12 * 2 ** -3 (representable)
+            (-3, 12, -1, 3, fp.RM.RNE), # 12 * 2 ** -3 => 1 * 3 ** -1
+            (-3, 12, -1, 3, fp.RM.RNA), # 12 * 2 ** -3 => 1 * 3 ** -1
+            (-3, 12, -1, 3, fp.RM.RTP), # 12 * 2 ** -3 => 1 * 3 ** -1
+            (-3, 12, -1, 3, fp.RM.RTN), # 12 * 2 ** -3 => 1 * 3 ** -1
+            (-3, 12, -1, 3, fp.RM.RTZ), # 12 * 2 ** -3 => 1 * 3 ** -1
+            (-3, 12, -1, 3, fp.RM.RAZ), # 12 * 2 ** -3 => 1 * 3 ** -1
+        ]
+
+        for exp, c, exp_rounded, c_rounded, rm in inputs:
+            x = fp.RealFloat(exp=exp, c=c)
+            x_rounded = x.round_at(n=-2, rm=rm)
+            expect = fp.RealFloat(exp=exp_rounded, c=c_rounded)
+            self.assertEqual(x_rounded, expect, f'x={x}, rm={rm!r}, x_rounded={x_rounded}, expect={expect}')
+
+    @given(
+        real_floats(100),
+        st.integers(),
+        st.one_of(st.none(), st.integers()),
+        rounding_modes()
+    )
+    def test_fuzz(self, x: fp.RealFloat, n: int, p: int | None, rm: fp.RoundingMode):
+        rounded = x.round_at(n=n, rm=rm)
+        self.assertIsInstance(rounded, fp.RealFloat)
+
+
+
+class RoundStochasticAtTestCase(unittest.TestCase):
+    """Testing `RealFloat.round_at()` with stochastic rounding"""
+
+    def test_valid(self):
+        inputs = [
+            # 8 * 2 ** -3 (representable)
+            (-3, 8, -1, 2, 0), # 8 * 2 ** -3 => 1 * 2 ** -1 (0: down)
+            (-3, 8, -1, 2, 1), # 8 * 2 ** -3 => 1 * 2 ** -1 (1: down)
+            (-3, 8, -1, 2, 2), # 8 * 2 ** -3 => 1 * 2 ** -1 (2: down)
+            (-3, 8, -1, 2, 3), # 8 * 2 ** -3 => 1 * 2 ** -1 (3: down)
+            # 9 * 2 ** -3 (below halfway)
+            (-3, 9, -1, 3, 0), # 9 * 2 ** -3 => 1 * 2 ** -1 (0: up)
+            (-3, 9, -1, 2, 1), # 9 * 2 ** -3 => 1 * 2 ** -1 (1: down)
+            (-3, 9, -1, 2, 2), # 9 * 2 ** -3 => 1 * 3 ** -1 (2: down)
+            (-3, 9, -1, 2, 3), # 9 * 2 ** -3 => 1 * 2 ** -1 (3: down)
+            # 10 * 2 ** -3 (exactly halfway)
+            (-3, 10, -1, 3, 0), # 10 * 2 ** -3 => 1 * 2 ** -1 (0: up)
+            (-3, 10, -1, 3, 1), # 10 * 2 ** -3 => 1 * 3 ** -1 (1: up)
+            (-3, 10, -1, 2, 2), # 10 * 2 ** -3 => 1 * 3 ** -1 (2: down)
+            (-3, 10, -1, 2, 3), # 10 * 2 ** -3 => 1 * 2 ** -1 (3: down)
+            # 11 * 2 ** -3 (above halfway)
+            (-3, 11, -1, 3, 0), # 11 * 2 ** -3 => 1 * 3 ** -1 (0: up)
+            (-3, 11, -1, 3, 1), # 11 * 2 ** -3 => 1 * 3 ** -1 (1: up)
+            (-3, 11, -1, 3, 2), # 11 * 2 ** -3 => 1 * 3 ** -1 (2: up)
+            (-3, 11, -1, 2, 3), # 11 * 2 ** -3 => 1 * 2 ** -1 (3: down)
+            # 12 * 2 ** -3 (representable)
+            (-3, 12, -1, 3, 0), # 12 * 2 ** -3 => 1 * 3 ** -1 (0: down)
+            (-3, 12, -1, 3, 1), # 12 * 2 ** -3 => 1 * 3 ** -1 (1: down)
+            (-3, 12, -1, 3, 2), # 12 * 2 ** -3 => 1 * 3 ** -1 (2: down)
+            (-3, 12, -1, 3, 3), # 12 * 2 ** -3 => 1 * 3 ** -1 (3: down)
+        ]
+
+        for exp, c, exp_rounded, c_rounded, randbits in inputs:
+            x = fp.RealFloat(exp=exp, c=c)
+            x_rounded = x.round_at(n=-2, num_randbits=2, randbits=randbits)
+            expect = fp.RealFloat(exp=exp_rounded, c=c_rounded)
+            self.assertEqual(x_rounded, expect, f'x={x}, randbits={randbits}, x_rounded={x_rounded}, expect={expect}')
+
+    @given(
+        real_floats(100),
+        st.integers(),
+        st.integers(min_value=1, max_value=100),
+        rounding_modes()
+    )
+    def test_fuzz(self, x: fp.RealFloat, n: int, num_randbits: int, rm: fp.RoundingMode):
+        rounded = x.round_at(n=n, rm=rm, num_randbits=num_randbits)
+        self.assertIsInstance(rounded, fp.RealFloat)

--- a/tests/unit/number/real/test_round.py
+++ b/tests/unit/number/real/test_round.py
@@ -5,7 +5,7 @@ import unittest
 class RoundTestCase(unittest.TestCase):
     """Testing `RealFloat.round()`"""
 
-    def test_round_float_p2(self):
+    def test_round(self):
         inputs = [
             # 8 * 2 ** -3 (representable)
             (-3, 8, -1, 2, fp.RM.RNE), # 8 * 2 ** -3 => 1 * 2 ** -1
@@ -49,3 +49,38 @@ class RoundTestCase(unittest.TestCase):
             x_rounded = x.round(max_p=2, rm=rm)
             expect = fp.RealFloat(exp=exp_rounded, c=c_rounded)
             self.assertEqual(x_rounded, expect, f'x={x}, rm={rm!r}, x_rounded={x_rounded}, expect={expect}')
+
+    def test_round_stochastic(self):
+        inputs = [
+            # 8 * 2 ** -3 (representable)
+            (-3, 8, -1, 2, 0), # 8 * 2 ** -3 => 1 * 2 ** -1 (0: down)
+            (-3, 8, -1, 2, 1), # 8 * 2 ** -3 => 1 * 2 ** -1 (1: down)
+            (-3, 8, -1, 2, 2), # 8 * 2 ** -3 => 1 * 2 ** -1 (2: down)
+            (-3, 8, -1, 2, 3), # 8 * 2 ** -3 => 1 * 2 ** -1 (3: down)
+            # 9 * 2 ** -3 (below halfway)
+            (-3, 9, -1, 3, 0), # 9 * 2 ** -3 => 1 * 2 ** -1 (0: up)
+            (-3, 9, -1, 2, 1), # 9 * 2 ** -3 => 1 * 2 ** -1 (1: down)
+            (-3, 9, -1, 2, 2), # 9 * 2 ** -3 => 1 * 3 ** -1 (2: down)
+            (-3, 9, -1, 2, 3), # 9 * 2 ** -3 => 1 * 2 ** -1 (3: down)
+            # 10 * 2 ** -3 (exactly halfway)
+            (-3, 10, -1, 3, 0), # 10 * 2 ** -3 => 1 * 2 ** -1 (0: up)
+            (-3, 10, -1, 3, 1), # 10 * 2 ** -3 => 1 * 3 ** -1 (1: up)
+            (-3, 10, -1, 2, 2), # 10 * 2 ** -3 => 1 * 3 ** -1 (2: down)
+            (-3, 10, -1, 2, 3), # 10 * 2 ** -3 => 1 * 2 ** -1 (3: down)
+            # 11 * 2 ** -3 (above halfway)
+            (-3, 11, -1, 3, 0), # 11 * 2 ** -3 => 1 * 3 ** -1 (0: up)
+            (-3, 11, -1, 3, 1), # 11 * 2 ** -3 => 1 * 3 ** -1 (1: up)
+            (-3, 11, -1, 3, 2), # 11 * 2 ** -3 => 1 * 3 ** -1 (2: up)
+            (-3, 11, -1, 2, 3), # 11 * 2 ** -3 => 1 * 2 ** -1 (3: down)
+            # 12 * 2 ** -3 (representable)
+            (-3, 12, -1, 3, 0), # 12 * 2 ** -3 => 1 * 3 ** -1 (0: down)
+            (-3, 12, -1, 3, 1), # 12 * 2 ** -3 => 1 * 3 ** -1 (1: down)
+            (-3, 12, -1, 3, 2), # 12 * 2 ** -3 => 1 * 3 ** -1 (2: down)
+            (-3, 12, -1, 3, 3), # 12 * 2 ** -3 => 1 * 3 ** -1 (3: down)
+        ]
+
+        for exp, c, exp_rounded, c_rounded, randbits in inputs:
+            x = fp.RealFloat(exp=exp, c=c)
+            x_rounded = x.round(max_p=2, num_randbits=2, randbits=randbits)
+            expect = fp.RealFloat(exp=exp_rounded, c=c_rounded)
+            self.assertEqual(x_rounded, expect, f'x={x}, randbits={randbits}, x_rounded={x_rounded}, expect={expect}')

--- a/tests/unit/number/real/test_round.py
+++ b/tests/unit/number/real/test_round.py
@@ -107,7 +107,7 @@ class RoundStochasticTestCase(unittest.TestCase):
         real_floats(100),
         st.one_of(st.none(), st.integers(min_value=0)),
         st.one_of(st.none(), st.integers()),
-        st.integers(min_value=1, max_value=100),
+        st.one_of(st.none(), st.integers(min_value=1, max_value=100)),
         rounding_modes()
     )
     def test_fuzz(self, x: fp.RealFloat, p: int | None, n: int | None, num_randbits: int, rm: fp.RoundingMode):
@@ -217,9 +217,9 @@ class RoundStochasticAtTestCase(unittest.TestCase):
     @given(
         real_floats(100),
         st.integers(),
-        st.integers(min_value=1, max_value=100),
+        st.one_of(st.none(), st.integers(min_value=1, max_value=100)),
         rounding_modes()
     )
-    def test_fuzz(self, x: fp.RealFloat, n: int, num_randbits: int, rm: fp.RoundingMode):
+    def test_fuzz(self, x: fp.RealFloat, n: int, num_randbits: int | None, rm: fp.RoundingMode):
         rounded = x.round_at(n=n, rm=rm, num_randbits=num_randbits)
         self.assertIsInstance(rounded, fp.RealFloat)


### PR DESCRIPTION
Add support for stochastic rounding. Stochastic rounding is supported by `round()` and `round_at()` via two optional keywords:
- `num_randbits`: the number of bits to decide stochastic rounding. By default, `num_randbits == 0` in which case rounding is not stochastic. If `num_randbits == k`, then the first `k` unrepresentable digits are used to decide which way to round and the rounding mode `rm` decides how any lower order bits are rounded off. If `num_randbits is None`, then all unrepresentable digits are used to decided which way to round. In practice, this is bounded above by the precision `p`.
- `randbits`: the random bits to decide stochastic rounding. By default, `randbits is None` and the bits are generated via `random`. If the `k` rounded digits + randbits is greater than `2 ** k`, then the value is rounded away. Otherwise, the value is rounded down.