### PR TITLE
Fixes

### DIFF
--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -471,17 +471,11 @@ class Parser:
             lower = None
         else:
             lower = self._parse_expr(e.lower)
-            if not isinstance(lower, ValueExpr):
-                loc = self._parse_location(e.lower)
-                raise FPyParserError(loc, 'FPy expects a value expression for slice lower bound', e.lower)
 
         if e.upper is None:
             upper = None
         else:
             upper = self._parse_expr(e.upper)
-            if not isinstance(upper, ValueExpr):
-                loc = self._parse_location(e.upper)
-                raise FPyParserError(loc, 'FPy expects a value expression for slice upper bound', e.upper)
 
         if e.step is not None:
             loc = self._parse_location(e.step)

--- a/fpy2/number/__init__.py
+++ b/fpy2/number/__init__.py
@@ -77,7 +77,7 @@ Alias for Nvidia's TensorFloat-32 (TF32) floating point format
 with round nearest, ties-to-even rounding mode.
 """
 
-BF16 = IEEEContext(5, 16, RM.RNE)
+BF16 = IEEEContext(8, 16, RM.RNE)
 """
 Alias for Google's Brain Floating Point (BF16) floating point format
 with round nearest, ties-to-even rounding mode.

--- a/fpy2/number/ext_float.py
+++ b/fpy2/number/ext_float.py
@@ -456,7 +456,7 @@ class ExtFloatContext(EncodableContext):
 
 
     def decode(self, x: int) -> Float:
-        if not isinstance(x, int) and x >= 0 and x < 2 ** self.nbits:
+        if not isinstance(x, int) or x < 0 or x >= (1 << self.nbits):
             raise TypeError(f'Expected integer x={x} on [0, 2 ** {self.nbits})')
 
         # bitmasks

--- a/fpy2/number/gmp.py
+++ b/fpy2/number/gmp.py
@@ -398,7 +398,7 @@ def mpfr_fmin(x: Float, y: Float, *, prec: Optional[int] = None, n: Optional[int
     Computes `min(x, y)` using MPFR such that it may be safely re-rounded
     accurately to `prec` digits of precision.
 
-    This is the same as computing `max(x, y)` exactly and 
+    This is the same as computing `min(x, y)` exactly and 
     then rounding the result to the desired precision.
     """
     return _mpfr_eval(gmp.minnum, x, y, prec=prec, n=n)

--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -10,7 +10,7 @@ import numbers
 import random
 
 from fractions import Fraction
-from typing import Optional, Self, TypeAlias, TYPE_CHECKING
+from typing import Optional, Self, TypeAlias, TYPE_CHECKING, override
 
 from ..utils import (
     bitmask,
@@ -180,6 +180,10 @@ class RealFloat(numbers.Rational):
     def __str__(self):
         fn = get_current_str_converter()
         return fn(self)
+
+    def __hash__(self): # type: ignore
+        # Complex has __hash__ = None, so mypy thinks there's a type mismatch.
+        return hash((self._s, self._exp, self._c))
 
     def __eq__(self, other):
         if not isinstance(other, RealFloat):
@@ -1334,6 +1338,10 @@ class Float(numbers.Rational):
     def __str__(self):
         fn = get_current_str_converter()
         return fn(self)
+
+    def __hash__(self): # type: ignore
+        # Complex has __hash__ = None, so mypy thinks there's a type mismatch.
+        return hash((self._isinf, self._isnan, self._real))
 
     def __eq__(self, other):
         ord = self.compare(other)

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -105,7 +105,9 @@ _real_ops: dict[Any, Callable[..., Float]] = {
     mpfr_add: real_add,
     mpfr_sub: real_sub,
     mpfr_mul: real_mul,
-    mpfr_fma: real_fma
+    mpfr_fma: real_fma,
+    mpfr_fmin: min,
+    mpfr_fmax: max
 }
 
 def _apply_real(fn: Callable[..., Float], args: tuple[Float, ...]) -> Float:


### PR DESCRIPTION
Various fixes:
 - removes restriction that slice bounds must be values (should be expressions)
 - adds missing `__hash__` methods to `Float` and `RealFloat`
 - adds `min/max` evaluation for `RealContext`
 - fixed definition of `fp.BF16`
 - tweaked guard on `ExtFloat.decode()`