### PR TITLE
Definition-use analysis: common `Definition` interface

### DIFF
--- a/fpy2/analysis/__init__.py
+++ b/fpy2/analysis/__init__.py
@@ -1,7 +1,7 @@
 """Program analyses for FPy programs"""
 
 from .define_use import (
-    DefineUse, DefineUseAnalysis, Definition, DefineUnion, DefinitionCtx,
+    DefineUse, DefineUseAnalysis, Definition, DefinitionCtx,
     DefSite, UseSite
 )
 

--- a/fpy2/analysis/type_check.py
+++ b/fpy2/analysis/type_check.py
@@ -9,7 +9,7 @@ from ..primitive import Primitive
 from ..types import Type, NullType, BoolType, RealType, VarType, FunctionType, TupleType, ListType
 from ..utils import Gensym, NamedId, Unionfind
 
-from .define_use import DefineUse, DefineUseAnalysis, Definition, DefineUnion, DefSite
+from .define_use import DefineUse, DefineUseAnalysis, Definition, DefSite
 
 #####################################################################
 # Type Inference
@@ -510,14 +510,8 @@ class _TypeCheckInstance(Visitor):
         # type check body
         self._visit_block(stmt.body, None)
 
-    def _select_def_repr(self, d: Definition | DefineUnion):
-        match d:
-            case Definition():
-                return d
-            case DefineUnion():
-                return next(iter(d.defs))
-            case _:
-                raise RuntimeError(f'unreachable {d}')
+    def _select_def_repr(self, d: Definition):
+        return d.assigns()[0]
 
     def _visit_if(self, stmt: IfStmt, ctx: None):
         # type check condition

--- a/fpy2/rewrite/pattern.py
+++ b/fpy2/rewrite/pattern.py
@@ -85,7 +85,7 @@ class StmtPattern(Pattern):
         for defs in def_use.defs.values():
             for d in defs:
                 if not isinstance(d.site, FuncDef):
-                    targets.add(d.id)
+                    targets.add(d.name)
 
         # set of uses
         live_vars = LiveVars.analyze(func)

--- a/fpy2/utils/identifier.py
+++ b/fpy2/utils/identifier.py
@@ -12,6 +12,7 @@ from .location import Location
 
 class Id(ABC):
     """Abstract base class for identifiers."""
+
     __slots__ = ()
 
     @abstractmethod
@@ -22,6 +23,11 @@ class Id(ABC):
         This method is for compability with AST classes.
         """
         ...
+
+    def __lt__(self, other: 'Id'):
+        if not isinstance(other, Id):
+            raise TypeError(f"'<' not supported between instances '{type(self)}' and '{type(other)}'")
+        return str(self) < str(other)
 
     def is_equiv(self, other) -> bool:
         """

--- a/tests/unit/rewrite/test_rewrite.py
+++ b/tests/unit/rewrite/test_rewrite.py
@@ -299,7 +299,7 @@ class RewriteTestCase(unittest.TestCase):
         self.assertIsInstance(k_rw, Function)
         self.assertAstEqual(k_rw.ast.body, k2.ast.body)
 
-    def test_unroll_while_example2(self):
+    def test_unroll_while_example3(self):
         assert isinstance(k, Function)
         assert isinstance(k3, Function)
 


### PR DESCRIPTION
The definition-use analysis relied in two separate definition "types": `Definition`, representing a single assignment, and `DefineUnion`, representing a phi node. Now, there's a common `Definition` interface with `AssignDef` and `PhiDef` implementing the interface. To support this change, `Id` is now sortable.