### PR TITLE
Context inference

### DIFF
--- a/fpy2/analysis/__init__.py
+++ b/fpy2/analysis/__init__.py
@@ -1,10 +1,14 @@
 """Program analyses for FPy programs"""
 
+from .context_infer import ContextInfer
+
 from .define_use import (
     DefineUse, DefineUseAnalysis, Definition, DefinitionCtx,
     DefSite, UseSite
 )
 
 from .live_vars import LiveVars
+
 from .syntax_check import SyntaxCheck, FPySyntaxError
+
 from .type_check import TypeCheck

--- a/fpy2/analysis/__init__.py
+++ b/fpy2/analysis/__init__.py
@@ -1,6 +1,6 @@
 """Program analyses for FPy programs"""
 
-from .context_infer import ContextInfer
+from .context_infer import ContextInfer, ContextAnalysis
 
 from .define_use import (
     DefineUse, DefineUseAnalysis, Definition, DefinitionCtx,
@@ -11,4 +11,4 @@ from .live_vars import LiveVars
 
 from .syntax_check import SyntaxCheck, FPySyntaxError
 
-from .type_check import TypeCheck
+from .type_check import TypeCheck, TypeAnalysis

--- a/fpy2/analysis/context_infer.py
+++ b/fpy2/analysis/context_infer.py
@@ -1,0 +1,207 @@
+"""
+Context inference.
+"""
+
+from typing import TypeAlias
+
+from ..ast import *
+from ..fpc_context import FPCoreContext
+from ..number import Context
+from ..utils import DEFAULT, DefaultOr
+from .define_use import DefineUse, DefineUseAnalysis, Definition, DefineUnion, DefSite
+
+
+_Context: TypeAlias = DefaultOr[Context | None]
+
+
+class _ContextInferInstance(Visitor):
+    """
+    Context inference instance.
+
+    This visitor traverses the function and infers rounding contexts
+    for each definition site.
+    """
+
+    func: FuncDef
+    def_use: DefineUseAnalysis
+    contexts: dict[Definition, _Context]
+
+    def __init__(self, func: FuncDef, def_use: DefineUseAnalysis):
+        self.func = func
+        self.def_use = def_use
+        self.contexts = {}
+
+    def infer(self):
+        self._visit_function(self.func, None)
+        return self.contexts
+
+    def _visit_var(self, e: Var, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_bool(self, e: BoolVal, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_foreign(self, e: ForeignVal, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_decnum(self, e: Decnum, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_hexnum(self, e: Hexnum, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_integer(self, e: Integer, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_rational(self, e: Rational, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_digits(self, e: Digits, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_nullaryop(self, e: NullaryOp, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_unaryop(self, e: UnaryOp, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_binaryop(self, e: BinaryOp, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_ternaryop(self, e: TernaryOp, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_naryop(self, e: NaryOp, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_compare(self, e: Compare, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_call(self, e: Call, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_tuple_expr(self, e: TupleExpr, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_list_expr(self, e: ListExpr, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_list_comp(self, e: ListComp, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_list_ref(self, e: ListRef, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_list_slice(self, e: ListSlice, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_list_set(self, e: ListSet, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_if_expr(self, e: IfExpr, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_context_expr(self, e: ContextExpr, ctx: _Context):
+        raise NotImplementedError
+
+    def _visit_binding(self, site: DefSite, target: Id | TupleBinding, ctx: _Context):
+        match target:
+            case NamedId():
+                d = self.def_use.find_def_from_site(target, site)
+                self.contexts[d] = ctx
+            case UnderscoreId():
+                pass
+            case TupleBinding():
+                for elt in target.elts:
+                    self._visit_binding(site, elt, ctx)
+            case _:
+                raise RuntimeError(f'unreachable: {target}')
+
+    def _visit_assign(self, stmt: Assign, ctx: _Context):
+        self._visit_binding(stmt, stmt.binding, ctx)
+        return ctx
+
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: _Context):
+        return ctx
+
+    def _visit_if1(self, stmt: If1Stmt, ctx: _Context):
+        self._visit_block(stmt.body, ctx)
+        return ctx
+
+    def _visit_if(self, stmt: IfStmt, ctx: _Context):
+        self._visit_block(stmt.ift, ctx)
+        self._visit_block(stmt.iff, ctx)
+        return ctx
+
+    def _visit_while(self, stmt: WhileStmt, ctx: _Context):
+        self._visit_block(stmt.body, ctx)
+        return ctx
+
+    def _visit_for(self, stmt: ForStmt, ctx: _Context):
+        self._visit_binding(stmt, stmt.target, ctx)
+        self._visit_block(stmt.body, ctx)
+        return ctx
+
+    def _visit_context(self, stmt: ContextStmt, ctx: _Context):
+        match stmt.ctx:
+            case ForeignVal():
+                if isinstance(stmt.ctx.val, Context):
+                    body_ctx = stmt.ctx.val
+                else:
+                    body_ctx = None
+            case Var() | ForeignAttribute() | ContextExpr():
+                body_ctx = None
+            case _:
+                raise RuntimeError(f'unreachable: {stmt.ctx}')
+
+        self._visit_block(stmt.body, body_ctx)
+        return ctx
+
+    def _visit_assert(self, stmt: AssertStmt, ctx: _Context):
+        return ctx
+
+    def _visit_effect(self, stmt: EffectStmt, ctx: _Context):
+        return ctx
+
+    def _visit_return(self, stmt: ReturnStmt, ctx: _Context):
+        return ctx
+
+    def _visit_block(self, block: StmtBlock, ctx: _Context):
+        for stmt in block.stmts:
+            ctx = self._visit_statement(stmt, ctx)
+
+    def _visit_function(self, func: FuncDef, ctx: None):
+        # function can have an overriding context
+        match func.ctx:
+            case None:
+                self._visit_block(func.body, DEFAULT)
+            case FPCoreContext():
+                self._visit_block(func.body, None)
+            case _:
+                self._visit_block(func.body, func.ctx)
+
+
+class ContextInfer:
+    """
+    Context inference.
+
+    Like type checking but for rounding contexts.
+    Most rounding contexts are statically known, so
+    we can assign every statement (or expression) a rounding context
+    if it can be determined.
+    """
+
+    @staticmethod
+    def infer(func: FuncDef):
+        """
+        Performs rounding context inference.
+
+        Produces a map from definition sites to their rounding contexts.
+        """
+        if not isinstance(func, FuncDef):
+            raise TypeError(f'expected a \'FuncDef\', got {func}')
+
+        def_use = DefineUse.analyze(func)
+        inst = _ContextInferInstance(func, def_use)
+        info = inst.infer()
+        print(func.name, info)

--- a/fpy2/analysis/type_check.py
+++ b/fpy2/analysis/type_check.py
@@ -154,9 +154,6 @@ class _TypeCheckInstance(Visitor):
         return ty
 
     def _resolve_type(self, ty: Type):
-        if ty in self.tvars:
-            return self.tvars.find(ty)
-
         match ty:
             case NullType() | BoolType() | RealType() | VarType():
                 return self.tvars.add(ty)
@@ -170,8 +167,8 @@ class _TypeCheckInstance(Visitor):
                 raise NotImplementedError(f'cannot resolve type {ty}')
 
     def _unify(self, a_ty: Type, b_ty: Type):
-        a_ty = self._resolve_type(a_ty)
-        b_ty = self._resolve_type(b_ty)
+        a_ty = self.tvars.get(a_ty, a_ty)
+        b_ty = self.tvars.get(b_ty, b_ty)
         match a_ty, b_ty:
             case VarType(), _:
                 b_ty = self.tvars.add(b_ty)
@@ -188,7 +185,7 @@ class _TypeCheckInstance(Visitor):
                 elt_ty = self.tvars.add(elt_ty)
                 elt_ty = self.tvars.union(elt_ty, self.tvars.add(a_ty.elt_type))
                 elt_ty = self.tvars.union(elt_ty, self.tvars.add(b_ty.elt_type))
-                return ListType(elt_ty)
+                return self.tvars.add(ListType(elt_ty))
             case TupleType(), TupleType():
                 # TODO: what if the length doesn't match
                 if len(a_ty.elt_types) != len(b_ty.elt_types):

--- a/fpy2/analysis/type_check.py
+++ b/fpy2/analysis/type_check.py
@@ -382,6 +382,7 @@ class _TypeCheckInstance(Visitor):
                 # calling a function
                 if e.fn.sig is None:
                     # type checking not run
+                    # TODO: guard against recursion
                     fn_info = TypeCheck.check(e.fn.ast)
                     fn_ty = fn_info.fn_type
                 else:
@@ -459,7 +460,7 @@ class _TypeCheckInstance(Visitor):
         # val[index] : A
         return ty
 
-    def _visit_list_slice(self, e: ListSlice, ctx: None) -> ListType:
+    def _visit_list_slice(self, e: ListSlice, ctx: None):
         # type check array
         value_ty = self._visit_expr(e.value, None)
         self._unify(value_ty, ListType(self._fresh_type_var()))

--- a/fpy2/analysis/type_check.py
+++ b/fpy2/analysis/type_check.py
@@ -154,6 +154,7 @@ class _TypeCheckInstance(Visitor):
         return ty
 
     def _resolve_type(self, ty: Type):
+        # fix to be recursive
         if ty in self.tvars:
             return self.tvars.find(ty)
         else:
@@ -184,7 +185,10 @@ class _TypeCheckInstance(Visitor):
                 if len(a_ty.elt_types) != len(b_ty.elt_types):
                     raise FPyTypeError(f'attempting to unify `{a_ty.format()}` and `{b_ty.format()}`')
                 elts = [self._unify(a_elt, b_elt) for a_elt, b_elt in zip(a_ty.elt_types, b_ty.elt_types)]
-                return TupleType(*elts)
+                ty = self.tvars.add(TupleType(*elts))
+                ty = self.tvars.union(ty, self.tvars.add(a_ty))
+                ty = self.tvars.union(ty, self.tvars.add(b_ty))
+                return ty
             case NullType(), NullType():
                 return a_ty
             case _:

--- a/fpy2/analysis/type_check.py
+++ b/fpy2/analysis/type_check.py
@@ -202,13 +202,13 @@ class _TypeCheckInstance(Visitor):
 
     def _instantiate(self, ty: Type) -> Type:
         subst: dict[VarType, Type] = {}
-        for fv in ty.free_vars():
+        for fv in sorted(ty.free_vars()):
             subst[fv] = self._fresh_type_var()
         return ty.subst(subst)
 
     def _generalize(self, ty: Type) -> Type:
         subst: dict[VarType, Type] = {}
-        for i, fv in enumerate(ty.free_vars()):
+        for i, fv in enumerate(sorted(ty.free_vars())):
             t = self.tvars.find(fv)
             match t: 
                 case VarType():
@@ -403,6 +403,9 @@ class _TypeCheckInstance(Visitor):
                     return NullType()
                 else:
                     # signature matches
+                    # instantiate the function type
+                    fn_ty = cast(FunctionType, self._instantiate(fn_ty))
+                    # merge arguments
                     for arg, expect_ty in zip(e.args, fn_ty.arg_types):
                         ty = self._visit_expr(arg, None)
                         self._unify(ty, expect_ty)

--- a/fpy2/analysis/type_check.py
+++ b/fpy2/analysis/type_check.py
@@ -156,7 +156,7 @@ class _TypeCheckInstance(Visitor):
     def _resolve_type(self, ty: Type):
         match ty:
             case NullType() | BoolType() | RealType() | VarType():
-                return self.tvars.add(ty)
+                return self.tvars.get(ty, ty)
             case TupleType():
                 elts = [self._resolve_type(elt) for elt in ty.elt_types]
                 return self.tvars.add(TupleType(*elts))

--- a/fpy2/decorator.py
+++ b/fpy2/decorator.py
@@ -15,10 +15,9 @@ from typing import (
     TypeVar
 )
 
-from .analysis import SyntaxCheck, ContextInfer
+from .analysis import SyntaxCheck
 from .ast import EffectStmt, NamedId
 from .env import ForeignEnv
-from .number import Float
 from .frontend import Parser
 from .function import Function
 from .primitive import Primitive
@@ -187,8 +186,7 @@ def _apply_fpy_decorator(
         ast.free_vars = SyntaxCheck.check(ast, free_vars=free_vars, ignore_unknown=not strict)
         # type checking [disabled: fpy is not statically typed]
         # ty = TypeCheck.check(ast)
-
-        ContextInfer.infer(ast)
+        # ContextInfer.infer(ast)
 
     # wrap the IR in a Function
     return Function(ast, None, env, func=func)

--- a/fpy2/decorator.py
+++ b/fpy2/decorator.py
@@ -15,8 +15,8 @@ from typing import (
     TypeVar
 )
 
-from .analysis import SyntaxCheck, TypeCheck
-from .ast import EffectStmt, NamedId, RealTypeAnn, BoolTypeAnn, AnyTypeAnn
+from .analysis import SyntaxCheck, ContextInfer
+from .ast import EffectStmt, NamedId
 from .env import ForeignEnv
 from .number import Float
 from .frontend import Parser
@@ -187,6 +187,8 @@ def _apply_fpy_decorator(
         ast.free_vars = SyntaxCheck.check(ast, free_vars=free_vars, ignore_unknown=not strict)
         # type checking [disabled: fpy is not statically typed]
         # ty = TypeCheck.check(ast)
+
+        ContextInfer.infer(ast)
 
     # wrap the IR in a Function
     return Function(ast, None, env, func=func)

--- a/fpy2/types.py
+++ b/fpy2/types.py
@@ -102,6 +102,17 @@ class VarType(Type):
     def __init__(self, name: NamedId):
         self.name = name
 
+    def __eq__(self, other):
+        return isinstance(other, VarType) and self.name == other.name
+
+    def __lt__(self, other: 'VarType'):
+        if not isinstance(other, VarType):
+            raise TypeError(f"'<' not supported between instances '{type(self)}' and '{type(other)}'")
+        return self.name < other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
     def format(self):
         return self.name
 
@@ -110,12 +121,6 @@ class VarType(Type):
 
     def subst(self, subst: dict['VarType', 'Type']) -> 'Type':
         return subst.get(self, self)
-
-    def __eq__(self, other):
-        return isinstance(other, VarType) and self.name == other.name
-
-    def __hash__(self):
-        return hash(self.name)
 
 class TupleType(Type):
     """Tuple type."""

--- a/fpy2/utils/unionfind.py
+++ b/fpy2/utils/unionfind.py
@@ -60,6 +60,16 @@ class Unionfind(Generic[T]):
             raise KeyError(x)
         return self._find(x)
 
+    def get(self, x: T, default=None):
+        """
+        Finds the representative of the set containing `x`,
+        or `default` if a representative is not found.
+        """
+        if x in self._parent:
+            return self._find(x)
+        else:
+            return default
+
     def union(self, x: T, y: T) -> T:
         """
         Union the sets containing `x` and `y`.

--- a/tests/infra/fpbench/__main__.py
+++ b/tests/infra/fpbench/__main__.py
@@ -6,6 +6,7 @@ FPBench infastructure tests.
 - Checks that FPy and FPCore functions are equivalent.
 """
 
+from .context_infer import test_context_infer
 from .eval import test_eval
 from .parse import test_parse
 from .round_trip import test_round_trip
@@ -15,3 +16,4 @@ test_parse()
 test_eval()
 test_round_trip()
 test_tcheck()
+test_context_infer()

--- a/tests/infra/fpbench/context_infer.py
+++ b/tests/infra/fpbench/context_infer.py
@@ -23,7 +23,8 @@ def test_context_infer():
             print('tcheck', core.name, core.ident)
             fn = fp.Function.from_fpcore(core, ignore_unknown=True)
             ast = ContextInline.apply(fn.ast, fn.env)
-            ContextInfer.infer(ast)
+            info = ContextInfer.infer(ast)
+            print(ast.name, info.ret_ctx)
 
 if __name__ == '__main__':
     test_context_infer()

--- a/tests/infra/fpbench/context_infer.py
+++ b/tests/infra/fpbench/context_infer.py
@@ -1,0 +1,29 @@
+"""
+Context inference tests
+"""
+
+import fpy2 as fp
+
+from fpy2.analysis import ContextInfer
+from fpy2.transform import ContextInline
+
+from .fetch import fetch_cores
+
+_skip_cores = [
+    'even-int',
+    'forward-euler-3d',
+    'midpoint-3d',
+    'ralston-3d',
+    'rk4-step-3d'
+]
+
+def test_context_infer():
+    for core in fetch_cores().all_cores():
+        if core.name not in _skip_cores:
+            print('tcheck', core.name, core.ident)
+            fn = fp.Function.from_fpcore(core, ignore_unknown=True)
+            ast = ContextInline.apply(fn.ast, fn.env)
+            ContextInfer.infer(ast)
+
+if __name__ == '__main__':
+    test_context_infer()

--- a/tests/infra/fpbench/tcheck.py
+++ b/tests/infra/fpbench/tcheck.py
@@ -18,7 +18,7 @@ def test_tcheck():
             print('tcheck', core.name, core.ident)
             fn = fp.Function.from_fpcore(core, ignore_unknown=True)
             info = TypeCheck.check(fn.ast)
-            print(core.name, core.ident, info.ret_type)
+            print(core.name, core.ident, info.fn_type)
 
 if __name__ == '__main__':
     test_tcheck()

--- a/tests/infra/fpbench/tcheck.py
+++ b/tests/infra/fpbench/tcheck.py
@@ -17,7 +17,7 @@ def test_tcheck():
         if core.name not in _skip_cores:
             print('tcheck', core.name, core.ident)
             fn = fp.Function.from_fpcore(core, ignore_unknown=True)
-            ty = TypeCheck.check(fn.ast)
+            ty, _ = TypeCheck.check(fn.ast)
             print(core.name, core.ident, ty)
 
 if __name__ == '__main__':

--- a/tests/infra/fpbench/tcheck.py
+++ b/tests/infra/fpbench/tcheck.py
@@ -17,8 +17,8 @@ def test_tcheck():
         if core.name not in _skip_cores:
             print('tcheck', core.name, core.ident)
             fn = fp.Function.from_fpcore(core, ignore_unknown=True)
-            ty, _ = TypeCheck.check(fn.ast)
-            print(core.name, core.ident, ty)
+            info = TypeCheck.check(fn.ast)
+            print(core.name, core.ident, info.ret_type)
 
 if __name__ == '__main__':
     test_tcheck()

--- a/tests/infra/unit/__main__.py
+++ b/tests/infra/unit/__main__.py
@@ -1,9 +1,12 @@
+from .context_infer import test_context_infer
 from .eval import test_eval
 from .format import test_format
 from .fpc import test_compile_fpc
 from .tcheck import test_tcheck
 
+
 test_format()
 test_eval()
 test_tcheck()
+test_context_infer()
 test_compile_fpc()

--- a/tests/infra/unit/context_infer.py
+++ b/tests/infra/unit/context_infer.py
@@ -1,10 +1,11 @@
 """
-Type checking tests
+Context inference tests
 """
 
 import fpy2 as fp
 
-from fpy2.analysis import TypeCheck
+from fpy2.analysis import ContextInfer
+from fpy2.transform import ContextInline
 
 from .defs import tests, examples
 
@@ -15,19 +16,19 @@ _modules = [
 def _test_tcheck_unit():
     for core in tests + examples:
         assert isinstance(core, fp.Function)
-        ty, _ = TypeCheck.check(core.ast)
-        print(core.name, ty)
+        ast = ContextInline.apply(core.ast, core.env)
+        ContextInfer.infer(ast)
 
 def _test_tcheck_library():
     for mod in _modules:
         for obj in mod.__dict__.values():
             if isinstance(obj, fp.Function):
-                ty, _ = TypeCheck.check(obj.ast)
-                print(obj.name, ty)
+                ast = ContextInline.apply(obj.ast, obj.env)
+                ContextInfer.infer(ast)
 
-def test_tcheck():
+def test_context_infer():
     _test_tcheck_unit()
     _test_tcheck_library()
 
 if __name__ == '__main__':
-    test_tcheck()
+    test_context_infer()

--- a/tests/infra/unit/context_infer.py
+++ b/tests/infra/unit/context_infer.py
@@ -17,14 +17,16 @@ def _test_tcheck_unit():
     for core in tests + examples:
         assert isinstance(core, fp.Function)
         ast = ContextInline.apply(core.ast, core.env)
-        ContextInfer.infer(ast)
+        info = ContextInfer.infer(ast)
+        print(ast.name, info.ret_ctx)
 
 def _test_tcheck_library():
     for mod in _modules:
         for obj in mod.__dict__.values():
             if isinstance(obj, fp.Function):
                 ast = ContextInline.apply(obj.ast, obj.env)
-                ContextInfer.infer(ast)
+                info = ContextInfer.infer(ast)
+                print(ast.name, info.ret_ctx)
 
 def test_context_infer():
     _test_tcheck_unit()

--- a/tests/infra/unit/tcheck.py
+++ b/tests/infra/unit/tcheck.py
@@ -16,14 +16,14 @@ def _test_tcheck_unit():
     for core in tests + examples:
         assert isinstance(core, fp.Function)
         info = TypeCheck.check(core.ast)
-        print(core.name, info.ret_type)
+        print(core.name, info.fn_type)
 
 def _test_tcheck_library():
     for mod in _modules:
         for obj in mod.__dict__.values():
             if isinstance(obj, fp.Function):
                 info = TypeCheck.check(obj.ast)
-                print(obj.name, info.ret_type)
+                print(obj.name, info.fn_type)
 
 def test_tcheck():
     _test_tcheck_unit()

--- a/tests/infra/unit/tcheck.py
+++ b/tests/infra/unit/tcheck.py
@@ -22,7 +22,7 @@ def _test_tcheck_library():
     for mod in _modules:
         for obj in mod.__dict__.values():
             if isinstance(obj, fp.Function):
-                ty = TypeCheck.check(obj.ast)
+                ty, _ = TypeCheck.check(obj.ast)
                 print(obj.name, ty)
 
 def test_tcheck():

--- a/tests/infra/unit/tcheck.py
+++ b/tests/infra/unit/tcheck.py
@@ -15,15 +15,15 @@ _modules = [
 def _test_tcheck_unit():
     for core in tests + examples:
         assert isinstance(core, fp.Function)
-        ty, _ = TypeCheck.check(core.ast)
-        print(core.name, ty)
+        info = TypeCheck.check(core.ast)
+        print(core.name, info.ret_type)
 
 def _test_tcheck_library():
     for mod in _modules:
         for obj in mod.__dict__.values():
             if isinstance(obj, fp.Function):
-                ty, _ = TypeCheck.check(obj.ast)
-                print(obj.name, ty)
+                info = TypeCheck.check(obj.ast)
+                print(obj.name, info.ret_type)
 
 def test_tcheck():
     _test_tcheck_unit()


### PR DESCRIPTION
Adds a context inference algorithm. This is just an orthogonal type system to the standard type system: values are paired with the rounding context under which they were created:

```
<context> ::= C_i
            | <context> x <context>
```

Unlike the type inference algorithm, the context inference algorithm is allowed to give up and produce unknown