### PR TITLE
Replace the `size` operator with `len`

### DIFF
--- a/fpy2/analysis/type_check.py
+++ b/fpy2/analysis/type_check.py
@@ -288,6 +288,10 @@ class _TypeCheckInstance(Visitor):
                     # sum operator
                     self._unify(arg_ty, ListType(RealType()))
                     return RealType()
+                case Len():
+                    # length operator
+                    self._unify(arg_ty, ListType(self._fresh_type_var()))
+                    return RealType()
                 case Range():
                     # range operator
                     self._unify(arg_ty, RealType())
@@ -321,11 +325,6 @@ class _TypeCheckInstance(Visitor):
             return fn_ty.return_type
         else:
             match e:
-                case Size():
-                    # size operator
-                    self._unify(lhs_ty, ListType(self._fresh_type_var()))
-                    self._unify(rhs_ty, RealType())
-                    return RealType()
                 case _:
                     raise ValueError(f'unknown binary operator: {cls}')
 

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -165,10 +165,10 @@ __all__ = [
     'RoundAt',
 
     # Tensor operators
+    'Len',
     'Range',
     'Empty',
     'Dim',
-    'Size',
     'Zip',
     'Enumerate',
 
@@ -1075,6 +1075,10 @@ class RoundAt(NamedBinaryOp):
 
 # Tensor operators
 
+class Len(NamedUnaryOp):
+    """FPy node: length operator"""
+    __slots__ = ()
+
 class Range(NamedUnaryOp):
     """FPy node: range constructor"""
     __slots__ = ()
@@ -1085,10 +1089,6 @@ class Empty(NamedUnaryOp):
 
 class Dim(NamedUnaryOp):
     """FPy node: dimension operator"""
-    __slots__ = ()
-
-class Size(NamedBinaryOp):
-    """FPy node: size operator"""
     __slots__ = ()
 
 class Zip(NamedNaryOp):

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -251,6 +251,11 @@ class FPCoreCompileInstance(Visitor):
         args = [self._visit_expr(c, ctx) for c in e.args]
         return fpc.UnknownOperator(*args, name=name)
 
+    def _visit_len(self, arg: Expr, ctx: None) -> fpc.Expr:
+        # length expression
+        arr = self._visit_expr(arg, ctx)
+        return fpc.Size(arr, fpc.Integer(0))
+
     def _visit_range(self, arg: Expr, ctx: None) -> fpc.Expr:
         # expand range expression
         tuple_id = str(self.gensym.fresh('i'))
@@ -369,6 +374,9 @@ class FPCoreCompileInstance(Visitor):
             return cls(arg)
         else:
             match e:
+                case Len():
+                    # length expression
+                    return self._visit_len(e.arg, ctx)
                 case Range():
                     # range expression
                     return self._visit_range(e.arg, ctx)
@@ -397,9 +405,6 @@ class FPCoreCompileInstance(Visitor):
             return cls(arg0, arg1)
         else:
             match e:
-                case Size():
-                    # size expression
-                    return self._visit_size(e.first, e.second, ctx)
                 case _:
                     # unknown operator
                     raise NotImplementedError('no FPCore operator for', e)

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -126,6 +126,12 @@ def _empty(ns: list[Expr]) -> Expr:
     else:
         raise ValueError(f'ns={ns} cannot be empty')
 
+def _size(x: Expr, n: int) -> Expr:
+    assert n >= 0
+    if n == 0:
+        return Len(NamedId('len'), x, None)
+    else:
+        return _size(ListRef(x, Integer(0, None), None), n - 1)
 
 # TODO: clean this up
 class _Ctx:
@@ -295,7 +301,8 @@ class _FPCore2FPy:
                     raise ValueError('size operator expects 2 arguments')
                 arg0 = self._visit(e.children[0], ctx)
                 arg1 = self._visit(e.children[1], ctx)
-                return Size(NamedId('size'), arg0, arg1, None)
+                # TODO: implement size(x, n)
+                raise NotImplementedError('size', arg0, arg1)
             case fpc.UnknownOperator():
                 ident = pythonize_id(e.name)
                 exprs = [self._visit(e, ctx) for e in e.children]
@@ -752,7 +759,7 @@ class _FPCore2FPy:
                             case str():
                                 # named dimension
                                 dim_id = self.gensym.fresh(dim)
-                                size_e = Size(NamedId('size'), Var(t, None), Integer(i, None), None)
+                                size_e = _size(Var(t, None), i)
                                 stmt = Assign(dim_id, None, size_e, None)
                                 ctx.stmts.append(stmt)
                                 # TODO: duplicate dimension names means a runtime check

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -285,7 +285,7 @@ class _FPCore2FPy:
         ))
 
         # result
-        return Var(tup_id, None)
+        return Len(NamedId("len"), Var(tup_id, None), None)
 
     def _visit_nary(self, e: fpc.NaryExpr, ctx: _Ctx) -> Expr:
         match e:

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -70,6 +70,7 @@ _unary_table: dict[Callable, type[UnaryOp] | type[NamedUnaryOp]] = {
     signbit: Signbit,
     round: Round,
     round_exact: RoundExact,
+    len: Len,
     range: Range,
     empty: Empty,
     dim: Dim,
@@ -89,7 +90,6 @@ _binary_table: dict[Callable, type[BinaryOp] | type[NamedBinaryOp]] = {
     hypot: Hypot,
     atan2: Atan2,
     pow: Pow,
-    size: Size,
     round_at: RoundAt,
 }
 
@@ -479,11 +479,6 @@ class Parser:
             return self._parse_hexfloat(e, func)
         elif fn == digits:
             return self._parse_digits(e, func)
-        elif fn == len:
-            if len(e.args) != 1:
-                raise FPyParserError(loc, 'FPy expects 1 argument for `len`', e)
-            arg = self._parse_expr(e.args[0])
-            return Size(func, arg, Integer(0, None), loc)
         else:
             args = [self._parse_expr(arg) for arg in e.args]
             return Call(func, fn, args, loc)

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -265,6 +265,12 @@ class _Interpreter(Visitor):
                 return True
         return False
 
+    def _apply_len(self, arg: Expr, ctx: Context):
+        arr = self._visit_expr(arg, ctx)
+        if not isinstance(arr, list):
+            raise TypeError(f'expected a list, got {arr}')
+        return len(arr)
+
     def _apply_range(self, arg: Expr, ctx: Context):
         stop = self._visit_expr(arg, ctx)
         if not isinstance(stop, Float):
@@ -296,17 +302,6 @@ class _Interpreter(Visitor):
             (Float.from_int(i, ctx=ctx), val)
             for i, val in enumerate(v)
         ]
-
-    def _apply_size(self, arr: Expr, idx: Expr, ctx: Context):
-        v = self._visit_expr(arr, ctx)
-        if not isinstance(v, list):
-            raise TypeError(f'expected a list, got {v}')
-        dim = self._visit_expr(idx, ctx)
-        if not isinstance(dim, Float):
-            raise TypeError(f'expected a real number argument, got {dim}')
-        if not dim.is_integer():
-            raise TypeError(f'expected an integer argument, got {dim}')
-        return ops.size(v, dim, ctx)
 
     def _apply_zip(self, args: Sequence[Expr], ctx: Context):
         """Apply the `zip` method to the given n-ary expression."""
@@ -392,6 +387,8 @@ class _Interpreter(Visitor):
             match e:
                 case Not():
                     return self._apply_not(e.arg, ctx)
+                case Len():
+                    return self._apply_len(e.arg, ctx)
                 case Range():
                     return self._apply_range(e.arg, ctx)
                 case Empty():
@@ -417,8 +414,6 @@ class _Interpreter(Visitor):
             return fn(first, second, ctx=ctx)
         else:
             match e:
-                case Size():
-                    return self._apply_size(e.first, e.second, ctx)
                 case _:
                     raise RuntimeError('unknown operator', e)
 

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -269,7 +269,7 @@ class _Interpreter(Visitor):
         arr = self._visit_expr(arg, ctx)
         if not isinstance(arr, list):
             raise TypeError(f'expected a list, got {arr}')
-        return len(arr)
+        return Float.from_int(len(arr), ctx=ctx)
 
     def _apply_range(self, arg: Expr, ctx: Context):
         stop = self._visit_expr(arg, ctx)

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -82,7 +82,6 @@ __all__ = [
     # Tensor
     'empty',
     'dim',
-    'size',
     # Constants
     'digits',
     'hexfloat',
@@ -711,30 +710,6 @@ def dim(x: list | tuple, ctx: Optional[Context] = None):
         return Float.from_int(dim)
     else:
         return ctx.round(dim)
-
-def size(x: list | tuple, dim: Real, ctx: Optional[Context] = None):
-    """
-    Returns the size of the dimension `dim` of the tensor `x`.
-
-    Assumes that `x` is not a ragged tensor.
-    """
-    dim = _real_to_float(dim)
-    if dim.is_zero():
-        # size(x, 0) = len(x)
-        if ctx is None:
-            return Float.from_int(len(x))
-        else:
-            return ctx.round(len(x))
-    else:
-        # size(x, n) = size(x[0], n - 1)
-        for _ in range(int(dim)):
-            x = x[0]
-            if not isinstance(x, (list, tuple)):
-                raise ValueError(f'dimension `{dim}` is out of bounds for the tensor `{x}`')
-        if ctx is None:
-            return Float.from_int(len(x))
-        else:
-            return ctx.round(len(x))
 
 #############################################################################
 # Constants

--- a/tests/infra/unit/defs.py
+++ b/tests/infra/unit/defs.py
@@ -169,16 +169,6 @@ def test_list_dim2():
     x = [[1.0, 2.0], [3.0, 4.0]]
     return dim(x)
 
-@fpy(name='Test size (1/2)')
-def test_list_size1():
-    x = [1.0, 2.0, 3.0]
-    return size(x, 0)
-
-@fpy(name='Test size (2/2)')
-def test_list_size2():
-    x = [[1.0, 2.0], [3.0, 4.0]]
-    return size(x, 1)
-
 @fpy(name='Test enumerate (1/1)')
 def test_enumerate():
     xs = [1.0, 2.0, 3.0]
@@ -634,8 +624,6 @@ tests = [
     test_list_len2,
     test_list_dim1,
     test_list_dim2,
-    test_list_size1,
-    test_list_size2,
     test_enumerate,
     # test_list_zip1,
     test_list_zip2,


### PR DESCRIPTION
Replaces the `size` operator with a `len` operator. The `size` operator is from FPCore, but `len` is more Pythonic. Any `size(x, n)` expression can be compiled to FPy via
```
t = x
for i in range(n):
  t = t[0]
```
and the result is `len(t)`.