### PR TITLE
Native support for `len`

### DIFF
--- a/fpy2/analysis/type_check.py
+++ b/fpy2/analysis/type_check.py
@@ -284,9 +284,9 @@ class _TypeCheckInstance(Visitor):
             return fn_ty.return_type
         else:
             match e:
-                case Sum():
-                    # sum operator
-                    self._unify(arg_ty, ListType(RealType()))
+                case Len():
+                    # length operator
+                    self._unify(arg_ty, ListType(self._fresh_type_var()))
                     return RealType()
                 case Range():
                     # range operator
@@ -307,6 +307,10 @@ class _TypeCheckInstance(Visitor):
                     ty = self._fresh_type_var()
                     self._unify(arg_ty, ListType(ty))
                     return ListType(TupleType(RealType(), ty))
+                case Sum():
+                    # sum operator
+                    self._unify(arg_ty, ListType(RealType()))
+                    return RealType()
                 case _:
                     raise ValueError(f'unknown unary operator: {cls}')
 

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -165,10 +165,11 @@ __all__ = [
     'RoundAt',
 
     # Tensor operators
+    'Len',
+    'Size',
     'Range',
     'Empty',
     'Dim',
-    'Size',
     'Zip',
     'Enumerate',
 
@@ -1075,6 +1076,14 @@ class RoundAt(NamedBinaryOp):
 
 # Tensor operators
 
+class Len(NamedUnaryOp):
+    """FPy node: length operator"""
+    __slots__ = ()
+
+class Size(NamedBinaryOp):
+    """FPy node: size operator"""
+    __slots__ = ()
+
 class Range(NamedUnaryOp):
     """FPy node: range constructor"""
     __slots__ = ()
@@ -1085,10 +1094,6 @@ class Empty(NamedUnaryOp):
 
 class Dim(NamedUnaryOp):
     """FPy node: dimension operator"""
-    __slots__ = ()
-
-class Size(NamedBinaryOp):
-    """FPy node: size operator"""
     __slots__ = ()
 
 class Zip(NamedNaryOp):

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -251,6 +251,11 @@ class FPCoreCompileInstance(Visitor):
         args = [self._visit_expr(c, ctx) for c in e.args]
         return fpc.UnknownOperator(*args, name=name)
 
+    def _visit_len(self, arg: Expr, ctx: None) -> fpc.Expr:
+        # length expression
+        arr = self._visit_expr(arg, ctx)
+        return fpc.Size(arr, fpc.Integer(0))
+
     def _visit_range(self, arg: Expr, ctx: None) -> fpc.Expr:
         # expand range expression
         tuple_id = str(self.gensym.fresh('i'))
@@ -369,6 +374,9 @@ class FPCoreCompileInstance(Visitor):
             return cls(arg)
         else:
             match e:
+                case Len():
+                    # len expression
+                    return self._visit_len(e.arg, ctx)
                 case Range():
                     # range expression
                     return self._visit_range(e.arg, ctx)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -70,6 +70,7 @@ _unary_table: dict[Callable, type[UnaryOp] | type[NamedUnaryOp]] = {
     signbit: Signbit,
     round: Round,
     round_exact: RoundExact,
+    len: Len,
     range: Range,
     empty: Empty,
     dim: Dim,

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -265,6 +265,12 @@ class _Interpreter(Visitor):
                 return True
         return False
 
+    def _apply_len(self, arg: Expr, ctx: Context):
+        arr = self._visit_expr(arg, ctx)
+        if not isinstance(arr, list):
+            raise TypeError(f'expected a list, got {arr}')
+        return Float.from_int(len(arr), ctx=ctx)
+
     def _apply_range(self, arg: Expr, ctx: Context):
         stop = self._visit_expr(arg, ctx)
         if not isinstance(stop, Float):
@@ -392,6 +398,8 @@ class _Interpreter(Visitor):
             match e:
                 case Not():
                     return self._apply_not(e.arg, ctx)
+                case Len():
+                    return self._apply_len(e.arg, ctx)
                 case Range():
                     return self._apply_range(e.arg, ctx)
                 case Empty():


### PR DESCRIPTION
FPy supports a `size(x, n)` operator which computes the length of the `n`th dimension of `x`. Prior to this PR, Pthon's `len` operator was expanded to `size(x, 0)`. This PR adds a distinct `Len` builtin operator that doesn't require rounding 0 under the current context.