### PR TITLE
Context expressions evaluate under a real context

### DIFF
--- a/fpy2/transform/context_inline.py
+++ b/fpy2/transform/context_inline.py
@@ -125,6 +125,8 @@ class _ContextInlineInstance(DefaultTransformVisitor):
             return None
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
+        # context expressions are implicitly evaluated under
+        # a real context so we don't need to round
         match stmt.ctx:
             case Var():
                 # if variables can be resolved to be a context,


### PR DESCRIPTION
For context statements
```
with <expr>:
   <stmts>
```
the context expression `expr` must be evaluated under a real context.

This PR:
- fixes evaluator to evaluate expressions correctly
- adds matching comment to context inlining