### PR TITLE
Support context statements that bind to a variable

### DIFF
--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -314,6 +314,12 @@ class _DefineUseInstance(DefaultVisitor):
                 self._add_def(var, d)
             ctx[var] = d
 
+    def _visit_context(self, stmt: ContextStmt, ctx: DefinitionCtx):
+        self._visit_expr(stmt.ctx, ctx)
+        for var in stmt.target.names():
+            ctx[var] = self._add_assign(var, stmt, ctx)
+        self._visit_block(stmt.body, ctx)
+
     def _visit_statement(self, stmt: Stmt, ctx: DefinitionCtx):
         ctx_in = ctx.copy()
         super()._visit_statement(stmt, ctx)

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -164,17 +164,14 @@ class LiveVarsInstance(Visitor):
     def _visit_for(self, stmt: ForStmt, live: _LiveSet) -> _LiveSet:
         live = set(live)
         live |= self._visit_block(stmt.body, live)
-        match stmt.target:
-            case NamedId():
-                live -= { stmt.target }
-            case TupleBinding():
-                live -= stmt.target.names()
+        live -= stmt.target.names()
         live |= self._visit_expr(stmt.iterable, None)
         return live
 
     def _visit_context(self, stmt: ContextStmt, live: _LiveSet) -> _LiveSet:
         live = set(live)
         live = self._visit_block(stmt.body, live)
+        live -= stmt.target.names()
         live |= self._visit_expr(stmt.ctx, None)
         return live
 

--- a/fpy2/analysis/syntax_check.py
+++ b/fpy2/analysis/syntax_check.py
@@ -305,7 +305,8 @@ class SyntaxCheckInstance(Visitor):
         self._visit_expr(stmt.ctx, ctx)
         if isinstance(stmt.target, NamedId):
             env = env.extend(stmt.target)
-        return self._visit_block(stmt.body, _Ctx(env, False))
+        body_env = self._visit_block(stmt.body, _Ctx(env, False))
+        return body_env # no merge
 
     def _visit_assert(self, stmt: AssertStmt, ctx: _Ctx):
         env = ctx.env

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -619,7 +619,10 @@ class _TypeInferInstance(Visitor):
             self._set_type(phi, ty)
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
-        self._visit_expr(stmt.ctx, None)
+        ty = self._visit_expr(stmt.ctx, None)
+        if isinstance(stmt.target, NamedId):
+            d = self.def_use.find_def_from_site(stmt.target, stmt)
+            self._set_type(d, ty)
         self._visit_block(stmt.body, None)
 
     def _visit_assert(self, stmt: AssertStmt, ctx: None):

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -287,7 +287,13 @@ class _FormatterInstance(Visitor):
 
     def _visit_context(self, stmt: ContextStmt, ctx: _Ctx):
         context = self._visit_expr(stmt.ctx, ctx)
-        self._add_line(f'with {context} as {str(stmt.target)}:', ctx)
+        match stmt.target:
+            case NamedId():
+                self._add_line(f'with {context} as {str(stmt.target)}:', ctx)
+            case UnderscoreId():
+                self._add_line(f'with {context}:', ctx)
+            case _:
+                raise RuntimeError('unreachable', stmt.target)
         self._visit_block(stmt.body, ctx + 1)
 
     def _visit_assert(self, stmt: AssertStmt, ctx: _Ctx):

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -802,6 +802,8 @@ class _CppBackendInstance(Visitor):
     def _visit_context(self, stmt: ContextStmt, ctx: _CompileCtx):
         if not isinstance(stmt.ctx, ForeignVal):
             raise CppCompileError(self.func, f'Rounding context cannot be compiled `{stmt.ctx}`')
+        if isinstance(stmt.target, NamedId):
+            raise CppCompileError(self.func, f'Cannot bind rounding context in C++: `{stmt.format()}`')
         rctx = stmt.ctx.val
         cpp_ctx = self._compile_type(RealTypeContext(rctx))
         if cpp_ctx.is_float():

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -893,6 +893,10 @@ class _FPCoreCompileInstance(Visitor):
                 raise NotImplementedError(repr(data))
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
+        # check if the context is bound
+        if isinstance(stmt.target, NamedId):
+            raise FPCoreCompileError('Context statements cannot bind to a variable', stmt.target)
+
         body = self._visit_block(stmt.body, ctx)
         # extract a context value
         match stmt.ctx:

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -665,7 +665,7 @@ class Parser:
             case None:
                 return UnderscoreId()
             case ast.Name():
-                return var.id
+                return NamedId(var.id)
             case _:
                 loc = self._parse_location(var)
                 raise FPyParserError(loc, '`Context` can only be optionally bound to an identifier`', var, item)

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -18,7 +18,7 @@ from ..primitive import Primitive
 
 from .interpreter import Interpreter, FunctionReturnError
 
-ScalarVal: TypeAlias = bool | Float
+ScalarVal: TypeAlias = bool | Float | Context
 """Type of scalar values in FPy programs."""
 TensorVal: TypeAlias = list
 """Type of list values in FPy programs."""
@@ -778,6 +778,8 @@ class _Interpreter(Visitor):
         round_ctx = self._visit_expr(stmt.ctx, REAL)
         if not isinstance(round_ctx, Context):
             raise TypeError(f'expected a context, got `{round_ctx}`')
+        if isinstance(stmt.target, NamedId):
+            self.env[stmt.target] = round_ctx
         # evaluate the body under the new context
         self._visit_block(stmt.body, round_ctx)
 

--- a/tests/infra/compile/cpp.py
+++ b/tests/infra/compile/cpp.py
@@ -55,11 +55,15 @@ _test_ignore = [
     'test_list_size1', # empty list is not monomorphic
     'test_enumerate1', # empty list is not monomorphic
     'test_context_expr1',
+    'test_context_expr2',
     'test_context1',
     'test_context2',
     'test_context3',
     'test_context4',
     'test_context5',
+    # 'test_context6',
+    'test_context7',
+    'test_context8',
     'test_assert2',
     'test_assert3',
 ]

--- a/tests/infra/unit/context_infer.py
+++ b/tests/infra/unit/context_infer.py
@@ -18,6 +18,8 @@ _modules = [
 
 _unit_ignore = [
     'test_context_expr1',
+    'test_context_expr2',
+    'test_context8',
     'keep_p_1'
 ]
 

--- a/tests/infra/unit/defs.py
+++ b/tests/infra/unit/defs.py
@@ -108,6 +108,12 @@ def test_context_expr1():
     return 1
 
 @fpy
+def test_context_expr2():
+    x = 8
+    ctx = MPFixedContext(x, RM.RTZ)
+    return 1
+
+@fpy
 def test_tuple1():
     return (1.0, 2.0, 3.0)
 
@@ -503,6 +509,20 @@ def test_context6():
             z += i * i
         return z
 
+@fp.fpy
+def test_context7():
+    with fp.MPFixedContext(-4) as ctx:
+        a = const_pi()
+    return a, ctx
+
+@fp.fpy
+def test_context8():
+    with fp.MPFixedContext(-4) as ctx:
+        a = const_pi()
+        with fp.IEEEContext(5, 12):
+            b = const_pi()
+            with ctx:
+                return a / b
 
 @fpy
 def test_assert1():
@@ -666,6 +686,7 @@ tests: list[Function] = [
     test_ife3,
     test_ife4,
     test_context_expr1,
+    test_context_expr2,
     test_tuple1,
     test_tuple2,
     test_tuple3,
@@ -727,6 +748,8 @@ tests: list[Function] = [
     test_context4,
     test_context5,
     test_context6,
+    test_context7,
+    test_context8,
     test_assert1,
     test_assert2,
     test_assert3

--- a/tests/infra/unit/fpc.py
+++ b/tests/infra/unit/fpc.py
@@ -3,7 +3,10 @@ from .defs import tests, examples
 
 _ignore = [
     'test_context_expr1',
+    'test_context_expr2',
     'test_context6',
+    'test_context7',
+    'test_context8',
     'keep_p_1',
 ]
 


### PR DESCRIPTION
This PR adds support for context statements that bind to a variable, i.e.,
```
with fp.FP64 as ctx:
   ...
with ctx:
   ...
```
Contexts can now be constructed and captured. This is the preferred method of binding rounding contexts instead of
```
x = <context>
```
which is evaluated under the global rounding context.