### PR TITLE
Add `Pass` statement

### DIFF
--- a/fpy2/analysis/context_infer.py
+++ b/fpy2/analysis/context_infer.py
@@ -538,6 +538,9 @@ class ContextTypeInferInstance(Visitor):
         self.ret_ty = self._visit_expr(stmt.expr, ctx)
         return ctx
 
+    def _visit_pass(self, stmt: PassStmt, ctx: ContextParam):
+        return ctx
+
     def _visit_block(self, block: StmtBlock, ctx: ContextParam):
         for stmt in block.stmts:
             ctx = self._visit_statement(stmt, ctx)

--- a/fpy2/analysis/live_vars.py
+++ b/fpy2/analysis/live_vars.py
@@ -188,6 +188,9 @@ class LiveVarsInstance(Visitor):
     def _visit_return(self, stmt: ReturnStmt, live: _LiveSet) -> _LiveSet:
         return self._visit_expr(stmt.expr, None)
 
+    def _visit_pass(self, stmt: PassStmt, live: _LiveSet) -> _LiveSet:
+        return live
+
     def _visit_block(self, block: StmtBlock, live: _LiveSet) -> _LiveSet:
         live = set(live)
         for stmt in reversed(block.stmts):

--- a/fpy2/analysis/reachability.py
+++ b/fpy2/analysis/reachability.py
@@ -110,6 +110,10 @@ class _ReachabilityInstance(DefaultVisitor):
     def _visit_return(self, stmt: ReturnStmt, ctx: _ReachabilityCtx) -> bool:
         self.ret_stmts.add(stmt)
         return False
+    
+    def _visit_pass(self, stmt: PassStmt, ctx: _ReachabilityCtx) -> bool:
+        # OUT[s] = IN[s]
+        return ctx.is_reachable
 
     def _visit_statement(self, stmt: Stmt, ctx: _ReachabilityCtx):
         self.has_entry[stmt] = ctx.is_reachable

--- a/fpy2/analysis/syntax_check.py
+++ b/fpy2/analysis/syntax_check.py
@@ -323,6 +323,9 @@ class SyntaxCheckInstance(Visitor):
     def _visit_return(self, stmt: ReturnStmt, ctx: _Ctx):
         return self._visit_expr(stmt.expr, ctx)
 
+    def _visit_pass(self, stmt: PassStmt, ctx: _Ctx):
+        return ctx.env
+
     def _visit_block(self, block: StmtBlock, ctx: _Ctx):
         env = ctx.env
         for stmt in block.stmts:

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -637,6 +637,9 @@ class _TypeInferInstance(Visitor):
     def _visit_return(self, stmt: ReturnStmt, ctx: None):
         self.ret_type = self._visit_expr(stmt.expr, None)
 
+    def _visit_pass(self, stmt: PassStmt, ctx: None):
+        pass
+
     def _visit_block(self, block: StmtBlock, ctx: None):
         for stmt in block.stmts:
             self._visit_statement(stmt, None)

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -312,6 +312,9 @@ class _FormatterInstance(Visitor):
         s = self._visit_expr(stmt.expr, ctx)
         self._add_line(f'return {s}', ctx)
 
+    def _visit_pass(self, stmt: PassStmt, ctx: _Ctx):
+        self._add_line('pass', ctx)
+
     def _visit_block(self, block: StmtBlock, ctx: _Ctx):
         for stmt in block.stmts:
             self._visit_statement(stmt, ctx)
@@ -349,20 +352,6 @@ class _FormatterInstance(Visitor):
                     self._add_line(f'\'{k}\': {v},', ctx + 2)
                 self._add_line('}', ctx + 1)
             self._add_line(')', ctx)
-
-    # def _format_decorator(self, props: dict[str, Any], arg_str: str, ctx: _Ctx):
-    #     if len(props) == 0:
-    #         self._add_line('@fpy', ctx)
-    #     elif len(props) == 1:
-    #         k = list(props.keys())[0]
-    #         v = self._format_data(props[k], arg_str)
-    #         self._add_line(f'@fpy({k}={v})', ctx)
-    #     else:
-    #         self._add_line('@fpy(', ctx)
-    #         for k, data in props.items():
-    #             v = self._format_data(data, arg_str)
-    #             self._add_line(f'{k}={v},', ctx + 1)
-    #         self._add_line(')', ctx)
 
     def _visit_function(self, func: FuncDef, ctx: _Ctx):
         # TODO: type annotation

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -198,6 +198,7 @@ __all__ = [
     'AssertStmt',
     'EffectStmt',
     'ReturnStmt',
+    'PassStmt',
 
     # Function definition
     'Argument',
@@ -1659,6 +1660,17 @@ class ReturnStmt(Stmt):
             isinstance(other, ReturnStmt)
             and self.expr.is_equiv(other.expr)
         )
+
+class PassStmt(Stmt):
+    """FPy AST: pass (skip) statement"""
+    __slots__ = ()
+
+    def __init__(self, loc: Location | None):
+        super().__init__(loc)
+
+    def is_equiv(self, other) -> bool:
+        return isinstance(other, PassStmt)
+
 
 class Argument(Ast):
     """FPy AST: function argument"""

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -42,6 +42,7 @@ _stmt_dispatch: dict[type[Stmt], str] = {
     AssertStmt: "_visit_assert",
     EffectStmt: "_visit_effect",
     ReturnStmt: "_visit_return",
+    PassStmt: "_visit_pass",
 }
 
 class Visitor(ABC):
@@ -187,6 +188,9 @@ class Visitor(ABC):
     def _visit_return(self, stmt: ReturnStmt, ctx: Any) -> Any:
         ...
 
+    @abstractmethod
+    def _visit_pass(self, stmt: PassStmt, ctx: Any) -> Any:
+        ...
 
     #######################################################
     # Block
@@ -362,6 +366,9 @@ class DefaultVisitor(Visitor):
 
     def _visit_return(self, stmt: ReturnStmt, ctx: Any):
         self._visit_expr(stmt.expr, ctx)
+
+    def _visit_pass(self, stmt: PassStmt, ctx: Any):
+        pass
 
     def _visit_block(self, block: StmtBlock, ctx: Any):
         for stmt in block.stmts:
@@ -559,6 +566,10 @@ class DefaultTransformVisitor(Visitor):
     def _visit_return(self, stmt: ReturnStmt, ctx: Any):
         expr = self._visit_expr(stmt.expr, ctx)
         s = ReturnStmt(expr, stmt.loc)
+        return s, ctx
+
+    def _visit_pass(self, stmt: PassStmt, ctx: Any):
+        s = PassStmt(stmt.loc)
         return s, ctx
 
     def _visit_block(self, block: StmtBlock, ctx: Any):

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -834,6 +834,9 @@ class _CppBackendInstance(Visitor):
         e = self._visit_expr(stmt.expr, ctx)
         ctx.add_line(f'return {e};')
 
+    def _visit_pass(self, stmt: PassStmt, ctx: _CompileCtx):
+        pass
+
     def _visit_block(self, block: StmtBlock, ctx: _CompileCtx):
         for stmt in block.stmts:
             self._visit_statement(stmt, ctx)

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -929,6 +929,9 @@ class _FPCoreCompileInstance(Visitor):
     def _visit_return(self, stmt: ReturnStmt, ctx: None) -> fpc.Expr:
         return self._visit_expr(stmt.expr, ctx)
 
+    def _visit_pass(self, stmt: PassStmt, ctx: None) -> fpc.Expr:
+        return ctx
+
     def _visit_block(self, block: StmtBlock, ctx: fpc.Expr | None):
         if ctx is None:
             e = self._visit_statement(block.stmts[-1], None)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -780,6 +780,8 @@ class Parser:
             case ast.Expr():
                 e = self._parse_expr(stmt.value)
                 return EffectStmt(e, loc)
+            case ast.Pass():
+                return PassStmt(loc)
             case _:
                 raise FPyParserError(loc, 'statement is unsupported in FPy', stmt)
 

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -803,6 +803,9 @@ class _Interpreter(Visitor):
         x = self._visit_expr(stmt.expr, ctx)
         raise FunctionReturnError(x)
 
+    def _visit_pass(self, stmt: PassStmt, ctx: Context):
+        pass
+
     def _visit_block(self, block: StmtBlock, ctx: Context):
         for stmt in block.stmts:
             self._visit_statement(stmt, ctx)

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -351,6 +351,9 @@ class _MatcherInst(Visitor):
     def _visit_return(self, stmt: ReturnStmt, pat: ReturnStmt):
         self._visit_expr(stmt.expr, pat.expr)
 
+    def _visit_pass(self, stmt: PassStmt, pat: ReturnStmt):
+        pass
+
     def _visit_block(self, block: StmtBlock, pat: StmtBlock):
         # check length of block
         if len(block.stmts) != len(pat.stmts):

--- a/tests/infra/unit/defs.py
+++ b/tests/infra/unit/defs.py
@@ -539,6 +539,11 @@ def test_assert3():
     assert 0 == 0, 1 + 1
     return 0
 
+@fpy
+def test_pass1():
+    pass
+    return 0
+
 ### Examples
 
 @fpy
@@ -752,7 +757,8 @@ tests: list[Function] = [
     test_context8,
     test_assert1,
     test_assert2,
-    test_assert3
+    test_assert3,
+    test_pass1,
 ]
 
 # Examples


### PR DESCRIPTION
This PR adds support for Python's `pass` statement in FPy. The use case for the statement is for constructing and binding rounding contexts:
```python
with <e> as ctx:
  pass
# x is a rounding context
```
This is semantically different than
```python
ctx = <e>
```
since in the first case, the expression is evaluated under the real rounding context while in the second, the expression is evaluated under the current context.