### PR TITLE
Constant propagation: enable propagation for numbers

### DIFF
--- a/fpy2/transform/const_prop.py
+++ b/fpy2/transform/const_prop.py
@@ -13,9 +13,10 @@ def _is_value(e: Expr) -> bool:
     Is this expression a constant?
 
     <cprop> ::= <bool>
+              | <number>
               | <foreign>
     """
-    return isinstance(e, BoolVal | ForeignVal)
+    return isinstance(e, BoolVal | RealVal | ForeignVal)
 
 class ConstPropagate:
     """

--- a/tests/unit/transform/test_const_prop.py
+++ b/tests/unit/transform/test_const_prop.py
@@ -21,5 +21,30 @@ class TestConstProp(unittest.TestCase):
 
         f = fp.transform.ConstPropagate.apply(test.ast)
         f.name = test_expect.name
-        self.assertTrue(f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}')
+        self.assertTrue(
+            f.is_equiv(test_expect.ast),
+            f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'
+        )
 
+
+    def test_example2(self):
+        @fp.fpy
+        def test():
+            ES = 2
+            NB = 8
+            with fp.IEEEContext(ES, NB):
+                return fp.R(1)
+
+        @fp.fpy
+        def test_expect():
+            ES = 2
+            NB = 8
+            with fp.IEEEContext(2, 8):
+                return fp.R(1)
+
+        f = fp.transform.ConstPropagate.apply(test.ast)
+        f.name = test_expect.name
+        self.assertTrue(
+            f.is_equiv(test_expect.ast),
+            f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'
+        )


### PR DESCRIPTION
This PR enables constant propagation for numbers. Since #93 changed numbers to be unrounded, numbers are now interpreted as-is; and, thus substitution of numbers is always valid.