### PR TITLE
Arithmetic supports fraction

### DIFF
--- a/fpy2/analysis/define_use.py
+++ b/fpy2/analysis/define_use.py
@@ -175,5 +175,4 @@ class DefineUse:
         if not isinstance(ast, FuncDef | StmtBlock):
             raise TypeError(f'Expected \'FuncDef\' or \'StmtBlock\', got {type(ast)} for {ast}')
         reaching_defs = ReachingDefs.analyze(ast)
-        print(reaching_defs.format(), flush=True)
         return _DefineUseInstance(ast, reaching_defs).analyze()

--- a/fpy2/number/__init__.py
+++ b/fpy2/number/__init__.py
@@ -14,7 +14,7 @@ from .mp_float import MPFloatContext
 from .mpb_fixed import MPBFixedContext
 from .mpb_float import MPBFloatContext
 from .mps_float import MPSFloatContext
-from .real import RealContext
+from .real import RealContext, REAL
 from .sm_fixed import SMFixedContext
 
 # Rounding
@@ -34,12 +34,6 @@ OV: TypeAlias = OverflowMode
 
 ###########################################################
 # Format aliases
-
-REAL = RealContext()
-"""
-Alias for exact computation.
-Operations are never rounded under this context.
-"""
 
 FP256 = IEEEContext(19, 256, RM.RNE)
 """

--- a/fpy2/number/context.py
+++ b/fpy2/number/context.py
@@ -166,7 +166,7 @@ class Context(ABC):
         """
         return self.round_at(x, -1)
 
-    def _round_prepare(self, x, n: int | None) -> Union[RealFloat, Float]:
+    def _round_prepare(self, x) -> Union[RealFloat, Float]:
         """
         Initial step during rounding.
 
@@ -181,6 +181,9 @@ class Context(ABC):
         - Python numbers: `int`, `float`, `Fraction`
         - Python strings: `str`
         """
+        # get around circular import issues
+        from .number import Float, RealFloat
+
         match x:
             case Float() | RealFloat():
                 return x

--- a/fpy2/number/mp_fixed.py
+++ b/fpy2/number/mp_fixed.py
@@ -261,7 +261,7 @@ class MPFixedContext(OrdinalContext):
             nmin = self.nmin - self.num_randbits
             return None, nmin
 
-    def _round_float_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
+    def _round_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
         """
         Like `self.round_at()` but only for `RealFloat` or `Float` instances.
 
@@ -308,28 +308,12 @@ class MPFixedContext(OrdinalContext):
         # step 4. wrap the value in a Float
         return Float(x=xr, ctx=self)
 
-    def _round_at(self, x, n: int | None, exact: bool) -> Float:
-        match x:
-            case Float() | RealFloat():
-                xr = x
-            case float():
-                xr = Float.from_float(x)
-            case int():
-                xr = RealFloat.from_int(x)
-            case Fraction() if x.denominator == 1:
-                xr = RealFloat.from_int(int(x))
-            case str() | Fraction():
-                p, n = self.round_params()
-                xr = mpfr_value(x, prec=p, n=n)
-            case _:
-                raise TypeError(f'not valid argument x={x}')
-
-        return self._round_float_at(xr, n, exact)
-
     def round(self, x, *, exact: bool = False) -> Float:
+        x = self._round_prepare(x)
         return self._round_at(x, None, exact)
 
     def round_at(self, x, n: int, *, exact: bool = False) -> Float:
+        x = self._round_prepare(x)
         return self._round_at(x, n, exact)
 
     def to_ordinal(self, x: Float, infval: bool = False) -> int:

--- a/fpy2/number/mp_float.py
+++ b/fpy2/number/mp_float.py
@@ -184,7 +184,7 @@ class MPFloatContext(Context):
             pmax = self.pmax + self.num_randbits
             return pmax, None
 
-    def _round_at(self, x, n: int | None, exact: bool) -> Float:
+    def _round_at(self, x, n: int | None, exact: bool):
         match x:
             case Float() | RealFloat():
                 xr = x

--- a/fpy2/number/mpb_fixed.py
+++ b/fpy2/number/mpb_fixed.py
@@ -312,7 +312,7 @@ class MPBFixedContext(SizedContext):
         else:
             return x > self.pos_maxval
 
-    def _round_float_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
+    def _round_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
         """
         Like `self.round_at()` but only for `RealFloat` or `Float` instances.
 
@@ -380,30 +380,14 @@ class MPBFixedContext(SizedContext):
         # step 5. return the rounded value
         return Float(x=xr, ctx=self)
 
-    def _round_at(self, x, n: int | None, exact: bool) -> Float:
-        match x:
-            case Float() | RealFloat():
-                xr = x
-            case float():
-                xr = Float.from_float(x)
-            case int():
-                xr = RealFloat.from_int(x)
-            case Fraction() if x.denominator == 1:
-                xr = RealFloat.from_int(int(x))
-            case str() | Fraction():
-                p, n = self.round_params()
-                xr = mpfr_value(x, prec=p, n=n)
-            case _:
-                raise TypeError(f'not valid argument x={x}')
-
-        return self._round_float_at(xr, n, exact)
-
     def round(self, x, *, exact: bool = False):
+        x = self._round_prepare(x)
         return self._round_at(x, None, exact)
 
     def round_at(self, x, n: int, *, exact: bool = False):
         if not isinstance(n, int):
             raise TypeError(f'Expected \'int\' for n={n}, got {type(n)}')
+        x = self._round_prepare(x)
         return self._round_at(x, n, exact)
 
     def to_ordinal(self, x: Float, infval: bool = False) -> int:

--- a/fpy2/number/mpb_float.py
+++ b/fpy2/number/mpb_float.py
@@ -271,7 +271,7 @@ class MPBFloatContext(SizedContext):
             case _:
                 raise RuntimeError(f'unrechable {direction}')
 
-    def _round_float_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
+    def _round_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
         """
         Like `self.round()` but for only `RealFloat` and `Float` inputs.
 
@@ -327,28 +327,12 @@ class MPBFloatContext(SizedContext):
         # step 6. return rounded result
         return Float(x=rounded, ctx=self)
 
-    def _round_at(self, x, n: int | None, exact: bool) -> Float:
-        match x:
-            case Float() | RealFloat():
-                xr = x
-            case float():
-                xr = Float.from_float(x)
-            case int():
-                xr = RealFloat.from_int(x)
-            case Fraction() if x.denominator == 1:
-                xr = RealFloat.from_int(int(x))
-            case str() | Fraction():
-                p, n = self.round_params()
-                xr = mpfr_value(x, prec=p, n=n)
-            case _:
-                raise TypeError(f'not valid argument x={x}')
-
-        return self._round_float_at(xr, n, exact)
-
     def round(self, x, *, exact: bool = False) -> Float:
+        x = self._round_prepare(x)
         return self._round_at(x, None, exact)
 
     def round_at(self, x, n: int, *, exact: bool = False) -> Float:
+        x = self._round_prepare(x)
         return self._round_at(x, n, exact)
 
     def to_ordinal(self, x: Float, infval = False):

--- a/fpy2/number/mps_float.py
+++ b/fpy2/number/mps_float.py
@@ -208,7 +208,7 @@ class MPSFloatContext(OrdinalContext):
             nmin = self.nmin - self.num_randbits
             return pmax, nmin
 
-    def _round_float_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
+    def _round_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
         """
         Like `self.round()` but for only `RealFloat` and `Float` inputs.
 
@@ -240,28 +240,12 @@ class MPSFloatContext(OrdinalContext):
         # step 4. wrap the result in a Float
         return Float(x=xr, ctx=self)
 
-    def _round_at(self, x, n: int | None, exact: bool) -> Float:
-        match x:
-            case Float() | RealFloat():
-                xr = x
-            case float():
-                xr = Float.from_float(x)
-            case int():
-                xr = RealFloat.from_int(x)
-            case Fraction() if x.denominator == 1:
-                xr = RealFloat.from_int(int(x))
-            case str() | Fraction():
-                p, n = self.round_params()
-                xr = mpfr_value(x, prec=p, n=n)
-            case _:
-                raise TypeError(f'not valid argument x={x}')
-
-        return self._round_float_at(xr, n, exact)
-
     def round(self, x, *, exact: bool = False) -> Float:
+        x = self._round_prepare(x)
         return self._round_at(x, None, exact)
 
     def round_at(self, x, n: int, *, exact: bool = False) -> Float:
+        x = self._round_prepare(x)
         return self._round_at(x, n, exact)
 
     def to_ordinal(self, x: Float, infval = False) -> int:

--- a/fpy2/number/number.py
+++ b/fpy2/number/number.py
@@ -494,7 +494,7 @@ class RealFloat(numbers.Rational):
                 # case: has fractional bits
                 exp = d.bit_length() - 1
                 m = n * (2 ** exp) // d
-                return RealFloat(m=m, exp=exp)
+                return RealFloat(m=m, exp=-exp)
 
     @staticmethod
     def zero(s: bool = False):

--- a/fpy2/number/real.py
+++ b/fpy2/number/real.py
@@ -9,6 +9,9 @@ from .context import Context
 from .number import Float, RealFloat
 from .round import RoundingMode
 
+#####################################################################
+# Real rounding context
+
 @default_repr
 class RealContext(Context):
     """
@@ -85,6 +88,8 @@ class RealContext(Context):
     def round_at(self, x, n: int, *, exact: bool = False):
         raise RuntimeError('cannot round at a specific position in real context')
 
+#####################################################################
+# Real methods
 
 def real_neg(x: Float) -> Float:
     """

--- a/fpy2/number/real.py
+++ b/fpy2/number/real.py
@@ -269,19 +269,19 @@ def _real_rint(x: Float | Fraction, rm: RoundingMode) -> Float:
     return Float(x=r, ctx=REAL)
 
 
-def real_ceil(x: Float | Fraction) -> Float | Fraction:
+def real_ceil(x: Float | Fraction):
     """
     Round a real number up to the nearest integer.
     """
     return _real_rint(x, RoundingMode.RTP)
 
-def real_floor(x: Float) -> Float:
+def real_floor(x: Float | Fraction):
     """
     Round a real number down to the nearest integer.
     """
     return _real_rint(x, RoundingMode.RTN)
 
-def real_trunc(x: Float) -> Float:
+def real_trunc(x: Float | Fraction):
     """
     Rounds a real number towards the nearest integer
     with smaller or equal magnitude to `x`.
@@ -289,7 +289,7 @@ def real_trunc(x: Float) -> Float:
     return _real_rint(x, RoundingMode.RTZ)
 
 
-def real_roundint(x: Float) -> Float:
+def real_roundint(x: Float | Fraction):
     """
     Round a real number to the nearest integer,
     rounding ties away from zero in halfway cases.

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -188,6 +188,10 @@ def _real_to_float(x: Real) -> Float:
             return Float.from_int(x)
         case float():
             return Float.from_float(x)
+        case Fraction():
+            if is_dyadic(x):
+                return Float.from_rational(x)
+            raise ValueError(f'Cannot convert non-dyadic rational to Float: {x}')
         case _:
             raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
 

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -536,7 +536,7 @@ def ceil(x: Real, ctx: Context = REAL):
     match ctx:
         case None | RealContext():
             # use rounding primitives
-            return real_ceil(x)
+            return real_ceil(_cvt_to_real(x))
         case _:
             return ctx.with_params(rm=RoundingMode.RTP).round_integer(x)
 
@@ -552,7 +552,7 @@ def floor(x: Real, ctx: Context = REAL):
     match ctx:
         case None | RealContext():
             # use rounding primitives
-            return real_floor(x)
+            return real_floor(_cvt_to_real(x))
         case _:
             return ctx.with_params(rm=RoundingMode.RTN).round_integer(x)
 
@@ -569,7 +569,7 @@ def trunc(x: Real, ctx: Context = REAL):
     match ctx:
         case None | RealContext():
             # use rounding primitives
-            return real_trunc(x)
+            return real_trunc(_cvt_to_real(x))
         case _:
             return ctx.with_params(rm=RoundingMode.RTZ).round_integer(x)
 
@@ -600,7 +600,7 @@ def roundint(x: Real, ctx: Context = REAL):
     match ctx:
         case None | RealContext():
             # use rounding primitives
-            return real_roundint(x)
+            return real_roundint(_cvt_to_real(x))
         case _:
             return ctx.with_params(rm=RoundingMode.RNA).round_integer(x)
 

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -2,8 +2,8 @@
 Mathematical functions under rounding contexts.
 """
 
+from collections.abc import Callable
 from fractions import Fraction
-from typing import Any, Callable
 
 from .number import Context, Float, Real, REAL, RoundingMode
 from .number.gmp import *
@@ -103,84 +103,32 @@ __all__ = [
     'const_sqrt1_2',
 ]
 
-_real_ops: dict[Any, Callable[..., Float]] = {
-    mpfr_fabs: real_abs,
-    mpfr_neg: real_neg,
-    mpfr_add: real_add,
-    mpfr_sub: real_sub,
-    mpfr_mul: real_mul,
-    mpfr_fma: real_fma,
-    mpfr_fmin: min,
-    mpfr_fmax: max
-}
-
-def _apply_real(fn: Callable[..., Float], args: tuple[Float, ...]) -> Float:
-    # real computation; no rounding
-    real_fn = _real_ops.get(fn)
-    if real_fn is None:
-        raise NotImplementedError(f'cannot evaluate exactly: fn={fn}, args={args}')
-    return real_fn(*args)
-
-def _apply_mpfr(fn: Callable[..., Float], *args: Float, ctx: Context | None = None) -> Float:
-    """
-    Applies a MPFR function with the given arguments and context.
-    The function is expected to take a variable number of `Float` arguments
-    followed by an integer for precision.
-    """
-    if ctx is None:
-        # real computation; no rounding
-        return _apply_real(fn, args)
-    else:
-        p, n = ctx.round_params()
-        match p, n:
-            case int(), _:
-                # floating-point style rounding
-                r = fn(*args, prec=p)  # compute with round-to-odd (safe at p digits)
-                return ctx.round(r)  # re-round under desired rounding mode
-            case _, int():
-                # fixed-point style rounding
-                r = fn(*args, n=n)
-                return ctx.round(r)  # re-round under desired rounding mode
-            case _:
-                # real computation; stochastic rounding may apply
-                x = _apply_real(fn, args)
-                return ctx.round(x)
-
-def _real_constant(name: str, ctx: Context | None = None) -> Float:
-    if name == 'NAN':
-        return Float(isnan=True, ctx=ctx)
-    elif name == 'INFINITY':
-        return Float(isinf=True, ctx=ctx)
-    else:
-        raise NotImplementedError(f'cannot evaluate exactly: name={name}')
-
-def _apply_mpfr_constant(name: str, ctx: Context | None = None) -> Float:
-    """
-    Computes an MPFR constant function with the given context.
-    """
-    if ctx is None:
-        # real computation; no rounding
-        return _real_constant(name)
-    else:
-        p, n = ctx.round_params()
-        match p, n:
-            case int(), _:
-                # floating-point style rounding
-                r = mpfr_constant(name, prec=p)  # compute with round-to-odd (safe at p digits)
-                return ctx.round(r)  # re-round under desired rounding mode
-            case _, int():
-                # fixed-point style rounding
-                r = mpfr_constant(name, n=n)
-                return ctx.round(r)  # re-round under desired rounding mode
-            case _:
-                # real computation; stochastic rounding may apply
-                x = _real_constant(name)
-                return ctx.round(x)
+# _real_ops: dict[Any, Callable[..., Float]] = {
+#     mpfr_fabs: real_abs,
+#     mpfr_neg: real_neg,
+#     mpfr_add: real_add,
+#     mpfr_sub: real_sub,
+#     mpfr_mul: real_mul,
+#     mpfr_fma: real_fma,
+#     mpfr_fmin: min,
+#     mpfr_fmax: max
+# }
 
 ################################################################################
-# Types
+# Type
 
-def _real_to_float(x: Real) -> Float:
+def _cvt_to_real(x: Real) -> Float | Fraction:
+    match x:
+        case Float() | Fraction():
+            return x
+        case int():
+            return Float.from_int(x)
+        case float():
+            return Float.from_float(x)
+        case _:
+            raise TypeError(f'Expected \'Float\' or \'Fraction\', got \'{type(x)}\' for x={x}')
+
+def _cvt_to_float(x: Real) -> Float:
     match x:
         case Float():
             return x
@@ -195,327 +143,340 @@ def _real_to_float(x: Real) -> Float:
         case _:
             raise TypeError(f'Expected \'Float\', got \'{type(x)}\' for x={x}')
 
+#####################################################################
+# Appliers
+
+def _apply_mpfr_constant(name: Constant, ctx: Context = REAL) -> Float:
+    """
+    Applies an MPFR constant with the given context.
+
+    The constant is computed with sufficient precision to be
+    safely re-rounded under the given context.
+    """
+    p, n = ctx.round_params()
+    match p, n:
+        case int(), _:
+            # floating-point style rounding
+            x = mpfr_constant(name, prec=p)  # compute with round-to-odd (safe at p digits)
+            return ctx.round(x)  # re-round under desired rounding mode
+        case _, int():
+            # fixed-point style rounding
+            x = mpfr_constant(name, n=n)
+            return ctx.round(x)  # re-round under desired rounding mode
+        case _:
+            # real computation
+            raise ValueError(f'Cannot compute exactly: name={name}, ctx={ctx}')
+
+def _apply_mpfr(fn: Callable[..., Float], *args: Real, ctx: Context = REAL) -> Float:
+    """
+    Applies an MPFR function with the given arguments and context.
+
+    The function is expected to take a fixed number of `Float` arguments
+    followed by either a precision `p` or a least absolute digit `n`.
+    """
+    p, n = ctx.round_params()
+    fl_args = tuple(_cvt_to_float(x) for x in args)
+    match p, n:
+        case int(), _:
+            # floating-point style rounding
+            x = fn(*fl_args, prec=p)  # compute with round-to-odd (safe at p digits)
+            return ctx.round(x)  # re-round under desired rounding mode
+        case _, int():
+            # fixed-point style rounding
+            x = fn(*fl_args, n=n)
+            return ctx.round(x)  # re-round under desired rounding mode
+        case _:
+            # real computation
+            raise ValueError(f'Cannot compute exactly: fn={fn}, args={args}, ctx={ctx}')
+
+def _apply_mpfr_or_real(
+    mpfr_fn: Callable[..., Float],
+    real_fn: Callable[..., Float],
+    *args: Real,
+    ctx: Context
+):
+    """
+    Applies either an MPFR function or a real function with
+    the given arguments and context depending on the rounding
+    requested by the context.
+
+    The MPFR function is expected to take a fixed number of `Float` arguments
+    followed by either a precision `p` or a least absolute digit `n`.
+    The real function only takes `Float | Fraction` arguments.
+    """
+    p, n = ctx.round_params()
+    if p is None and n is None:
+        # real computation
+        r_args = tuple(_cvt_to_real(x) for x in args)
+        x = real_fn(*r_args)
+        return ctx.round(x)
+    else:
+        return _apply_mpfr(mpfr_fn, *args, ctx=ctx)
+
 ################################################################################
 # General operations
 
-def acos(x: Real, ctx: Context | None = None):
+def acos(x: Real, ctx: Context = REAL):
     """Computes the inverse cosine of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_acos, x, ctx=ctx)
 
-def acosh(x: Real, ctx: Context | None = None):
+def acosh(x: Real, ctx: Context = REAL):
     """Computes the inverse hyperbolic cosine of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_acosh, x, ctx=ctx)
 
-def add(x: Real, y: Real, ctx: Context | None = None):
+def add(x: Real, y: Real, ctx: Context = REAL):
     """Adds `x` and `y` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_add, x, y, ctx=ctx)
 
-def asin(x: Real, ctx: Context | None = None):
+def asin(x: Real, ctx: Context = REAL):
     """Computes the inverse sine of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_asin, x, ctx=ctx)
 
-def asinh(x: Real, ctx: Context | None = None):
+def asinh(x: Real, ctx: Context = REAL):
     """Computes the inverse hyperbolic sine of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_asinh, x, ctx=ctx)
 
-def atan(x: Real, ctx: Context | None = None):
+def atan(x: Real, ctx: Context = REAL):
     """Computes the inverse tangent of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_atan, x, ctx=ctx)
 
-def atan2(y: Real, x: Real, ctx: Context | None = None):
+def atan2(y: Real, x: Real, ctx: Context = REAL):
     """
     Computes `atan(y / x)` taking into account the correct quadrant
     that the point `(x, y)` resides in. The result is rounded under `ctx`.
     """
-    y = _real_to_float(y)
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_atan2, y, x, ctx=ctx)
 
-def atanh(x: Real, ctx: Context | None = None):
+def atanh(x: Real, ctx: Context = REAL):
     """Computes the inverse hyperbolic tangent of `x` under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_atanh, x, ctx=ctx)
 
-def cbrt(x: Real, ctx: Context | None = None):
+def cbrt(x: Real, ctx: Context = REAL):
     """Computes the cube root of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_cbrt, x, ctx=ctx)
 
-def copysign(x: Real, y: Real, ctx: Context | None = None):
+def copysign(x: Real, y: Real, ctx: Context = REAL):
     """Returns `|x| * sign(y)` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_copysign, x, y, ctx=ctx)
 
-def cos(x: Real, ctx: Context | None = None):
+def cos(x: Real, ctx: Context = REAL):
     """Computes the cosine of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_cos, x, ctx=ctx)
 
-def cosh(x: Real, ctx: Context | None = None):
+def cosh(x: Real, ctx: Context = REAL):
     """Computes the hyperbolic cosine `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_cosh, x, ctx=ctx)
 
-def div(x: Real, y: Real, ctx: Context | None = None):
+def div(x: Real, y: Real, ctx: Context = REAL):
     """Computes `x / y` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_div, x, y, ctx=ctx)
 
-def erf(x: Real, ctx: Context | None = None):
+def erf(x: Real, ctx: Context = REAL):
     """Computes the error function of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_erf, x, ctx=ctx)
 
-def erfc(x: Real, ctx: Context | None = None):
+def erfc(x: Real, ctx: Context = REAL):
     """Computes `1 - erf(x)` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_erfc, x, ctx=ctx)
 
-def exp(x: Real, ctx: Context | None = None):
+def exp(x: Real, ctx: Context = REAL):
     """Computes `e ** x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_exp, x, ctx=ctx)
 
-def exp2(x: Real, ctx: Context | None = None):
+def exp2(x: Real, ctx: Context = REAL):
     """Computes `2 ** x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_exp2, x, ctx=ctx)
 
-def exp10(x: Real, ctx: Context | None = None):
+def exp10(x: Real, ctx: Context = REAL):
     """Computes `10 *** x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_exp10, x, ctx=ctx)
 
-def expm1(x: Real, ctx: Context | None = None):
+def expm1(x: Real, ctx: Context = REAL):
     """Computes `exp(x) - 1` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_expm1, x, ctx=ctx)
 
-def fabs(x: Real, ctx: Context | None = None):
+def fabs(x: Real, ctx: Context = REAL):
     """Computes `|x|` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_fabs, x, ctx=ctx)
 
-def fdim(x: Real, y: Real, ctx: Context | None = None):
+def fdim(x: Real, y: Real, ctx: Context = REAL):
     """Computes `max(x - y, 0)` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_fdim, x, y, ctx=ctx)
 
-def fma(x: Real, y: Real, z: Real, ctx: Context | None = None):
+def fma(x: Real, y: Real, z: Real, ctx: Context = REAL):
     """Computes `x * y + z` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
-    z = _real_to_float(z)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_fma, x, y, z, ctx=ctx)
 
-def fmax(x: Real, y: Real, ctx: Context | None = None):
+def fmax(x: Real, y: Real, ctx: Context = REAL):
     """Computes `max(x, y)` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_fmax, x, y, ctx=ctx)
 
-def fmin(x: Real, y: Real, ctx: Context | None = None):
+def fmin(x: Real, y: Real, ctx: Context = REAL):
     """Computes `min(x, y)` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_fmin, x, y, ctx=ctx)
 
-def fmod(x: Real, y: Real, ctx: Context | None = None):
+def fmod(x: Real, y: Real, ctx: Context = REAL):
     """
     Computes the remainder of `x / y` rounded under this context.
 
     The remainder has the same sign as `x`; it is exactly `x - iquot * y`,
     where `iquot` is the `x / y` with its fractional part truncated.
     """
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_fmod, x, y, ctx=ctx)
 
-def hypot(x: Real, y: Real, ctx: Context | None = None):
+def hypot(x: Real, y: Real, ctx: Context = REAL):
     """Computes `sqrt(x * x + y * y)` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_hypot, x, y, ctx=ctx)
 
-def lgamma(x: Real, ctx: Context | None = None):
+def lgamma(x: Real, ctx: Context = REAL):
     """Computes the log-gamma of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_lgamma, x, ctx=ctx)
 
-def log(x: Real, ctx: Context | None = None):
+def log(x: Real, ctx: Context = REAL):
     """Computes `log(x)` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_log, x, ctx=ctx)
 
-def log10(x: Real, ctx: Context | None = None):
+def log10(x: Real, ctx: Context = REAL):
     """Computes `log10(x)` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_log10, x, ctx=ctx)
 
-def log1p(x: Real, ctx: Context | None = None):
+def log1p(x: Real, ctx: Context = REAL):
     """Computes `log1p(x)` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_log1p, x, ctx=ctx)
 
-def log2(x: Real, ctx: Context | None = None):
+def log2(x: Real, ctx: Context = REAL):
     """Computes `log2(x)` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_log2, x, ctx=ctx)
 
-def mul(x: Real, y: Real, ctx: Context | None = None):
+def mul(x: Real, y: Real, ctx: Context = REAL):
     """Multiplies `x` and `y` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_mul, x, y, ctx=ctx)
 
-def neg(x: Real, ctx: Context | None = None):
+def neg(x: Real, ctx: Context = REAL):
     """Computes `-x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for ctx={ctx}')
     return _apply_mpfr(mpfr_neg, x, ctx=ctx)
 
-def pow(x: Real, y: Real, ctx: Context | None = None):
+def pow(x: Real, y: Real, ctx: Context = REAL):
     """Computes `x**y` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_pow, x, y, ctx=ctx)
 
-def remainder(x: Real, y: Real, ctx: Context | None = None):
+def remainder(x: Real, y: Real, ctx: Context = REAL):
     """
     Computes the remainder of `x / y` rounded under `ctx`.
 
     The remainder is exactly `x - quo * y`, where `quo` is the
     integral value nearest the exact value of `x / y`.
     """
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_remainder, x, y, ctx=ctx)
 
-def sin(x: Real, ctx: Context | None = None):
+def sin(x: Real, ctx: Context = REAL):
     """Computes the sine of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_sin, x, ctx=ctx)
 
-def sinh(x: Real, ctx: Context | None = None):
+def sinh(x: Real, ctx: Context = REAL):
     """Computes the hyperbolic sine of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_sinh, x, ctx=ctx)
 
-def sqrt(x: Real, ctx: Context | None = None):
+def sqrt(x: Real, ctx: Context = REAL):
     """Computes square-root of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_sqrt, x, ctx=ctx)
 
-def sub(x: Real, y: Real, ctx: Context | None = None):
+def sub(x: Real, y: Real, ctx: Context = REAL):
     """Subtracts `y` from `x` rounded under `ctx`."""
-    x = _real_to_float(x)
-    y = _real_to_float(y)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_sub, x, y, ctx=ctx)
 
-def tan(x: Real, ctx: Context | None = None):
+def tan(x: Real, ctx: Context = REAL):
     """Computes the tangent of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_tan, x, ctx=ctx)
 
-def tanh(x: Real, ctx: Context | None = None):
+def tanh(x: Real, ctx: Context = REAL):
     """Computes the hyperbolic tangent of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_tanh, x, ctx=ctx)
 
-def tgamma(x: Real, ctx: Context | None = None):
+def tgamma(x: Real, ctx: Context = REAL):
     """Computes gamma of `x` rounded under `ctx`."""
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return _apply_mpfr(mpfr_tgamma, x, ctx=ctx)
@@ -536,7 +497,7 @@ def _round(x: Real, ctx: Context | None, exact: bool):
         case _:
             return ctx.round(x, exact=exact)
 
-def round(x: Real, ctx: Context | None = None):
+def round(x: Real, ctx: Context = REAL):
     """
     Rounds `x` under the given context `ctx`.
 
@@ -544,7 +505,7 @@ def round(x: Real, ctx: Context | None = None):
     """
     return _round(x, ctx, exact=False)
 
-def round_exact(x: Real, ctx: Context | None = None):
+def round_exact(x: Real, ctx: Context = REAL):
     """
     Rounds `x` under the given context `ctx`.
 
@@ -553,14 +514,13 @@ def round_exact(x: Real, ctx: Context | None = None):
     """
     return _round(x, ctx, exact=True)
 
-def round_at(x: Real, n: Real, ctx: Context | None = None) -> Float:
+def round_at(x: Real, n: Real, ctx: Context = REAL) -> Float:
     """
     Rounds `x` with least absolute digit `n`, the most significant digit
     that must definitely be rounded off. If `ctx` has bounded precision,
     the actual `n` use may be larger than the one specified.
     """
-    x = _real_to_float(x)
-    n = _real_to_float(n)
+    n = _cvt_to_float(n)
     if not n.is_integer():
         raise ValueError(f'n={n} must be an integer')
     match ctx:
@@ -572,14 +532,13 @@ def round_at(x: Real, n: Real, ctx: Context | None = None) -> Float:
 #############################################################################
 # Round-to-integer operations
 
-def ceil(x: Real, ctx: Context | None = None):
+def ceil(x: Real, ctx: Context = REAL):
     """
     Computes the smallest integer greater than or equal to `x`
     that is representable under `ctx`.
 
     If the context supports overflow, the result may be infinite.
     """
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     match ctx:
@@ -589,14 +548,13 @@ def ceil(x: Real, ctx: Context | None = None):
         case _:
             return ctx.with_params(rm=RoundingMode.RTP).round_integer(x)
 
-def floor(x: Real, ctx: Context | None = None):
+def floor(x: Real, ctx: Context = REAL):
     """
     Computes the largest integer less than or equal to `x`
     that is representable under `ctx`.
 
     If the context supports overflow, the result may be infinite.
     """
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     match ctx:
@@ -606,7 +564,7 @@ def floor(x: Real, ctx: Context | None = None):
         case _:
             return ctx.with_params(rm=RoundingMode.RTN).round_integer(x)
 
-def trunc(x: Real, ctx: Context | None = None):
+def trunc(x: Real, ctx: Context = REAL):
     """
     Computes the integer with the largest magnitude whose
     magnitude is less than or equal to the magnitude of `x`
@@ -614,7 +572,6 @@ def trunc(x: Real, ctx: Context | None = None):
 
     If the context supports overflow, the result may be infinite.
     """
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     match ctx:
@@ -624,14 +581,13 @@ def trunc(x: Real, ctx: Context | None = None):
         case _:
             return ctx.with_params(rm=RoundingMode.RTZ).round_integer(x)
 
-def nearbyint(x: Real, ctx: Context | None = None):
+def nearbyint(x: Real, ctx: Context = REAL):
     """
     Rounds `x` to a representable integer according to
     the rounding mode of this context.
 
     If the context supports overflow, the result may be infinite.
     """
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     match ctx:
@@ -640,14 +596,13 @@ def nearbyint(x: Real, ctx: Context | None = None):
         case _:
             return ctx.round_integer(x)
 
-def roundint(x: Real, ctx: Context | None = None):
+def roundint(x: Real, ctx: Context = REAL):
     """
     Rounds `x` to the nearest representable integer,
     rounding ties away from zero in halfway cases.
 
     If the context supports overflow, the result may be infinite.
     """
-    x = _real_to_float(x)
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     match ctx:
@@ -660,45 +615,49 @@ def roundint(x: Real, ctx: Context | None = None):
 #############################################################################
 # Classification
 
-def isnan(x: Real, ctx: Context | None = None) -> bool:
+def isnan(x: Real, ctx: Context = REAL) -> bool:
     """Checks if `x` is NaN."""
-    x = _real_to_float(x)
+    x = _cvt_to_float(x)
     return x.isnan
 
-def isinf(x: Real, ctx: Context | None = None) -> bool:
+def isinf(x: Real, ctx: Context = REAL) -> bool:
     """Checks if `x` is infinite."""
-    x = _real_to_float(x)
+    x = _cvt_to_float(x)
     return x.isinf
 
-def isfinite(x: Real, ctx: Context | None = None) -> bool:
+def isfinite(x: Real, ctx: Context = REAL) -> bool:
     """Checks if `x` is finite."""
-    x = _real_to_float(x)
-    return not x.is_nar()
+    x = _cvt_to_real(x)
+    return isinstance(x, Fraction) or not x.is_nar()
 
-def isnormal(x: Real, ctx: Context | None = None) -> bool:
+def isnormal(x: Real, ctx: Context = REAL) -> bool:
     """Checks if `x` is normal (not subnormal, zero, or NaN)."""
-    x = _real_to_float(x)
-    return x.is_normal()
+    # TODO: what if the argument is a Fraction?
+    x = _cvt_to_real(x)
+    return isinstance(x, Fraction) or x.is_normal()
 
-def signbit(x: Real, ctx: Context | None = None) -> bool:
+def signbit(x: Real, ctx: Context = REAL) -> bool:
     """Checks if the sign bit of `x` is set (i.e., `x` is negative)."""
-    x = _real_to_float(x)
     # TODO: should all Floats have this property?
-    return x.s
+    x = _cvt_to_float(x)
+    if isinstance(x, Fraction):
+        return x < 0
+    else:
+        return x.s
 
 #############################################################################
 # Tensor
 
-def empty(n: Real, ctx: Context | None = None) -> list:
+def empty(n: Real, ctx: Context = REAL) -> list:
     """
     Initializes an empty list of length `n`.
     """
-    n = _real_to_float(n)
+    n = _cvt_to_float(n)
     if not n.is_integer() or n.is_negative():
         raise ValueError(f'Invalid list size: {n}')
     return [UNINIT for _ in range(int(n))]
 
-def dim(x: list, ctx: Context | None = None):
+def dim(x: list, ctx: Context = REAL):
     """
     Returns the number of dimensions of the tensor `x`.
 
@@ -719,13 +678,13 @@ def dim(x: list, ctx: Context | None = None):
     else:
         return ctx.round(dim)
 
-def size(x: list, dim: Real, ctx: Context | None = None):
+def size(x: list, dim: Real, ctx: Context = REAL):
     """
     Returns the size of the dimension `dim` of the tensor `x`.
 
     Assumes that `x` is not a ragged tensor.
     """
-    dim = _real_to_float(dim)
+    dim = _cvt_to_float(dim)
     if dim.is_zero():
         # size(x, 0) = len(x)
         if ctx is None:
@@ -746,7 +705,7 @@ def size(x: list, dim: Real, ctx: Context | None = None):
 #############################################################################
 # Constants
 
-def digits(m: int, e: int, b: int, ctx: Context | None = None) -> Float:
+def digits(m: int, e: int, b: int, ctx: Context = REAL) -> Float:
     """
     Creates a `Float` of the form `m * b**e`, where `m` is the
     significand, `e` is the exponent, and `b` is the base.
@@ -768,7 +727,7 @@ def digits(m: int, e: int, b: int, ctx: Context | None = None) -> Float:
         case _:
             raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for ctx={ctx}')
 
-def hexfloat(s: str, ctx: Context | None = None) -> Float:
+def hexfloat(s: str, ctx: Context = REAL) -> Float:
     """
     Creates a `Float` from a hexadecimal floating-point string `s`.
     The result is rounded under the given context.
@@ -788,7 +747,7 @@ def hexfloat(s: str, ctx: Context | None = None) -> Float:
         case _:
             raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for ctx={ctx}')
 
-def rational(n: int, d: int, ctx: Context | None = None) -> Float:
+def rational(n: int, d: int, ctx: Context = REAL) -> Float:
     """
     Creates a `Float` from a fraction with the given numerator and denominator.
     The result is rounded under the given context.
@@ -811,7 +770,7 @@ def rational(n: int, d: int, ctx: Context | None = None) -> Float:
         case _:
             raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for ctx={ctx}')
 
-def nan(ctx: Context | None = None) -> Float:
+def nan(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing NaN (Not a Number).
     The result is rounded under the given context.
@@ -820,7 +779,7 @@ def nan(ctx: Context | None = None) -> Float:
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return Float(isnan=True, ctx=ctx)
 
-def inf(ctx: Context | None = None) -> Float:
+def inf(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing (positive) infinity.
     The result is rounded under the given context.
@@ -829,110 +788,110 @@ def inf(ctx: Context | None = None) -> Float:
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
     return Float(isinf=True, ctx=ctx)
 
-def const_pi(ctx: Context | None = None) -> Float:
+def const_pi(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing π (pi).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('PI', ctx=ctx)
+    return _apply_mpfr_constant(Constant.PI, ctx=ctx)
 
-def const_e(ctx: Context | None = None) -> Float:
+def const_e(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing e (Euler's number).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('E', ctx=ctx)
+    return _apply_mpfr_constant(Constant.E, ctx=ctx)
 
-def const_log2e(ctx: Context | None = None) -> Float:
+def const_log2e(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing log2(e) (the logarithm of e base 2).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('LOG2E', ctx=ctx)
+    return _apply_mpfr_constant(Constant.LOG2E, ctx=ctx)
 
-def const_log10e(ctx: Context | None = None) -> Float:
+def const_log10e(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing log10(e) (the logarithm of e base 10).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('LOG10E', ctx=ctx)
+    return _apply_mpfr_constant(Constant.LOG10E, ctx=ctx)
 
-def const_ln2(ctx: Context | None = None) -> Float:
+def const_ln2(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing ln(2) (the natural logarithm of 2).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('LN2', ctx=ctx)
+    return _apply_mpfr_constant(Constant.LN2, ctx=ctx)
 
-def const_pi_2(ctx: Context | None = None) -> Float:
+def const_pi_2(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing π/2 (pi divided by 2).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('PI_2', ctx=ctx)
+    return _apply_mpfr_constant(Constant.PI_2, ctx=ctx)
 
-def const_pi_4(ctx: Context | None = None) -> Float:
+def const_pi_4(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing π/4 (pi divided by 4).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('PI_4', ctx=ctx)
+    return _apply_mpfr_constant(Constant.PI_4, ctx=ctx)
 
-def const_1_pi(ctx: Context | None = None) -> Float:
+def const_1_pi(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing 1/π (one divided by pi).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('M_1_PI', ctx=ctx)
+    return _apply_mpfr_constant(Constant.M_1_PI, ctx=ctx)
 
-def const_2_pi(ctx: Context | None = None) -> Float:
+def const_2_pi(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing 2/π (two divided by pi).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('M_2_PI', ctx=ctx)
+    return _apply_mpfr_constant(Constant.M_2_PI, ctx=ctx)
 
-def const_2_sqrt_pi(ctx: Context | None = None) -> Float:
+def const_2_sqrt_pi(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing 2/sqrt(π) (two divided by the square root of pi).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('M_2_SQRTPI', ctx=ctx)
+    return _apply_mpfr_constant(Constant.M_2_SQRTPI, ctx=ctx)
 
-def const_sqrt2(ctx: Context | None = None) -> Float:
+def const_sqrt2(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing sqrt(2) (the square root of 2).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('SQRT2', ctx=ctx)
+    return _apply_mpfr_constant(Constant.SQRT2, ctx=ctx)
 
-def const_sqrt1_2(ctx: Context | None = None) -> Float:
+def const_sqrt1_2(ctx: Context = REAL) -> Float:
     """
     Creates a `Float` representing sqrt(1/2) (the square root of 1/2).
     The result is rounded under the given context.
     """
     if ctx is not None and not isinstance(ctx, Context):
         raise TypeError(f'Expected \'Context\' or \'None\', got \'{type(ctx)}\' for x={ctx}')
-    return _apply_mpfr_constant('SQRT1_2', ctx=ctx)
+    return _apply_mpfr_constant(Constant.SQRT1_2, ctx=ctx)

--- a/fpy2/transform/const_fold.py
+++ b/fpy2/transform/const_fold.py
@@ -156,7 +156,6 @@ class _ConstFoldInstance(DefaultTransformVisitor):
 
     def _visit_call(self, e: Call, ctx: Context | None):
         e = super()._visit_call(e, ctx)
-        print(e.format(), ctx)
         if (
             self.enable_context 
             and isinstance(e.fn, type)

--- a/tests/unit/number/test_compare.py
+++ b/tests/unit/number/test_compare.py
@@ -10,17 +10,12 @@ from hypothesis import given, strategies as st
 
 from ..generators import real_floats, floats
 
-_PREC = 8
-_EXP_MIN = -10
-_EXP_MAX = 10
-
-
 @st.composite
 def number(
     draw,
-    prec: int = _PREC,
-    exp_min: int = _EXP_MIN,
-    exp_max: int = _EXP_MAX
+    prec: int = 8,
+    exp_min: int = -10,
+    exp_max: int = 10
 ):
     """
     Returns a strategy for generating either a

--- a/tests/unit/number/test_float.py
+++ b/tests/unit/number/test_float.py
@@ -18,3 +18,32 @@ class TestFloatMethods(unittest.TestCase):
         self.assertIsInstance(y, fp.Float)
         z = float(y)
         self.assertTrue(math.isnan(z) if math.isnan(x) else z == x)
+
+    @given(st.fractions(min_value=-1, max_value=1, max_denominator=1000))
+    def test_from_rational(self, x):
+        if fp.utils.is_dyadic(x):
+            y = fp.Float.from_rational(x)
+            self.assertIsInstance(y, fp.Float)
+            self.assertEqual(x, y)
+        else:
+            with self.assertRaises(ValueError):
+                fp.Float.from_rational(x)
+
+    @given(st.integers())
+    def test_as_int(self, x):
+        y = fp.Float.from_int(x)
+        self.assertEqual(x, int(y))
+
+    @given(st.floats(allow_nan=False, allow_infinity=False, allow_subnormal=True))
+    def test_as_float(self, x):
+        y = fp.Float.from_float(x)
+        self.assertEqual(x, float(y))
+
+    @given(st.fractions(min_value=-1, max_value=1, max_denominator=1000))
+    def test_as_rational(self, x):
+        if fp.utils.is_dyadic(x):
+            y = fp.Float.from_rational(x)
+            self.assertEqual(x, y.as_rational())
+        else:
+            with self.assertRaises(ValueError):
+                fp.Float.from_rational(x)

--- a/tests/unit/number/test_round.py
+++ b/tests/unit/number/test_round.py
@@ -21,6 +21,7 @@ def _all_contexts():
         fp.MPBFloatContext(24, -127, fp.RealFloat.from_int(2 ** 100).normalize(24), fp.RM.RNE),
         fp.MPFixedContext(-8, fp.RM.RNE),
         fp.MPBFixedContext(-8, fp.RealFloat.from_int(2 ** 30), fp.RM.RNE, fp.OV.SATURATE),
+        fp.ExpContext(8),
         fp.RealContext()
     ]
 

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -31,6 +31,30 @@ def _cvt_to_frac(x: int | float | Fraction | fp.RealFloat | fp.Float) -> float |
         case _:
             raise TypeError(f'cannot convert {type(x)} to Fraction or float')
 
+def _ceil(x: float | Fraction):
+    if math.isnan(x):
+        return float('nan')
+    elif math.isinf(x):
+        return x
+    else:
+        return math.ceil(x)
+
+def _floor(x: float | Fraction):
+    if math.isnan(x):
+        return float('nan')
+    elif math.isinf(x):
+        return x
+    else:
+        return math.floor(x)
+
+def _trunc(x: float | Fraction):
+    if math.isnan(x):
+        return float('nan')
+    elif math.isinf(x):
+        return x
+    else:
+        return math.trunc(x)
+
 @st.composite
 def number(
     draw,
@@ -57,9 +81,10 @@ def number(
 class TestOps(unittest.TestCase):
 
     def assertEqualOrNan(self, a: Fraction | float, b: Fraction | float, msg: str = ''):
-        if isinstance(a, float) and isinstance(b, float) and math.isnan(a) and math.isnan(b):
-            return
-        self.assertEqual(a, b, msg)
+        if math.isnan(a) or math.isnan(b):
+            self.assertTrue(math.isnan(a) and math.isnan(b), msg)
+        else:
+            self.assertEqual(a, b, msg)
 
     @given(number())
     def test_neg(self, a):
@@ -101,3 +126,21 @@ class TestOps(unittest.TestCase):
         cf = _cvt_to_frac(c)
         op = _cvt_to_frac(fp.fma(a, b, c))
         self.assertEqualOrNan(op, af * bf + cf, f'Failed FMA: {a} * {b} + {c} ({af} * {bf} + {cf})')
+
+    @given(number())
+    def test_ceil(self, a):
+        af = _cvt_to_frac(a)
+        op = _cvt_to_frac(fp.ceil(a))
+        self.assertEqualOrNan(op, _ceil(af), f'Failed ceiling: {a} ({af})')
+
+    @given(number())
+    def test_floor(self, a):
+        af = _cvt_to_frac(a)
+        op = _cvt_to_frac(fp.floor(a))
+        self.assertEqualOrNan(op, _floor(af), f'Failed floor: {a} ({af})')
+
+    @given(number())
+    def test_trunc(self, a):
+        af = _cvt_to_frac(a)
+        op = _cvt_to_frac(fp.trunc(a))
+        self.assertEqualOrNan(op, _trunc(af), f'Failed truncation: {a} ({af})')

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -1,0 +1,103 @@
+"""
+Tests for `fpy2/ops.py`.
+"""
+
+import fpy2 as fp
+import math
+import unittest
+
+from fractions import Fraction
+from hypothesis import given, strategies as st
+
+from .generators import floats
+
+def _cvt_to_frac(x: int | float | Fraction | fp.RealFloat | fp.Float) -> float | Fraction:
+    match x:
+        case int():
+            return Fraction(x)
+        case float():
+            return x
+        case Fraction():
+            return x
+        case fp.Float():
+            if x.isnan:
+                return float('nan')
+            elif x.isinf:
+                return float('inf') if x.is_positive() else float('-inf')
+            else:
+                return x.as_rational()
+        case fp.RealFloat():
+            return x.as_rational()
+        case _:
+            raise TypeError(f'cannot convert {type(x)} to Fraction or float')
+
+@st.composite
+def number(
+    draw,
+    prec: int = 8,
+    exp_min: int = -10,
+    exp_max: int = 10
+):
+    """
+    Returns a strategy for generating either a
+    - `int`,
+    - `Fraction`,
+    - `Float`,
+    - or `RealFloat`.
+    """
+    choice = draw(st.integers(min_value=0, max_value=2))
+    if choice == 0:
+        return draw(st.integers())
+    elif choice == 2:
+        return draw(st.fractions())
+    else:
+        return draw(floats(prec=prec, exp_min=exp_min, exp_max=exp_max, allow_nan=True, allow_infinity=True))
+
+
+class TestOps(unittest.TestCase):
+
+    def assertEqualOrNan(self, a: Fraction | float, b: Fraction | float, msg: str = ''):
+        if isinstance(a, float) and isinstance(b, float) and math.isnan(a) and math.isnan(b):
+            return
+        self.assertEqual(a, b, msg)
+
+    @given(number())
+    def test_neg(self, a):
+        af = _cvt_to_frac(a)
+        op = _cvt_to_frac(fp.neg(a))
+        self.assertEqualOrNan(op, -af, f'Failed negation: {a} ({af})')
+
+    @given(number())
+    def test_abs(self, a):
+        af = _cvt_to_frac(a)
+        op = _cvt_to_frac(fp.fabs(a))
+        self.assertEqualOrNan(op, abs(af), f'Failed absolute value: {a} ({af})')
+
+    @given(number(), number())
+    def test_add(self, a, b):
+        af = _cvt_to_frac(a)
+        bf = _cvt_to_frac(b)
+        op = _cvt_to_frac(fp.add(a, b))
+        self.assertEqualOrNan(op, af + bf, f'Failed addition: {a} + {b} ({af} + {bf})')
+
+    @given(number(), number())
+    def test_sub(self, a, b):
+        af = _cvt_to_frac(a)
+        bf = _cvt_to_frac(b)
+        op = _cvt_to_frac(fp.sub(a, b))
+        self.assertEqualOrNan(op, af - bf, f'Failed subtraction: {a} - {b} ({af} - {bf})')
+
+    @given(number(), number())
+    def test_mul(self, a, b):
+        af = _cvt_to_frac(a)
+        bf = _cvt_to_frac(b)
+        op = _cvt_to_frac(fp.mul(a, b))
+        self.assertEqualOrNan(op, af * bf, f'Failed multiplication: {a} * {b} ({af} * {bf})')
+
+    @given(number(), number(), number())
+    def test_fma(self, a, b, c):
+        af = _cvt_to_frac(a)
+        bf = _cvt_to_frac(b)
+        cf = _cvt_to_frac(c)
+        op = _cvt_to_frac(fp.fma(a, b, c))
+        self.assertEqualOrNan(op, af * bf + cf, f'Failed FMA: {a} * {b} + {c} ({af} * {bf} + {cf})')


### PR DESCRIPTION
This PR enables support for arithmetic with fractions. The operations that support fractions are: `+`, `-`, `*`, `abs`, `fma`, `ceil`, `floor`, `trunc`, `nearbyint`. For example, the following programs will execute without error:
```python
import fpy2 as fp

@fp.fpy
def f():
    return fp.rational(1, 3) + fp.rational(1, 3)

print(f())
```
The result is:
```
Float('0.66666666666666663')
```