### PR TITLE
Support for 2-/3-argument `range`

### DIFF
--- a/fpy2/analysis/context_infer.py
+++ b/fpy2/analysis/context_infer.py
@@ -293,7 +293,7 @@ class ContextTypeInferInstance(Visitor):
                 # sum operator
                 # C, Γ |- sum e : real C
                 return RealTypeContext(ctx)
-            case Range():
+            case Range1():
                 # range operator
                 # C, Γ |- range e : list (real INTEGER)
                 return ListTypeContext(RealTypeContext(INTEGER))

--- a/fpy2/analysis/context_infer.py
+++ b/fpy2/analysis/context_infer.py
@@ -323,6 +323,10 @@ class ContextTypeInferInstance(Visitor):
                 # size operator
                 # C, Γ |- size e : real INTEGER
                 return RealTypeContext(INTEGER)
+            case Range2():
+                # range operator
+                # C, Γ |- range e1 e2 : list (real INTEGER)
+                return ListTypeContext(RealTypeContext(INTEGER))
             case _:
                 #   Γ |- real : T         Γ |- bool : T
                 # ----------------      ------------------
@@ -330,13 +334,19 @@ class ContextTypeInferInstance(Visitor):
                 return self._from_scalar(self._lookup_ty(e), ctx)
 
     def _visit_ternaryop(self, e: TernaryOp, ctx: ContextParam):
-        #   Γ |- real : T         Γ |- bool : T
-        # ----------------      ------------------
-        #  C, Γ |- e : real C    C, Γ |- e : bool
         self._visit_expr(e.first, ctx)
         self._visit_expr(e.second, ctx)
         self._visit_expr(e.third, ctx)
-        return self._from_scalar(self._lookup_ty(e), ctx)
+        match e:
+            case Range3():
+                # range operator
+                # C, Γ |- range e1 e2 e3 : list (real INTEGER)
+                return ListTypeContext(RealTypeContext(INTEGER))
+            case _:
+                #   Γ |- real : T         Γ |- bool : T
+                # ----------------      ------------------
+                #  C, Γ |- e : real C    C, Γ |- e : bool
+                return self._from_scalar(self._lookup_ty(e), ctx)
 
     def _visit_naryop(self, e: NaryOp, ctx: ContextParam):
         arg_tys = [self._visit_expr(arg, ctx) for arg in e.args]

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -296,7 +296,7 @@ class _TypeInferInstance(Visitor):
                     # length operator
                     self._unify(arg_ty, ListType(self._fresh_type_var()))
                     return RealType()
-                case Range():
+                case Range1():
                     # range operator
                     self._unify(arg_ty, RealType())
                     return ListType(RealType())

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -338,6 +338,11 @@ class _TypeInferInstance(Visitor):
                     self._unify(lhs_ty, ListType(self._fresh_type_var()))
                     self._unify(rhs_ty, RealType())
                     return RealType()
+                case Range2():
+                    # range2 operator
+                    self._unify(lhs_ty, RealType())
+                    self._unify(rhs_ty, RealType())
+                    return ListType(RealType())
                 case _:
                     raise ValueError(f'unknown binary operator: {cls}')
 
@@ -353,7 +358,15 @@ class _TypeInferInstance(Visitor):
             self._unify(fn_ty.arg_types[2], third)
             return fn_ty.return_type
         else:
-            raise ValueError(f'unknown ternary operator: {cls}')
+            match e:
+                case Range3():
+                    # range3 operator
+                    self._unify(first, RealType())
+                    self._unify(second, RealType())
+                    self._unify(third, RealType())
+                    return ListType(RealType())
+                case _:
+                    raise ValueError(f'unknown ternary operator: {cls}')
 
     def _visit_naryop(self, e: NaryOp, ctx: None) -> Type:
         match e:

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -168,7 +168,9 @@ __all__ = [
     # Tensor operators
     'Len',
     'Size',
-    'Range',
+    'Range1',
+    'Range2',
+    'Range3',
     'Empty',
     'Dim',
     'Zip',
@@ -1063,8 +1065,16 @@ class Size(NamedBinaryOp):
     """FPy node: size operator"""
     __slots__ = ()
 
-class Range(NamedUnaryOp):
-    """FPy node: range constructor"""
+class Range1(NamedUnaryOp):
+    """FPy node: range(stop)"""
+    __slots__ = ()
+
+class Range2(NamedBinaryOp):
+    """FPy node: range(start, stop)"""
+    __slots__ = ()
+
+class Range3(NamedTernaryOp):
+    """FPy node: range(start, stop, step)"""
     __slots__ = ()
 
 class Empty(NamedUnaryOp):

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -374,7 +374,7 @@ class _CppBackendInstance(Visitor):
         _, cpp_ty = self._expr_type(e)
         return f'static_cast<{cpp_ty.format()}>({arg_cpp}.size())'
 
-    def _visit_range(self, e: Range1, ctx: _CompileCtx):
+    def _visit_range1(self, e: Range1, ctx: _CompileCtx):
         # range(n)
         arg_cpp = self._visit_expr(e.arg, ctx)
         _, e_ty = self._expr_type(e)
@@ -385,6 +385,82 @@ class _CppBackendInstance(Visitor):
         ctx.add_line(f'std::vector<{e_ty.elt.format()}> {t}({s});')
         ctx.add_line(f'std::iota({t}.begin(), {t}.end(), static_cast<{e_ty.elt.format()}>(0));')
         return t
+
+    def _visit_range2(self, e: Range2, ctx: _CompileCtx):
+        # range(start, end) =>
+        # t1 = <start>;
+        # t2 = <end>;
+        # std::vector<T> t3(static_cast<size_t>(t2) - static_cast<size_t>(t1));
+        # std::iota(t3.begin(), t3.end(), static_cast<T>(t1));
+
+        _, start_ty = self._expr_type(e.first)
+        _, end_ty = self._expr_type(e.second)
+        _, e_ty = self._expr_type(e)
+        assert isinstance(e_ty, CppList) and isinstance(e_ty.elt, CppScalar)
+
+        start_cpp = self._visit_expr(e.first, ctx)
+        stop_cpp = self._visit_expr(e.second, ctx)
+
+        t1 = self._fresh_var()
+        t2 = self._fresh_var()
+        t3 = self._fresh_var()
+        ctx.add_line(f'auto {t1} = {start_cpp};')
+        ctx.add_line(f'auto {t2} = {stop_cpp};')
+        start_idx = self._compile_size(t1, start_ty)
+        stop_idx = self._compile_size(t2, end_ty)
+        ctx.add_line(f'std::vector<{e_ty.elt.format()}> {t3}({stop_idx} - {start_idx});')
+        ctx.add_line(f'std::iota({t3}.begin(), {t3}.end(), static_cast<{e_ty.elt.format()}>({t1}));')
+        return t3
+    
+    def _visit_range3(self, e: Range3, ctx: _CompileCtx):
+        # range(start, end, step) =>
+        # t1 = <start>;
+        # t2 = <end>;
+        # t3 = <step>;
+        # // compute size
+        # t4 = static_cast<size_t>(t2) - static_cast<size_t>(t1); // distance
+        # t5 = static_cast<size_t>(t3); // step size
+        # assert t5 > 0 && "step size must be positive";
+        # t6 = (t4 + t5 - 1) / t5; // ceiling division
+        # std::vector<T> t7(t6);
+        # for (size_t i = 0; i < t6; ++i) {
+        #     t7[i] = static_cast<T>(t1 + i * t3);
+        # }
+
+        _, start_ty = self._expr_type(e.first)
+        _, end_ty = self._expr_type(e.second)
+        _, step_ty = self._expr_type(e.third)
+        _, e_ty = self._expr_type(e)
+        assert isinstance(e_ty, CppList) and isinstance(e_ty.elt, CppScalar)
+
+        start_cpp = self._visit_expr(e.first, ctx)
+        stop_cpp = self._visit_expr(e.second, ctx)
+        step_cpp = self._visit_expr(e.third, ctx)
+
+        t1 = self._fresh_var()
+        t2 = self._fresh_var()
+        t3 = self._fresh_var()
+        t4 = self._fresh_var()
+        t5 = self._fresh_var()
+        t6 = self._fresh_var()
+        t7 = self._fresh_var()
+
+        ctx.add_line(f'auto {t1} = {start_cpp};')
+        ctx.add_line(f'auto {t2} = {stop_cpp};')
+        ctx.add_line(f'auto {t3} = {step_cpp};')
+        start_idx = self._compile_size(t1, start_ty)
+        stop_idx = self._compile_size(t2, end_ty)
+        step_idx = self._compile_size(t3, step_ty)
+        ctx.add_line(f'auto {t4} = {stop_idx} - {start_idx};') # distance
+        ctx.add_line(f'auto {t5} = {step_idx};') # step size
+        ctx.add_line(f'assert({t5} > 0 && "step size must be positive");')
+        ctx.add_line(f'auto {t6} = ({t4} + {t5} - 1) / {t5};') # ceiling division
+        ctx.add_line(f'std::vector<{e_ty.elt.format()}> {t7}({t6});')
+        ctx.add_line(f'for (size_t i = 0; i < {t6}; ++i) {{')
+        ctx.indent().add_line(f'{t7}[i] = static_cast<{e_ty.elt.format()}>({t1} + i * {t3});')
+        ctx.add_line('}')
+
+        return t7
 
     def _visit_size(self, arr: Expr, dim: Expr, ctx: _CompileCtx):
         # size(x, n)
@@ -519,7 +595,7 @@ class _CppBackendInstance(Visitor):
             case Len():
                 return self._visit_len(e, ctx)
             case Range1():
-                return self._visit_range(e, ctx)
+                return self._visit_range1(e, ctx)
             case Dim():
                 return self._visit_dim(e, ctx)
             case Enumerate():
@@ -552,6 +628,8 @@ class _CppBackendInstance(Visitor):
         match e:
             case Size():
                 return self._visit_size(e.first, e.second, ctx)
+            case Range2():
+                return self._visit_range2(e, ctx)
             case _:
                 raise CppCompileError(self.func, f'no matching operator for `{e.format()}`')
 
@@ -574,7 +652,11 @@ class _CppBackendInstance(Visitor):
             # TODO: list options vs. actual signature
             raise CppCompileError(self.func, f'no matching signature for `{e.format()}`')
         else:
-            raise CppCompileError(self.func, f'no matching operator for `{e.format()}`')
+            match e:
+                case Range3():
+                    return self._visit_range3(e, ctx)
+                case _:
+                    raise CppCompileError(self.func, f'no matching operator for `{e.format()}`')
 
     def _visit_naryop(self, e: NaryOp, ctx: _CompileCtx):
         # Handle n-ary operations

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -374,7 +374,7 @@ class _CppBackendInstance(Visitor):
         _, cpp_ty = self._expr_type(e)
         return f'static_cast<{cpp_ty.format()}>({arg_cpp}.size())'
 
-    def _visit_range(self, e: Range, ctx: _CompileCtx):
+    def _visit_range(self, e: Range1, ctx: _CompileCtx):
         # range(n)
         arg_cpp = self._visit_expr(e.arg, ctx)
         _, e_ty = self._expr_type(e)
@@ -518,7 +518,7 @@ class _CppBackendInstance(Visitor):
         match e:
             case Len():
                 return self._visit_len(e, ctx)
-            case Range():
+            case Range1():
                 return self._visit_range(e, ctx)
             case Dim():
                 return self._visit_dim(e, ctx)

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -423,7 +423,7 @@ class _FPCoreCompileInstance(Visitor):
                 case Len():
                     # len expression
                     return self._visit_len(e.arg, ctx)
-                case Range():
+                case Range1():
                     # range expression
                     return self._visit_range(e.arg, ctx)
                 case Empty():

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -87,7 +87,7 @@ def _get_unary_table():
             'isnan': IsNan,
             'isnormal': IsNormal,
             'signbit': Signbit,
-            'range': Range,
+            'range': Range1,
             'dim': Dim,
         }
     return _unary_table_cache
@@ -126,7 +126,7 @@ def _empty(ns: list[Expr]) -> Expr:
         return Empty(_func_symbol('empty'), ns[0], None)
     elif len(ns) > 1:
         elt = _empty(ns[1:])
-        return ListComp([UnderscoreId()], [Range(_func_symbol('range'), ns[0], None)], elt, None)
+        return ListComp([UnderscoreId()], [Range1(_func_symbol('range'), ns[0], None)], elt, None)
     else:
         raise ValueError(f'ns={ns} cannot be empty')
 
@@ -455,7 +455,7 @@ class _FPCore2FPy:
             t = iter_vars[0]
             n = range_vars[0]
             inner_stmts: list[Stmt] = []
-            e = Range(_func_symbol('range'), Var(n, None), None)
+            e = Range1(_func_symbol('range'), Var(n, None), None)
             stmt = ForStmt(t, e, StmtBlock(inner_stmts), None)
             stmts.append(stmt)
             return self._make_tensor_body(iter_vars[1:], range_vars[1:], inner_stmts)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -539,7 +539,7 @@ class Parser:
             if kwargs:
                 raise FPyParserError(loc, 'FPy does not support keyword arguments for `len`', e)
             return Size(func, args[0], Integer(0, None), loc)
-        elif fn == range:
+        elif fn is range:
             if kwargs:
                 raise FPyParserError(loc, 'FPy does not support keyword arguments for `range`', e)
             return self._parse_range(e, func)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -336,6 +336,7 @@ class Parser:
                 start = self._parse_expr(e.args[0])
                 stop = self._parse_expr(e.args[1])
                 step = self._parse_expr(e.args[2])
+                return Range3(func, start, stop, step, loc)
             case _:
                 raise FPyParserError(loc, 'FPy `range` expects 1, 2, or 3 arguments', e)
 

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -244,13 +244,40 @@ class _Interpreter(Visitor):
             raise TypeError(f'expected a list, got {arr}')
         return Float.from_int(len(arr), ctx=INTEGER, checked=False)
 
-    def _apply_range(self, arg: Expr, ctx: Context):
-        stop = self._visit_expr(arg, ctx)
-        if not isinstance(stop, RealValue):
-            raise TypeError(f'expected a real number argument, got {stop}')
-        if not self._is_integer(stop):
-            raise ValueError(f'expected an integer argument, got {stop}')
-        return [Float.from_int(i, ctx=INTEGER, checked=False) for i in range(int(stop))]
+    def _apply_range(self, start: Expr | None, stop: Expr, step: Expr | None, ctx: Context):
+        if start is not None:
+            start_val = self._visit_expr(start, ctx)
+            if not isinstance(start_val, RealValue):
+                raise TypeError(f'expected a real number argument, got {start_val}')
+            if not self._is_integer(start_val):
+                raise ValueError(f'expected an integer argument, got {start_val}')
+            start_idx = int(start_val)
+        else:
+            start_idx = 0
+
+        stop_val = self._visit_expr(stop, ctx)
+        if not isinstance(stop_val, RealValue):
+            raise TypeError(f'expected a real number argument, got {stop_val}')
+        if not self._is_integer(stop_val):
+            raise ValueError(f'expected an integer argument, got {stop_val}')
+        stop_idx = int(stop_val)
+
+        if step is not None:
+            step_val = self._visit_expr(step, ctx)
+            if not isinstance(step_val, RealValue):
+                raise TypeError(f'expected a real number argument, got {step_val}')
+            if not self._is_integer(step_val):
+                raise ValueError(f'expected an integer argument, got {step_val}')
+            step_idx = int(step_val)
+            if step_idx == 0:
+                raise ValueError('step argument cannot be zero')
+        else:
+            step_idx = 1
+
+        return [
+            Float.from_int(i, ctx=INTEGER, checked=False)
+            for i in range(start_idx, stop_idx, step_idx)
+        ]
 
     def _apply_empty(self, arg: Expr, ctx: Context):
         size = self._visit_expr(arg, ctx)
@@ -380,7 +407,7 @@ class _Interpreter(Visitor):
                 case Len():
                     return self._apply_len(e.arg, ctx)
                 case Range1():
-                    return self._apply_range(e.arg, ctx)
+                    return self._apply_range(None, e.arg, None, ctx)
                 case Empty():
                     return self._apply_empty(e.arg, ctx)
                 case Dim():
@@ -406,6 +433,8 @@ class _Interpreter(Visitor):
             match e:
                 case Size():
                     return self._apply_size(e.first, e.second, ctx)
+                case Range2():
+                    return self._apply_range(e.first, e.second, None, ctx)
                 case _:
                     raise RuntimeError('unknown operator', e)
 
@@ -423,7 +452,11 @@ class _Interpreter(Visitor):
                 raise TypeError(f'expected a real number argument, got {third}')
             return fn(first, second, third, ctx=ctx)
         else:
-            raise RuntimeError('unknown operator', e)
+            match e:
+                case Range3():
+                    return self._apply_range(e.first, e.second, e.third, ctx)
+                case _:
+                    raise RuntimeError('unknown operator', e)
 
     def _visit_naryop(self, e: NaryOp, ctx: Context):
         match e:

--- a/fpy2/interpret/default.py
+++ b/fpy2/interpret/default.py
@@ -379,7 +379,7 @@ class _Interpreter(Visitor):
                     return self._apply_not(e.arg, ctx)
                 case Len():
                     return self._apply_len(e.arg, ctx)
-                case Range():
+                case Range1():
                     return self._apply_range(e.arg, ctx)
                 case Empty():
                     return self._apply_empty(e.arg, ctx)

--- a/tests/infra/unit/unit_tests.py
+++ b/tests/infra/unit/unit_tests.py
@@ -251,6 +251,18 @@ def test_list_size3():
     return size(x, 1)
 
 @fpy
+def test_range1():
+    return range(5)
+
+@fpy
+def test_range2():
+    return range(1, 5)
+
+@fpy
+def test_range3():
+    return range(1, 5, 2)
+
+@fpy
 def test_list_size4():
     x = [False, True]
     return size(x, 0)
@@ -852,6 +864,9 @@ tests: list[Function] = [
     test_list_size2,
     test_list_size3,
     test_list_size4,
+    test_range1,
+    test_range2,
+    test_range3,
     test_enumerate1,
     test_enumerate2,
     test_enumerate3,


### PR DESCRIPTION
This PR adds support for `range(start, stop)` and `range(start, stop, step)`.