### PR TITLE
Switch from `unittest` to `pytest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ infratest:
 
 unittest:
 	@echo "Running unit tests..."
-	python3 -m unittest -v -k $(UNITTEST_PATTERN)
+	python3 -m pytest -v tests/unit -k $(UNITTEST_PATTERN)
 
 clean: clean-docs
 	@echo "Cleaning build artifacts..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "pytest",
   "hypothesis==6.135",
   "mypy",
   "ruff",

--- a/tests/unit/backend/mpfx/test_double_round.py
+++ b/tests/unit/backend/mpfx/test_double_round.py
@@ -114,6 +114,7 @@ class TestDoubleRound():
     def test_rto_rto(self, p1, exp1, k1, dp, dexp, dk, x: fp.RealFloat):
         """ctx1[RTO](ctx2[RTO](x)) == ctx1[RTO](x)"""
         ctx1, ctx2 = _make_contexts(p1, exp1, k1, dp, dexp, dk, fp.RM.RTO, fp.RM.RTO)
+        assume(ctx1.pos_maxval < ctx2.pos_maxval)
         A1 = AbstractFormat.from_context(ctx1)
         A2 = AbstractFormat.from_context(ctx2)
         y1 = ctx1.round(x)

--- a/tests/unit/backend/mpfx/test_double_round.py
+++ b/tests/unit/backend/mpfx/test_double_round.py
@@ -3,7 +3,6 @@ Double rounding tests for `A(p, exp, bound)`.
 """
 
 import fpy2 as fp
-import unittest
 
 from hypothesis import assume, given, strategies as st
 
@@ -60,7 +59,7 @@ def _make_contexts(p1, exp1, k1, dp, dexp, dk, rm1, rm2, ensure_odd=False):
 
     return ctx1, ctx2
 
-class TestDoubleRound(unittest.TestCase):
+class TestDoubleRound():
     """Testing double rounding with overflow."""
 
     @given(
@@ -80,8 +79,8 @@ class TestDoubleRound(unittest.TestCase):
         y1 = ctx1.round(x)
         y2 = ctx2.round(x)
         y3 = ctx1.round(y2)
-        self.assertLessEqual(A1, A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}")
-        self.assertEqual(y1, y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}")
+        assert A1 <= A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}"
+        assert y1 == y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}"
 
     @given(
         st.one_of(st.integers(1, 5), st.just(float('inf'))),  # p1: precision (inf = fixed-point)
@@ -100,8 +99,8 @@ class TestDoubleRound(unittest.TestCase):
         y1 = ctx1.round(x)
         y2 = ctx2.round(x)
         y3 = ctx1.round(y2)
-        self.assertLessEqual(A1, A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}")
-        self.assertEqual(y1, y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}")
+        assert A1 <= A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}"
+        assert y1 == y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}"
 
     @given(
         st.one_of(st.integers(1, 5), st.just(float('inf'))),  # p1: precision (inf = fixed-point)
@@ -120,8 +119,8 @@ class TestDoubleRound(unittest.TestCase):
         y1 = ctx1.round(x)
         y2 = ctx2.round(x)
         y3 = ctx1.round(y2)
-        self.assertLessEqual(A1, A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}")
-        self.assertEqual(y1, y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}")
+        assert A1 <= A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}"
+        assert y1 == y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}"
 
     # TODO: restore this test with proper preconditions
     # the problem is that RTO overflows to infinity while RTZ does not
@@ -163,8 +162,8 @@ class TestDoubleRound(unittest.TestCase):
         y1 = ctx1.round(x)
         y2 = ctx2.round(x)
         y3 = ctx1.round(y2)
-        self.assertLessEqual(A1, A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}")
-        self.assertEqual(y1, y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}")
+        assert A1 <= A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}"
+        assert y1 == y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}"
 
     @given(
         st.one_of(st.integers(2, 5)),                         # p1: precision (inf = fixed-point)
@@ -184,5 +183,5 @@ class TestDoubleRound(unittest.TestCase):
         y1 = ctx1.round(x)
         y2 = ctx2.round(x)
         y3 = ctx1.round(y2)
-        self.assertLessEqual(A1, A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}")
-        self.assertEqual(y1, y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}")
+        assert A1 <= A2, f"Failed: A1={A1}, A2={A2}, x={float(x)}"
+        assert y1 == y3, f"Failed: y1={float(y1)}, y2={float(y2)}, y3={float(y3)}, x={float(x)}"

--- a/tests/unit/backend/mpfx/test_elim_round.py
+++ b/tests/unit/backend/mpfx/test_elim_round.py
@@ -1,6 +1,5 @@
 import fpy2 as fp
 import itertools
-import unittest
 
 
 from fpy2.backend.mpfx import ElimRound
@@ -41,7 +40,7 @@ def _example_mul_1_expect(x: fp.Real, y: fp.Real) -> fp.Real:
         return fp.cast(t)
 
 
-class TestElimRound(unittest.TestCase):
+class TestElimRound():
 
     def test_elim_round(self):
         ast = _example_round_1.ast
@@ -54,7 +53,7 @@ class TestElimRound(unittest.TestCase):
         opt = ElimRound.apply(ast)
         opt.name = expect_ast.name
 
-        self.assertTrue(opt.is_equiv(expect_ast), f'expect:\n{expect_ast.format()}\nactual:\n{opt.format()}')
+        assert opt.is_equiv(expect_ast), f'expect:\n{expect_ast.format()}\nactual:\n{opt.format()}'
 
     def test_elim_add(self):
         ast = _example_add_1.ast
@@ -67,7 +66,7 @@ class TestElimRound(unittest.TestCase):
         opt = ElimRound.apply(ast)
         opt.name = expect_ast.name
 
-        self.assertTrue(opt.is_equiv(expect_ast), f'expect:\n{expect_ast.format()}\nactual:\n{opt.format()}')
+        assert opt.is_equiv(expect_ast), f'expect:\n{expect_ast.format()}\nactual:\n{opt.format()}'
 
     def test_elim_mul(self):
         ast = _example_mul_1.ast
@@ -80,4 +79,4 @@ class TestElimRound(unittest.TestCase):
         opt = ElimRound.apply(ast)
         opt.name = expect_ast.name
 
-        self.assertTrue(opt.is_equiv(expect_ast), f'expect:\n{expect_ast.format()}\nactual:\n{opt.format()}')
+        assert opt.is_equiv(expect_ast), f'expect:\n{expect_ast.format()}\nactual:\n{opt.format()}'

--- a/tests/unit/backend/mpfx/test_format.py
+++ b/tests/unit/backend/mpfx/test_format.py
@@ -173,7 +173,7 @@ class TestAbstractFormat():
         vals2 = set(generate(p2, q2, b2.as_rational()))
         all_contained = all(v in vals2 for v in generate(p1, q1, b1.as_rational()))
 
-        assert fmt1 <= fmt2 == all_contained, f"format containment mismatch: {fmt1} <= {fmt2} should be {all_contained}"
+        assert (fmt1 <= fmt2) == all_contained, f"format containment mismatch: {fmt1} <= {fmt2} should be {all_contained}"
 
 
     def test_effective_prec(self):

--- a/tests/unit/backend/mpfx/test_format.py
+++ b/tests/unit/backend/mpfx/test_format.py
@@ -5,7 +5,6 @@ Test for the abstract number format `A(p, exp, bound)`.
 import fpy2 as fp
 import itertools
 import math
-import unittest
 
 from hypothesis import given, settings, strategies as st
 from fractions import Fraction
@@ -37,50 +36,50 @@ def generate(p: int | float, q: Fraction, b: Fraction) -> Generator[Fraction, No
             q = 2 * q
 
 
-class TestAbstractFormat(unittest.TestCase):
+class TestAbstractFormat():
 
     def test_construct(self):
         """Testing construction of AbstractFormat."""
         # MPFloatContext(24)
         fmt = AbstractFormat.from_context(fp.MPFloatContext(24))
-        self.assertEqual(fmt.prec, 24)
-        self.assertEqual(fmt.exp, float('-inf'))
-        self.assertEqual(fmt.bound, float('inf'))
+        assert fmt.prec == 24
+        assert fmt.exp == float('-inf')
+        assert fmt.bound == float('inf')
         # MPSFloatContext(24, -10)
         fmt = AbstractFormat.from_context(fp.MPSFloatContext(24, -10))
-        self.assertEqual(fmt.prec, 24)
-        self.assertEqual(fmt.exp, -33)
-        self.assertEqual(fmt.bound, float('inf'))
+        assert fmt.prec == 24
+        assert fmt.exp == -33
+        assert fmt.bound == float('inf')
         # MPBFloatContext(24, -10, 1.0)
         fmt = AbstractFormat.from_context(fp.MPBFloatContext(24, -10, fp.RealFloat.from_int(1)))
-        self.assertEqual(fmt.prec, 24)
-        self.assertEqual(fmt.exp, -33)
-        self.assertEqual(fmt.bound, fp.RealFloat.from_int(1))
+        assert fmt.prec == 24
+        assert fmt.exp == -33
+        assert fmt.bound == fp.RealFloat.from_int(1)
         # FP64
         fmt = AbstractFormat.from_context(fp.FP64)
-        self.assertEqual(fmt.prec, 53)
-        self.assertEqual(fmt.exp, -1074)
-        self.assertEqual(fmt.bound, fp.RealFloat(exp=971, c=(1 << 53) - 1))
+        assert fmt.prec == 53
+        assert fmt.exp == -1074
+        assert fmt.bound == fp.RealFloat(exp=971, c=(1 << 53) - 1)
         # FP32
         fmt = AbstractFormat.from_context(fp.FP32)
-        self.assertEqual(fmt.prec, 24)
-        self.assertEqual(fmt.exp, -149)
-        self.assertEqual(fmt.bound, fp.RealFloat(exp=104, c=(1 << 24) - 1))
+        assert fmt.prec == 24
+        assert fmt.exp == -149
+        assert fmt.bound == fp.RealFloat(exp=104, c=(1 << 24) - 1)
         # MPFixedContext(-8)
         fmt = AbstractFormat.from_context(fp.MPFixedContext(-8))
-        self.assertEqual(fmt.prec, float('inf'))
-        self.assertEqual(fmt.exp, -7)
-        self.assertEqual(fmt.bound, float('inf'))
+        assert fmt.prec == float('inf')
+        assert fmt.exp == -7
+        assert fmt.bound == float('inf')
         # MPBFixedContext(-8, 1.0)
         fmt = AbstractFormat.from_context(fp.MPBFixedContext(-8, fp.RealFloat.from_int(1)))
-        self.assertEqual(fmt.prec, float('inf'))
-        self.assertEqual(fmt.exp, -7)
-        self.assertEqual(fmt.bound, fp.RealFloat.from_int(1))
+        assert fmt.prec == float('inf')
+        assert fmt.exp == -7
+        assert fmt.bound == fp.RealFloat.from_int(1)
         # INT8
         fmt = AbstractFormat.from_context(fp.SINT8)
-        self.assertEqual(fmt.prec, float('inf'))
-        self.assertEqual(fmt.exp, 0)
-        self.assertEqual(fmt.bound, fp.RealFloat.from_int(128))
+        assert fmt.prec == float('inf')
+        assert fmt.exp == 0
+        assert fmt.bound == fp.RealFloat.from_int(128)
 
     def test_contains_sandbox(self):
         A1 = AbstractFormat(5, -3, fp.RealFloat.from_int(1))
@@ -98,47 +97,47 @@ class TestAbstractFormat(unittest.TestCase):
         # FP32 \subseteq FP64
         CTX1 = AbstractFormat.from_context(fp.FP32)
         CTX2 = AbstractFormat.from_context(fp.FP64)
-        self.assertTrue(CTX1 <= CTX2, "Expected FP32 to be contained in FP64.")
+        assert CTX1 <= CTX2, "Expected FP32 to be contained in FP64."
 
         # MX_E5M2 \subseteq FP32
         CTX1 = AbstractFormat.from_context(fp.MX_E5M2)
         CTX2 = AbstractFormat.from_context(fp.FP32)
-        self.assertTrue(CTX1 <= CTX2, "Expected MX_E5M2 to be contained in FP32.")
+        assert CTX1 <= CTX2, "Expected MX_E5M2 to be contained in FP32."
 
         # FP64 ⊄ FP32
         CTX1 = AbstractFormat.from_context(fp.FP64)
         CTX2 = AbstractFormat.from_context(fp.FP32)
-        self.assertFalse(CTX1 <= CTX2, "Expected FP64 to not be contained in FP32.")
+        assert not CTX1 <= CTX2, "Expected FP64 to not be contained in FP32."
 
         # MX_E4M3 ⊄ MX_E5M2
         CTX1 = AbstractFormat.from_context(fp.MX_E4M3)
         CTX2 = AbstractFormat.from_context(fp.MX_E5M2)
-        self.assertFalse(CTX1 <= CTX2, "Expected MX_E4M3 to not be contained in MX_E5M2.")
+        assert not CTX1 <= CTX2, "Expected MX_E4M3 to not be contained in MX_E5M2."
 
         # MX_E4M3 \subseteq fixed<-9, 32>
         CTX1 = AbstractFormat.from_context(fp.MX_E4M3)
         CTX2 = AbstractFormat.from_context(fp.FixedContext(True, -9, 32))
-        self.assertTrue(CTX1 <= CTX2, "Expected MX_E4M3 to be contained in fixed<-9, 32>.")
+        assert CTX1 <= CTX2, "Expected MX_E4M3 to be contained in fixed<-9, 32>."
 
         # MX_E5M2 ⊄ fixed<-9, 32>
         CTX1 = AbstractFormat.from_context(fp.MX_E5M2)
         CTX2 = AbstractFormat.from_context(fp.FixedContext(True, -9, 32))
-        self.assertFalse(CTX1 <= CTX2, "Expected MX_E5M2 to not be contained in fixed<-9, 32>.")
+        assert not CTX1 <= CTX2, "Expected MX_E5M2 to not be contained in fixed<-9, 32>."
 
         # INT8 \subseteq FP32
         CTX1 = AbstractFormat.from_context(fp.SINT8)
         CTX2 = AbstractFormat.from_context(fp.FP32)
-        self.assertTrue(CTX1 <= CTX2, "Expected INT8 to be contained in FP32.")
+        assert CTX1 <= CTX2, "Expected INT8 to be contained in FP32."
 
         # INT4 \subseteq A(3, 0, 4)
         CTX1 = AbstractFormat.from_context(fp.FixedContext(True, 0, 4))
         CTX2 = AbstractFormat(3, 0, fp.RealFloat.from_int(8))
-        self.assertTrue(CTX1 <= CTX2, "Expected INT4 to be contained in A(3, 0, 4).")
+        assert CTX1 <= CTX2, "Expected INT4 to be contained in A(3, 0, 4)."
 
         # INT4 \subseteq A(4, 0, 12)
         CTX1 = AbstractFormat.from_context(fp.FixedContext(True, 0, 4))
         CTX2 = AbstractFormat(4, 0, fp.RealFloat.from_int(12))
-        self.assertTrue(CTX1 <= CTX2, "Expected INT4 to be contained in A(4, 0, 12).")
+        assert CTX1 <= CTX2, "Expected INT4 to be contained in A(4, 0, 12)."
 
 
     @given(
@@ -174,10 +173,7 @@ class TestAbstractFormat(unittest.TestCase):
         vals2 = set(generate(p2, q2, b2.as_rational()))
         all_contained = all(v in vals2 for v in generate(p1, q1, b1.as_rational()))
 
-        self.assertEqual(
-            fmt1 <= fmt2, all_contained,
-            f"format containment mismatch: {fmt1} <= {fmt2} should be {all_contained}",
-        )
+        assert fmt1 <= fmt2 == all_contained, f"format containment mismatch: {fmt1} <= {fmt2} should be {all_contained}"
 
 
     def test_effective_prec(self):
@@ -190,7 +186,7 @@ class TestAbstractFormat(unittest.TestCase):
             if p == float('inf') and e == float('-inf'):
                 continue  # skip invalid format
             fmt = AbstractFormat(p, e, b)
-            self.assertLessEqual(fmt.effective_prec(), p)
+            assert fmt.effective_prec() <= p
 
     def test_pos(self):
         """Testing positive bound calculation."""
@@ -205,10 +201,10 @@ class TestAbstractFormat(unittest.TestCase):
             fmt = +fmt1
 
             # should be an exact copy
-            self.assertEqual(fmt.prec, p)
-            self.assertEqual(fmt.exp, e)
-            self.assertEqual(fmt.pos_bound, b)
-            self.assertEqual(fmt.neg_bound, -b)
+            assert fmt.prec == p
+            assert fmt.exp == e
+            assert fmt.pos_bound == b
+            assert fmt.neg_bound == -b
 
     def test_neg(self):
         """Testing negative bound calculation."""
@@ -223,10 +219,10 @@ class TestAbstractFormat(unittest.TestCase):
             fmt = -fmt1
 
             # should be an exact copy
-            self.assertEqual(fmt.prec, p)
-            self.assertEqual(fmt.exp, e)
-            self.assertEqual(fmt.pos_bound, b)
-            self.assertEqual(fmt.neg_bound, -b)
+            assert fmt.prec == p
+            assert fmt.exp == e
+            assert fmt.pos_bound == b
+            assert fmt.neg_bound == -b
 
     def test_abs(self):
         """Testing absolute bound calculation."""
@@ -241,10 +237,10 @@ class TestAbstractFormat(unittest.TestCase):
             fmt = abs(fmt1)
 
             # should be an exact copy
-            self.assertEqual(fmt.prec, p)
-            self.assertEqual(fmt.exp, e)
-            self.assertEqual(fmt.pos_bound, b)
-            self.assertEqual(fmt.neg_bound, 0)
+            assert fmt.prec == p
+            assert fmt.exp == e
+            assert fmt.pos_bound == b
+            assert fmt.neg_bound == 0
 
 
     def test_add(self, logging: bool = False):
@@ -271,8 +267,8 @@ class TestAbstractFormat(unittest.TestCase):
                     fmt_str = f"A({fmt.prec}, {fmt.exp}, {float(fmt.pos_bound)})"
                     print(f"{fmt1_str} + {fmt2_str} = {fmt_str}")
 
-                self.assertEqual(fmt.exp, min(e1, e2))
-                self.assertEqual(fmt.pos_bound, b1 + b2)
+                assert fmt.exp == min(e1, e2)
+                assert fmt.pos_bound == b1 + b2
 
 
     def test_mul(self):
@@ -296,6 +292,6 @@ class TestAbstractFormat(unittest.TestCase):
                 fmt2 = AbstractFormat(p2, e2, b2)
                 fmt = fmt1 * fmt2
 
-                self.assertEqual(fmt.effective_prec(), fmt1.effective_prec() + fmt2.effective_prec())
-                self.assertEqual(fmt.exp, e1 + e2)
-                self.assertEqual(fmt.pos_bound, b1 * b2)
+                assert fmt.effective_prec() == fmt1.effective_prec() + fmt2.effective_prec()
+                assert fmt.exp == e1 + e2
+                assert fmt.pos_bound == b1 * b2

--- a/tests/unit/libraries/test_core.py
+++ b/tests/unit/libraries/test_core.py
@@ -1,17 +1,17 @@
-import unittest
+import pytest
 
 from fpy2 import *
 from fpy2.libraries.core import split, logb, modf, ldexp, isinteger
 
-class TestCore(unittest.TestCase):
+class TestCore():
     """Testing core functionality"""
 
     def assertNumEqual(self, a: Float, b: Float):
         """Assert that two numbers are equal, handling NaN and Inf"""
         if a.isnan or b.isnan:
-            self.assertEqual(a.isnan, b.isnan)
+            assert a.isnan == b.isnan
         else:
-            self.assertEqual(a, b, f"Expected {a} to be equal to {b}")
+            assert a == b, f"Expected {a} to be equal to {b}"
 
     def assertArrayEqual(self, a: list, b: list):
         """Assert that two arrays are equal, handling NaN and Inf"""
@@ -58,7 +58,7 @@ class TestCore(unittest.TestCase):
         self.assertNumEqual(ldexp(Float.from_int(1), Float.from_int(1)), Float.from_int(2))
         self.assertNumEqual(ldexp(Float.from_int(1), Float.from_int(-1)), Float.from_float(0.5))
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             ldexp(Float.from_int(1), Float.from_float(0.5))
 
         self.assertNumEqual(ldexp(Float(isnan=True), Float.from_int(0)), Float(isnan=True))
@@ -67,9 +67,9 @@ class TestCore(unittest.TestCase):
 
     def test_isinteger(self):
         """Testing `isinteger` function"""
-        self.assertTrue(isinteger(Float.from_int(0)))
-        self.assertTrue(isinteger(Float.from_int(1)))
-        self.assertFalse(isinteger(Float.from_float(1.5)))
-        self.assertFalse(isinteger(Float(isnan=True)))
-        self.assertFalse(isinteger(Float(isinf=True)))
-        self.assertFalse(isinteger(Float(s=True, isinf=True)))
+        assert isinteger(Float.from_int(0))
+        assert isinteger(Float.from_int(1))
+        assert not isinteger(Float.from_float(1.5))
+        assert not isinteger(Float(isnan=True))
+        assert not isinteger(Float(isinf=True))
+        assert not isinteger(Float(s=True, isinf=True))

--- a/tests/unit/libraries/test_metrics.py
+++ b/tests/unit/libraries/test_metrics.py
@@ -1,5 +1,4 @@
 import fpy2 as fp
-import unittest
 
 from fractions import Fraction
 from hypothesis import given, strategies as st
@@ -12,7 +11,7 @@ _EXP_MIN=-100
 _EXP_MAX=100
 
 
-class TestMetrics(unittest.TestCase):
+class TestMetrics():
     """Testing `fpy2.libraries.metrics` functionality."""
 
     @given(
@@ -22,8 +21,8 @@ class TestMetrics(unittest.TestCase):
     def test_absolute_error(self, a: fp.Float, b: fp.Float):
         """Testing `absolute_error` function"""
         err = fp.libraries.metrics.absolute_error(a, b)
-        self.assertIsInstance(err, fp.Float)
-        self.assertTrue(err.isnan or err >= 0)
+        assert isinstance(err, fp.Float)
+        assert err.isnan or err >= 0
 
     @given(
         floats(prec_max=_PREC_MAX, exp_min=_EXP_MIN, exp_max=_EXP_MAX),
@@ -33,8 +32,8 @@ class TestMetrics(unittest.TestCase):
     def test_scaled_error(self, a: fp.Float, b: fp.Float, scale: fp.Float):
         """Testing `scaled_error` function"""
         err = fp.libraries.metrics.scaled_error(a, b, scale)
-        self.assertIsInstance(err, fp.Float)
-        self.assertTrue(err.isnan or err >= 0)
+        assert isinstance(err, fp.Float)
+        assert err.isnan or err >= 0
 
     @given(
         floats(prec_max=_PREC_MAX, exp_min=_EXP_MIN, exp_max=_EXP_MAX),
@@ -43,8 +42,8 @@ class TestMetrics(unittest.TestCase):
     def test_relative_error(self, a: fp.Float, b: fp.Float):
         """Testing `relative_error` function"""
         err = fp.libraries.metrics.relative_error(a, b)
-        self.assertIsInstance(err, fp.Float)
-        self.assertTrue(err.isnan or err >= 0)
+        assert isinstance(err, fp.Float)
+        assert err.isnan or err >= 0
 
     @given(
         floats(prec_max=_PREC_MAX, exp_min=_EXP_MIN, exp_max=_EXP_MAX, allow_nan=False, allow_infinity=False),
@@ -53,5 +52,5 @@ class TestMetrics(unittest.TestCase):
     def test_ordinal_error(self, a: fp.Float, b: fp.Float):
         """Testing `ordinal_error` function"""
         err = fp.libraries.metrics.ordinal_error(a, b)
-        self.assertIsInstance(err, fp.Float)
-        self.assertTrue(err >= 0)
+        assert isinstance(err, fp.Float)
+        assert err >= 0

--- a/tests/unit/math/test_mpfr.py
+++ b/tests/unit/math/test_mpfr.py
@@ -1,6 +1,5 @@
 import gmpy2 as gmp
 import random
-import unittest
 
 from dataclasses import dataclass
 from typing import Callable
@@ -168,7 +167,7 @@ def _mpfr_apply(
         return mpfr_to_float(y), flags
 
 
-class MPFREquivTestCase(unittest.TestCase):
+class MPFREquivTestCase():
     """
     Fuzz testing under `fpy2.math`.
 
@@ -194,12 +193,12 @@ class MPFREquivTestCase(unittest.TestCase):
                         assert isinstance(fl, Float)
                         # check that they are the numerical values are the same
                         if fl.isnan:
-                            self.assertTrue(fl.isnan, f'op={op}, rm={rm}, x={x}, fl={fl}, ref={ref}')
+                            assert fl.isnan, f'op={op}, rm={rm}, x={x}, fl={fl}, ref={ref}'
                         else:
-                            self.assertEqual(fl, ref, f'op={op}, rm={rm}, x={x}, fl={fl}, ref={ref}')
+                            assert fl == ref, f'op={op}, rm={rm}, x={x}, fl={fl}, ref={ref}'
                         # check that the flags are the same
-                        self.assertEqual(fl.overflow, flags.overflow, f'op={op}, rm={rm}, x={x}, fl={fl}, ref={ref}, flags={flags}')
-                        self.assertEqual(fl.inexact, flags.inexact, f'op={op}, rm={rm}, x={x}, fl={fl}, ref={ref}, flags={flags}')
+                        assert fl.overflow == flags.overflow, f'op={op}, rm={rm}, x={x}, fl={fl}, ref={ref}, flags={flags}'
+                        assert fl.inexact == flags.inexact, f'op={op}, rm={rm}, x={x}, fl={fl}, ref={ref}, flags={flags}'
 
     def test_fuzz_binary(self, num_inputs: int = 256):
         for op, mpfr in _binary_ops.items():
@@ -222,12 +221,12 @@ class MPFREquivTestCase(unittest.TestCase):
                         assert isinstance(fl, Float)
                         # check that they are the same
                         if fl.isnan:
-                            self.assertTrue(fl.isnan, f'op={op}, rm={rm}, x={x}, y={y}, fl={fl}, ref={ref}')
+                            assert fl.isnan, f'op={op}, rm={rm}, x={x}, y={y}, fl={fl}, ref={ref}'
                         else:
-                            self.assertEqual(fl, ref, f'op={op}, rm={rm}, x={x}, y={y}, fl={fl}, ref={ref}')
+                            assert fl == ref, f'op={op}, rm={rm}, x={x}, y={y}, fl={fl}, ref={ref}'
                         # check that the flags are the same
-                        self.assertEqual(fl.overflow, flags.overflow, f'op={op}, rm={rm}, x={x}, y={y}, fl={fl}, ref={ref}, flags={flags}')
-                        self.assertEqual(fl.inexact, flags.inexact, f'op={op}, rm={rm}, x={x}, y={y}, fl={fl}, ref={ref}, flags={flags}')
+                        assert fl.overflow == flags.overflow, f'op={op}, rm={rm}, x={x}, y={y}, fl={fl}, ref={ref}, flags={flags}'
+                        assert fl.inexact == flags.inexact, f'op={op}, rm={rm}, x={x}, y={y}, fl={fl}, ref={ref}, flags={flags}'
 
     def test_fuzz_ternary(self, num_inputs: int = 256):
         for op, mpfr in _ternary_ops.items():
@@ -252,9 +251,9 @@ class MPFREquivTestCase(unittest.TestCase):
                         assert isinstance(fl, Float)
                         # check that they are the same
                         if fl.isnan:
-                            self.assertTrue(fl.isnan, f'op={op}, rm={rm}, x={x}, y={y}, z={z}, fl={fl}, ref={ref}')
+                            assert fl.isnan, f'op={op}, rm={rm}, x={x}, y={y}, z={z}, fl={fl}, ref={ref}'
                         else:
-                            self.assertEqual(fl, ref, f'op={op}, rm={rm}, x={x}, y={y}, z={z}, fl={fl}, ref={ref}')
+                            assert fl == ref, f'op={op}, rm={rm}, x={x}, y={y}, z={z}, fl={fl}, ref={ref}'
                         # check that the flags are the same
-                        self.assertEqual(fl.overflow, flags.overflow, f'op={op}, rm={rm}, x={x}, y={y}, z={z}, fl={fl}, ref={ref}, flags={flags}')
-                        self.assertEqual(fl.inexact, flags.inexact, f'op={op}, rm={rm}, x={x}, y={y}, z={z}, fl={fl}, ref={ref}, flags={flags}')
+                        assert fl.overflow == flags.overflow, f'op={op}, rm={rm}, x={x}, y={y}, z={z}, fl={fl}, ref={ref}, flags={flags}'
+                        assert fl.inexact == flags.inexact, f'op={op}, rm={rm}, x={x}, y={y}, z={z}, fl={fl}, ref={ref}, flags={flags}'

--- a/tests/unit/math/test_ops.py
+++ b/tests/unit/math/test_ops.py
@@ -1,5 +1,4 @@
 import random
-import unittest
 
 from fpy2 import IEEEContext, MPFixedContext, FixedContext, Float, RM, OV, FP64, FP32, FP16
 from fpy2.ops import *
@@ -75,7 +74,7 @@ _ctxs = [
     IEEEContext(5, 8, RM.RNE)
 ]
 
-class MathIEEENoExceptTestCase(unittest.TestCase):
+class MathIEEENoExceptTestCase():
     """
     Fuzz testing for each operation under `fpy2.math`.
 
@@ -126,7 +125,7 @@ class MathIEEENoExceptTestCase(unittest.TestCase):
                         # evaluate
                         op(x, y, z, ctx=ctx)
 
-class MathIntegerNoExceptTestCase(unittest.TestCase):
+class MathIntegerNoExceptTestCase():
     """
     Fuzz testing for integer operations under `fpy2.math`.
 
@@ -189,7 +188,7 @@ class MathIntegerNoExceptTestCase(unittest.TestCase):
                     # evaluate
                     op(x, y, z, ctx=ctx)
 
-class MathInt64NoExceptTestCase(unittest.TestCase):
+class MathInt64NoExceptTestCase():
     """
     Fuzz testing for integer operations under `fpy2.math`.
 

--- a/tests/unit/number/efloat/test_encode.py
+++ b/tests/unit/number/efloat/test_encode.py
@@ -1,4 +1,3 @@
-import unittest
 
 from fpy2 import (
     EFloatContext,
@@ -14,7 +13,7 @@ _common: list[EFloatContext] = [
     FP8P1, FP8P2, FP8P3, FP8P4, FP8P5, FP8P6, FP8P7
 ]
 
-class DecodeTestCase(unittest.TestCase):
+class DecodeTestCase():
     """Testing `ExtFloatContext.decode()`"""
 
     def test_common(self):
@@ -23,10 +22,10 @@ class DecodeTestCase(unittest.TestCase):
             # for ctx, decode all possible encodings
             for i in range(1 << ctx.nbits):
                 x = ctx.decode(i)
-                self.assertIsInstance(x, Float, f'i={i}, x={x}')
-                self.assertTrue(x.is_representable(), f'i={i}, x={x}')
+                assert isinstance(x, Float), f'i={i}, x={x}'
+                assert x.is_representable(), f'i={i}, x={x}'
 
-class EncodeTestCase(unittest.TestCase):
+class EncodeTestCase():
     """Testing `ExtFloatContext.encode()`"""
 
     def test_common(self):
@@ -45,12 +44,12 @@ class EncodeTestCase(unittest.TestCase):
             # run encoding
             for x in xs:
                 i = ctx.encode(x)
-                self.assertIsInstance(i, int, f'x={x}, i={i}')
-                self.assertGreaterEqual(i, 0, f'x={x}, i={i}')
-                self.assertLess(i, 1 << ctx.nbits, f'x={x}, i={i}')
+                assert isinstance(i, int), f'x={x}, i={i}'
+                assert i >= 0, f'x={x}, i={i}'
+                assert i < 1 << ctx.nbits, f'x={x}, i={i}'
 
 
-class EncodeRoundTripTestCase(unittest.TestCase):
+class EncodeRoundTripTestCase():
     """Testing `ExtFloatContext.encode()` and `ExtFloatContext.decode()`"""
 
     def test_common(self):
@@ -62,6 +61,6 @@ class EncodeRoundTripTestCase(unittest.TestCase):
                 j = ctx.encode(x)
                 if x.isnan:
                     y = ctx.decode(j)
-                    self.assertTrue(y.isnan, f'i={i}, j={j}, y={y}')
+                    assert y.isnan, f'i={i}, j={j}, y={y}'
                 else:
-                    self.assertEqual(i, j, f'i={i}, j={j}')
+                    assert i == j, f'i={i}, j={j}'

--- a/tests/unit/number/efloat/test_ordinal.py
+++ b/tests/unit/number/efloat/test_ordinal.py
@@ -1,4 +1,3 @@
-import unittest
 
 from fpy2 import (
     EFloatContext,
@@ -14,7 +13,7 @@ _common: list[EFloatContext] = [
     FP8P1, FP8P2, FP8P3, FP8P4, FP8P5, FP8P6, FP8P7
 ]
 
-class ToOrdinalTestCase(unittest.TestCase):
+class ToOrdinalTestCase():
     """Testing `IEEEContext.to_ordinal()`"""
 
     def test_common(self):
@@ -28,12 +27,12 @@ class ToOrdinalTestCase(unittest.TestCase):
                         if ctx.representable_under(xr):
                             x = Float(x=xr, ctx=ctx)
                             i = ctx.to_ordinal(x)
-                            self.assertIsInstance(i, int, f'x={x}, i={i}')
-                            self.assertGreaterEqual(i, -(1 << ctx.nbits - 1), f'x={x}, i={i}')
-                            self.assertLess(i, 1 << ctx.nbits - 1, f'x={x}, i={i}')
+                            assert isinstance(i, int), f'x={x}, i={i}'
+                            assert i >= -(1 << ctx.nbits - 1), f'x={x}, i={i}'
+                            assert i < 1 << ctx.nbits - 1, f'x={x}, i={i}'
 
 
-class OrdinalRoundTripTestCase(unittest.TestCase):
+class OrdinalRoundTripTestCase():
     """Testing `ExtFloatContext.to_ordinal()` and `ExtFloatContext.from_ordinal()`"""
 
     def test_common(self):
@@ -49,5 +48,5 @@ class OrdinalRoundTripTestCase(unittest.TestCase):
                             x = Float(x=xr, ctx=ctx)
                             i = ctx.to_ordinal(x)
                             y = ctx.from_ordinal(i)
-                            self.assertIsInstance(y, Float, f'x={x}, i={i}, y={y}')
-                            self.assertEqual(x, y, f'x={x}, i={i}, y={y}')
+                            assert isinstance(y, Float), f'x={x}, i={i}, y={y}'
+                            assert x == y, f'x={x}, i={i}, y={y}'

--- a/tests/unit/number/efloat/test_params.py
+++ b/tests/unit/number/efloat/test_params.py
@@ -1,5 +1,4 @@
 import fpy2 as fp
-import unittest
 
 from fpy2 import (
     S1E5M2, S1E4M3,
@@ -7,131 +6,131 @@ from fpy2 import (
     FP8P1, FP8P2, FP8P3, FP8P4, FP8P5, FP8P6, FP8P7
 )
 
-class TestGraphcoreParams(unittest.TestCase):
+class TestGraphcoreParams():
     """Test Graphcore floating-point parameters."""
 
     def test_s1e5m2_params(self):
-        self.assertEqual(S1E5M2.nbits, 8)
-        self.assertEqual(S1E5M2.pmax, 3)
-        self.assertEqual(S1E5M2.emin, -15)
-        self.assertEqual(S1E5M2.emax, 15)
-        self.assertEqual(S1E5M2.expmin, -17)
-        self.assertEqual(S1E5M2.expmax, 13)
+        assert S1E5M2.nbits == 8
+        assert S1E5M2.pmax == 3
+        assert S1E5M2.emin == -15
+        assert S1E5M2.emax == 15
+        assert S1E5M2.expmin == -17
+        assert S1E5M2.expmax == 13
 
     def test_s1e4m3_params(self):
-        self.assertEqual(S1E4M3.nbits, 8)
-        self.assertEqual(S1E4M3.pmax, 4)
-        self.assertEqual(S1E4M3.emin, -7)
-        self.assertEqual(S1E4M3.emax, 7)
-        self.assertEqual(S1E4M3.expmin, -10)
-        self.assertEqual(S1E4M3.expmax, 4)
+        assert S1E4M3.nbits == 8
+        assert S1E4M3.pmax == 4
+        assert S1E4M3.emin == -7
+        assert S1E4M3.emax == 7
+        assert S1E4M3.expmin == -10
+        assert S1E4M3.expmax == 4
 
 
-class TestOCPParams(unittest.TestCase):
+class TestOCPParams():
     """Test OCP floating-point parameters."""
 
     def test_mx_e5m2_params(self):
-        self.assertEqual(MX_E5M2.nbits, 8)
-        self.assertEqual(MX_E5M2.pmax, 3)
-        self.assertEqual(MX_E5M2.emin, -14)
-        self.assertEqual(MX_E5M2.emax, 15)
-        self.assertEqual(MX_E5M2.expmin, -16)
-        self.assertEqual(MX_E5M2.expmax, 13)
+        assert MX_E5M2.nbits == 8
+        assert MX_E5M2.pmax == 3
+        assert MX_E5M2.emin == -14
+        assert MX_E5M2.emax == 15
+        assert MX_E5M2.expmin == -16
+        assert MX_E5M2.expmax == 13
 
     def test_mx_e4m3_params(self):
-        self.assertEqual(MX_E4M3.nbits, 8)
-        self.assertEqual(MX_E4M3.pmax, 4)
-        self.assertEqual(MX_E4M3.emin, -6)
-        self.assertEqual(MX_E4M3.emax, 8)
-        self.assertEqual(MX_E4M3.expmin, -9)
-        self.assertEqual(MX_E4M3.expmax, 5)
+        assert MX_E4M3.nbits == 8
+        assert MX_E4M3.pmax == 4
+        assert MX_E4M3.emin == -6
+        assert MX_E4M3.emax == 8
+        assert MX_E4M3.expmin == -9
+        assert MX_E4M3.expmax == 5
 
     def test_mx_e3m2_params(self):
-        self.assertEqual(MX_E3M2.nbits, 6)
-        self.assertEqual(MX_E3M2.pmax, 3)
-        self.assertEqual(MX_E3M2.emin, -2)
-        self.assertEqual(MX_E3M2.emax, 4)
-        self.assertEqual(MX_E3M2.expmin, -4)
-        self.assertEqual(MX_E3M2.expmax, 2)
+        assert MX_E3M2.nbits == 6
+        assert MX_E3M2.pmax == 3
+        assert MX_E3M2.emin == -2
+        assert MX_E3M2.emax == 4
+        assert MX_E3M2.expmin == -4
+        assert MX_E3M2.expmax == 2
 
     def test_mx_e2m3_params(self):
-        self.assertEqual(MX_E2M3.nbits, 6)
-        self.assertEqual(MX_E2M3.pmax, 4)
-        self.assertEqual(MX_E2M3.emin, 0)
-        self.assertEqual(MX_E2M3.emax, 2)
-        self.assertEqual(MX_E2M3.expmin, -3)
-        self.assertEqual(MX_E2M3.expmax, -1)
+        assert MX_E2M3.nbits == 6
+        assert MX_E2M3.pmax == 4
+        assert MX_E2M3.emin == 0
+        assert MX_E2M3.emax == 2
+        assert MX_E2M3.expmin == -3
+        assert MX_E2M3.expmax == -1
 
     def test_mx_e2m1_params(self):
-        self.assertEqual(MX_E2M1.nbits, 4)
-        self.assertEqual(MX_E2M1.pmax, 2)
-        self.assertEqual(MX_E2M1.emin, 0)
-        self.assertEqual(MX_E2M1.emax, 2)
-        self.assertEqual(MX_E2M1.expmin, -1)
-        self.assertEqual(MX_E2M1.expmax, 1)
+        assert MX_E2M1.nbits == 4
+        assert MX_E2M1.pmax == 2
+        assert MX_E2M1.emin == 0
+        assert MX_E2M1.emax == 2
+        assert MX_E2M1.expmin == -1
+        assert MX_E2M1.expmax == 1
 
 
-class TestIEEEP3109Params(unittest.TestCase):
+class TestIEEEP3109Params():
     """Test IEEE P3109 floating-point parameters."""
 
     def test_fp8p1_params(self):
-        self.assertEqual(FP8P1.nbits, 8)
-        self.assertEqual(FP8P1.pmax, 1)
-        self.assertEqual(FP8P1.emin, -62)
-        self.assertEqual(FP8P1.emax, 63)
-        self.assertEqual(FP8P1.expmin, -62)
-        self.assertEqual(FP8P1.expmax, 63)
+        assert FP8P1.nbits == 8
+        assert FP8P1.pmax == 1
+        assert FP8P1.emin == -62
+        assert FP8P1.emax == 63
+        assert FP8P1.expmin == -62
+        assert FP8P1.expmax == 63
 
     def test_fp8p2_params(self):
-        self.assertEqual(FP8P2.nbits, 8)
-        self.assertEqual(FP8P2.pmax, 2)
-        self.assertEqual(FP8P2.emin, -31)
-        self.assertEqual(FP8P2.emax, 31)
-        self.assertEqual(FP8P2.expmin, -32)
-        self.assertEqual(FP8P2.expmax, 30)
+        assert FP8P2.nbits == 8
+        assert FP8P2.pmax == 2
+        assert FP8P2.emin == -31
+        assert FP8P2.emax == 31
+        assert FP8P2.expmin == -32
+        assert FP8P2.expmax == 30
 
     def test_fp8p3_params(self):
-        self.assertEqual(FP8P3.nbits, 8)
-        self.assertEqual(FP8P3.pmax, 3)
-        self.assertEqual(FP8P3.emin, -15)
-        self.assertEqual(FP8P3.emax, 15)
-        self.assertEqual(FP8P3.expmin, -17)
-        self.assertEqual(FP8P3.expmax, 13)
+        assert FP8P3.nbits == 8
+        assert FP8P3.pmax == 3
+        assert FP8P3.emin == -15
+        assert FP8P3.emax == 15
+        assert FP8P3.expmin == -17
+        assert FP8P3.expmax == 13
 
     def test_fp8p4_params(self):
-        self.assertEqual(FP8P4.nbits, 8)
-        self.assertEqual(FP8P4.pmax, 4)
-        self.assertEqual(FP8P4.emin, -7)
-        self.assertEqual(FP8P4.emax, 7)
-        self.assertEqual(FP8P4.expmin, -10)
-        self.assertEqual(FP8P4.expmax, 4)
+        assert FP8P4.nbits == 8
+        assert FP8P4.pmax == 4
+        assert FP8P4.emin == -7
+        assert FP8P4.emax == 7
+        assert FP8P4.expmin == -10
+        assert FP8P4.expmax == 4
 
     def test_fp8p5_params(self):
-        self.assertEqual(FP8P5.nbits, 8)
-        self.assertEqual(FP8P5.pmax, 5)
-        self.assertEqual(FP8P5.emin, -3)
-        self.assertEqual(FP8P5.emax, 3)
-        self.assertEqual(FP8P5.expmin, -7)
-        self.assertEqual(FP8P5.expmax, -1)
+        assert FP8P5.nbits == 8
+        assert FP8P5.pmax == 5
+        assert FP8P5.emin == -3
+        assert FP8P5.emax == 3
+        assert FP8P5.expmin == -7
+        assert FP8P5.expmax == -1
 
     def test_fp8p6_params(self):
-        self.assertEqual(FP8P6.nbits, 8)
-        self.assertEqual(FP8P6.pmax, 6)
-        self.assertEqual(FP8P6.emin, -1)
-        self.assertEqual(FP8P6.emax, 1)
-        self.assertEqual(FP8P6.expmin, -6)
-        self.assertEqual(FP8P6.expmax, -4)
+        assert FP8P6.nbits == 8
+        assert FP8P6.pmax == 6
+        assert FP8P6.emin == -1
+        assert FP8P6.emax == 1
+        assert FP8P6.expmin == -6
+        assert FP8P6.expmax == -4
 
     def test_fp8p7_params(self):
-        self.assertEqual(FP8P7.nbits, 8)
-        self.assertEqual(FP8P7.pmax, 7)
-        self.assertEqual(FP8P7.emin, 0)
-        self.assertEqual(FP8P7.emax, 0)
-        self.assertEqual(FP8P7.expmin, -6)
-        self.assertEqual(FP8P7.expmax, -6)
+        assert FP8P7.nbits == 8
+        assert FP8P7.pmax == 7
+        assert FP8P7.emin == 0
+        assert FP8P7.emax == 0
+        assert FP8P7.expmin == -6
+        assert FP8P7.expmax == -6
 
 
-class TestSmallFloatParams(unittest.TestCase):
+class TestSmallFloatParams():
     """
     Test small floating-point parameters.
 
@@ -140,144 +139,144 @@ class TestSmallFloatParams(unittest.TestCase):
 
     def test_region1(self):
         CTX = fp.IEEEContext(2, 5)
-        self.assertEqual(CTX.emin, 0)
-        self.assertEqual(CTX.emax, 1)
-        self.assertEqual(CTX.expmin, -2)
-        self.assertEqual(CTX.expmax, -1)
-        self.assertEqual(CTX.maxval(), 3.5)
-        self.assertEqual(CTX.largest(), 3.5)
-        self.assertEqual(CTX.smallest(), -3.5)
+        assert CTX.emin == 0
+        assert CTX.emax == 1
+        assert CTX.expmin == -2
+        assert CTX.expmax == -1
+        assert CTX.maxval() == 3.5
+        assert CTX.largest() == 3.5
+        assert CTX.smallest() == -3.5
 
     def test_region2(self):
         CTX = fp.IEEEContext(2, 4)
-        self.assertEqual(CTX.emin, 0)
-        self.assertEqual(CTX.emax, 1)
-        self.assertEqual(CTX.expmin, -1)
-        self.assertEqual(CTX.expmax, 0)
-        self.assertEqual(CTX.maxval(), 3)
-        self.assertEqual(CTX.largest(), 3)
-        self.assertEqual(CTX.smallest(), -3)
+        assert CTX.emin == 0
+        assert CTX.emax == 1
+        assert CTX.expmin == -1
+        assert CTX.expmax == 0
+        assert CTX.maxval() == 3
+        assert CTX.largest() == 3
+        assert CTX.smallest() == -3
 
     def test_region3(self):
         CTX = fp.EFloatContext(2, 3, False, fp.EFloatNanKind.NONE, 0)
-        self.assertEqual(CTX.emin, 0)
-        self.assertEqual(CTX.emax, 2)
-        self.assertEqual(CTX.expmin, 0)
-        self.assertEqual(CTX.expmax, 2)
-        self.assertEqual(CTX.maxval(), 4)
-        self.assertEqual(CTX.largest(), 4)
-        self.assertEqual(CTX.smallest(), -4)
+        assert CTX.emin == 0
+        assert CTX.emax == 2
+        assert CTX.expmin == 0
+        assert CTX.expmax == 2
+        assert CTX.maxval() == 4
+        assert CTX.largest() == 4
+        assert CTX.smallest() == -4
 
     def test_region4(self):
         CTX1 = fp.EFloatContext(1, 4, True, fp.EFloatNanKind.IEEE_754, 0)
-        self.assertEqual(CTX1.emin, 1)
-        self.assertEqual(CTX1.emax, 0)
-        self.assertEqual(CTX1.expmin, -1)
-        self.assertEqual(CTX1.expmax, -2)
-        self.assertEqual(CTX1.maxval(), 1.5)
-        self.assertEqual(CTX1.largest(), 1.5)
-        self.assertEqual(CTX1.smallest(), -1.5)
+        assert CTX1.emin == 1
+        assert CTX1.emax == 0
+        assert CTX1.expmin == -1
+        assert CTX1.expmax == -2
+        assert CTX1.maxval() == 1.5
+        assert CTX1.largest() == 1.5
+        assert CTX1.smallest() == -1.5
 
         CTX2 = fp.EFloatContext(1, 4, False, fp.EFloatNanKind.NONE, 0)
-        self.assertEqual(CTX2.emin, 1)
-        self.assertEqual(CTX2.emax, 1)
-        self.assertEqual(CTX2.expmin, -1)
-        self.assertEqual(CTX2.expmax, -1)
-        self.assertEqual(CTX2.maxval(), 3.5)
-        self.assertEqual(CTX2.largest(), 3.5)
-        self.assertEqual(CTX2.smallest(), -3.5)
+        assert CTX2.emin == 1
+        assert CTX2.emax == 1
+        assert CTX2.expmin == -1
+        assert CTX2.expmax == -1
+        assert CTX2.maxval() == 3.5
+        assert CTX2.largest() == 3.5
+        assert CTX2.smallest() == -3.5
 
     def test_region5(self):
         CTX = fp.EFloatContext(0, 3, False, fp.EFloatNanKind.NONE, 0)
-        self.assertEqual(CTX.emin, 1)
-        self.assertEqual(CTX.emax, 0)
-        self.assertEqual(CTX.expmin, -1)
-        self.assertEqual(CTX.expmax, -2)
-        self.assertEqual(CTX.maxval(), 1.5)
-        self.assertEqual(CTX.largest(), 1.5)
-        self.assertEqual(CTX.smallest(), -1.5)
+        assert CTX.emin == 1
+        assert CTX.emax == 0
+        assert CTX.expmin == -1
+        assert CTX.expmax == -2
+        assert CTX.maxval() == 1.5
+        assert CTX.largest() == 1.5
+        assert CTX.smallest() == -1.5
 
     def test_region6(self):
         CTX = fp.EFloatContext(1, 3, True, fp.EFloatNanKind.MAX_VAL, 0)
-        self.assertEqual(CTX.emin, 1)
-        self.assertEqual(CTX.emax, 0)
-        self.assertEqual(CTX.expmin, 0)
-        self.assertEqual(CTX.expmax, -1)
-        self.assertEqual(CTX.maxval(), 1)
-        self.assertEqual(CTX.largest(), 1)
-        self.assertEqual(CTX.smallest(), -1)
+        assert CTX.emin == 1
+        assert CTX.emax == 0
+        assert CTX.expmin == 0
+        assert CTX.expmax == -1
+        assert CTX.maxval() == 1
+        assert CTX.largest() == 1
+        assert CTX.smallest() == -1
 
     def test_region7(self):
         CTX1 = fp.EFloatContext(1, 2, False, fp.EFloatNanKind.NONE, 0)
-        self.assertEqual(CTX1.emin, 1)
-        self.assertEqual(CTX1.emax, 1)
-        self.assertEqual(CTX1.expmin, 1)
-        self.assertEqual(CTX1.expmax, 1)
-        self.assertEqual(CTX1.maxval(), 2)
-        self.assertEqual(CTX1.largest(), 2)
-        self.assertEqual(CTX1.smallest(), -2)
+        assert CTX1.emin == 1
+        assert CTX1.emax == 1
+        assert CTX1.expmin == 1
+        assert CTX1.expmax == 1
+        assert CTX1.maxval() == 2
+        assert CTX1.largest() == 2
+        assert CTX1.smallest() == -2
 
         CTX2 = fp.EFloatContext(1, 2, True, fp.EFloatNanKind.NONE, 0)
-        self.assertEqual(CTX2.emin, 1)
-        self.assertEqual(CTX2.emax, 0)
-        self.assertEqual(CTX2.expmin, 1)
-        self.assertEqual(CTX2.expmax, 0)
-        self.assertEqual(CTX2.maxval(), 0)
-        self.assertEqual(CTX2.largest(), 0)
-        self.assertEqual(CTX2.smallest(), 0)
+        assert CTX2.emin == 1
+        assert CTX2.emax == 0
+        assert CTX2.expmin == 1
+        assert CTX2.expmax == 0
+        assert CTX2.maxval() == 0
+        assert CTX2.largest() == 0
+        assert CTX2.smallest() == 0
 
         CTX3 = fp.EFloatContext(1, 2, False, fp.EFloatNanKind.MAX_VAL, 0)
-        self.assertEqual(CTX3.emin, 1)
-        self.assertEqual(CTX3.emax, 0)
-        self.assertEqual(CTX3.expmin, 1)
-        self.assertEqual(CTX3.expmax, 0)
-        self.assertEqual(CTX3.maxval(), 0)
-        self.assertEqual(CTX3.largest(), 0)
-        self.assertEqual(CTX3.smallest(), 0)
+        assert CTX3.emin == 1
+        assert CTX3.emax == 0
+        assert CTX3.expmin == 1
+        assert CTX3.expmax == 0
+        assert CTX3.maxval() == 0
+        assert CTX3.largest() == 0
+        assert CTX3.smallest() == 0
 
     def test_region8(self):
         CTX1 = fp.EFloatContext(0, 2, False, fp.EFloatNanKind.NONE, 0)
-        self.assertEqual(CTX1.emin, 1)
-        self.assertEqual(CTX1.emax, 0)
-        self.assertEqual(CTX1.expmin, 0)
-        self.assertEqual(CTX1.expmax, -1)
-        self.assertEqual(CTX1.maxval(), 1)
-        self.assertEqual(CTX1.largest(), 1)
-        self.assertEqual(CTX1.smallest(), -1)
+        assert CTX1.emin == 1
+        assert CTX1.emax == 0
+        assert CTX1.expmin == 0
+        assert CTX1.expmax == -1
+        assert CTX1.maxval() == 1
+        assert CTX1.largest() == 1
+        assert CTX1.smallest() == -1
 
         CTX2 = fp.EFloatContext(0, 2, True, fp.EFloatNanKind.NONE, 0)
-        self.assertEqual(CTX2.emin, 1)
-        self.assertEqual(CTX2.emax, 0)
-        self.assertEqual(CTX2.expmin, 0)
-        self.assertEqual(CTX2.expmax, -1)
-        self.assertEqual(CTX2.maxval(), 0)
-        self.assertEqual(CTX2.largest(), 0)
-        self.assertEqual(CTX2.smallest(), 0)
+        assert CTX2.emin == 1
+        assert CTX2.emax == 0
+        assert CTX2.expmin == 0
+        assert CTX2.expmax == -1
+        assert CTX2.maxval() == 0
+        assert CTX2.largest() == 0
+        assert CTX2.smallest() == 0
 
         CTX3 = fp.EFloatContext(0, 2, False, fp.EFloatNanKind.MAX_VAL, 0)
-        self.assertEqual(CTX3.emin, 1)
-        self.assertEqual(CTX3.emax, 0)
-        self.assertEqual(CTX3.expmin, 0)
-        self.assertEqual(CTX3.expmax, -1)
-        self.assertEqual(CTX3.maxval(), 0)
-        self.assertEqual(CTX3.largest(), 0)
-        self.assertEqual(CTX3.smallest(), 0)
+        assert CTX3.emin == 1
+        assert CTX3.emax == 0
+        assert CTX3.expmin == 0
+        assert CTX3.expmax == -1
+        assert CTX3.maxval() == 0
+        assert CTX3.largest() == 0
+        assert CTX3.smallest() == 0
 
     def test_region9(self):
         CTX1 = fp.EFloatContext(0, 1, False, fp.EFloatNanKind.NONE, 0)
-        self.assertEqual(CTX1.emin, 1)
-        self.assertEqual(CTX1.emax, 0)
-        self.assertEqual(CTX1.expmin, 1)
-        self.assertEqual(CTX1.expmax, 0)
-        self.assertEqual(CTX1.maxval(), 0)
-        self.assertEqual(CTX1.largest(), 0)
-        self.assertEqual(CTX1.smallest(), 0)
+        assert CTX1.emin == 1
+        assert CTX1.emax == 0
+        assert CTX1.expmin == 1
+        assert CTX1.expmax == 0
+        assert CTX1.maxval() == 0
+        assert CTX1.largest() == 0
+        assert CTX1.smallest() == 0
 
         CTX2 = fp.EFloatContext(0, 1, False, fp.EFloatNanKind.NEG_ZERO, 0)
-        self.assertEqual(CTX2.emin, 1)
-        self.assertEqual(CTX2.emax, 0)
-        self.assertEqual(CTX2.expmin, 1)
-        self.assertEqual(CTX2.expmax, 0)
-        self.assertEqual(CTX2.maxval(), 0)
-        self.assertEqual(CTX2.largest(), 0)
-        self.assertEqual(CTX2.smallest(), 0)
+        assert CTX2.emin == 1
+        assert CTX2.emax == 0
+        assert CTX2.expmin == 1
+        assert CTX2.expmax == 0
+        assert CTX2.maxval() == 0
+        assert CTX2.largest() == 0
+        assert CTX2.smallest() == 0

--- a/tests/unit/number/efloat/test_round.py
+++ b/tests/unit/number/efloat/test_round.py
@@ -1,4 +1,3 @@
-import unittest
 
 import fpy2 as fp
 from hypothesis import given
@@ -11,7 +10,7 @@ _common: list[fp.EFloatContext] = [
     fp.FP8P1, fp.FP8P2, fp.FP8P3, fp.FP8P4, fp.FP8P5, fp.FP8P6, fp.FP8P7
 ]
 
-class TestRound(unittest.TestCase):
+class TestRound():
     """Test rounding behavior."""
 
     @given(floats(prec_max=fp.FP16.pmax, exp_min=fp.FP16.expmin, exp_max=fp.FP16.expmax))
@@ -20,10 +19,10 @@ class TestRound(unittest.TestCase):
         for ctx in _common:
             y = ctx.round(x)
             y = fp.Float(x=y, ctx=None) # strip context for testing
-            self.assertIsInstance(y, fp.Float, f'ctx={ctx}, x={x}, y={y}')
-            self.assertTrue(ctx.representable_under(y), f'ctx={ctx}, x={x}, y={y}')
+            assert isinstance(y, fp.Float), f'ctx={ctx}, x={x}, y={y}'
+            assert ctx.representable_under(y), f'ctx={ctx}, x={x}, y={y}'
 
-class TestRoundSaturate(unittest.TestCase):
+class TestRoundSaturate():
     """Test saturation behavior."""
 
     def test_saturate(self):
@@ -31,5 +30,5 @@ class TestRoundSaturate(unittest.TestCase):
         maxval = ctx.maxval()
         eps = fp.Float(c=1, exp=maxval.exp)
 
-        self.assertEqual(ctx.round(maxval), maxval)
-        self.assertEqual(ctx.round(fp.add(maxval, eps)), maxval)
+        assert ctx.round(maxval) == maxval
+        assert ctx.round(fp.add(maxval, eps)) == maxval

--- a/tests/unit/number/exponential/test_encode.py
+++ b/tests/unit/number/exponential/test_encode.py
@@ -1,41 +1,40 @@
 import fpy2 as fp
-import unittest
 
 from hypothesis import given, strategies as st
 
-class EncodeTestCase(unittest.TestCase):
+class EncodeTestCase():
     """Testing `ExpContext.encode()`"""
 
     @given(st.integers(-127, 127), st.integers(0, 8))
     def test_encode_e8m0(self, exp: int, shift: int):
         x = fp.Float(c=1 << shift, exp=exp - shift)
         i = fp.MX_E8M0.encode(x)
-        self.assertIsInstance(i, int, f'x={x}, i={i}')
-        self.assertEqual(i, exp + 127)
+        assert isinstance(i, int), f'x={x}, i={i}'
+        assert i == exp + 127
 
     def test_encode_nan_e8m0(self):
         x = fp.Float.nan()
         i = fp.MX_E8M0.encode(x)
-        self.assertIsInstance(i, int, f'x={x}, i={i}')
-        self.assertEqual(i, 255)
+        assert isinstance(i, int), f'x={x}, i={i}'
+        assert i == 255
 
-class DecodeTestCase(unittest.TestCase):
+class DecodeTestCase():
     """Testing `ExpContext.decode()`"""
 
     @given(st.integers(0, 254))
     def test_decode_e8m0(self, i: int):
         x = fp.MX_E8M0.decode(i)
-        self.assertIsInstance(x, fp.Float, f'i={i}, x={x}')
-        self.assertEqual(x.c, 1)
-        self.assertEqual(x.exp, i - 127, f'i={i}, x={x}')
+        assert isinstance(x, fp.Float), f'i={i}, x={x}'
+        assert x.c == 1
+        assert x.exp == i - 127, f'i={i}, x={x}'
 
     def test_decode_nan_e8m0(self):
         i = 255
         x = fp.MX_E8M0.decode(i)
-        self.assertIsInstance(x, fp.Float, f'i={i}, x={x}')
-        self.assertTrue(x.isnan, f'i={i}, x={x}')
+        assert isinstance(x, fp.Float), f'i={i}, x={x}'
+        assert x.isnan, f'i={i}, x={x}'
 
-class EncodeRoundTripTestCase(unittest.TestCase):
+class EncodeRoundTripTestCase():
     """Ensure `ExpContext.decode()` and `ExpContext.encode()` roundtrips."""
 
     @given(st.sampled_from(['nan', 'finite']), st.integers(-127, 127), st.integers(0, 8))
@@ -48,6 +47,6 @@ class EncodeRoundTripTestCase(unittest.TestCase):
         i = fp.MX_E8M0.encode(x)
         y = fp.MX_E8M0.decode(i)
         if y.isnan:
-            self.assertTrue(x.isnan, f'x={x}, y={y}')
+            assert x.isnan, f'x={x}, y={y}'
         else:
-            self.assertEqual(x, y)
+            assert x == y

--- a/tests/unit/number/exponential/test_params.py
+++ b/tests/unit/number/exponential/test_params.py
@@ -1,27 +1,26 @@
 import fpy2 as fp
-import unittest
 
-class TestParams(unittest.TestCase):
+class TestParams():
     """Test `ExpContext` parameters."""
 
     def test_common(self):
         e8m0 = fp.ExpContext(8, 0)
-        self.assertEqual(e8m0.nbits, 8)
-        self.assertEqual(e8m0.eoffset, 0)
-        self.assertEqual(e8m0.emin, -127)
-        self.assertEqual(e8m0.emax, 127)
-        self.assertEqual(e8m0.ebias, 127)
+        assert e8m0.nbits == 8
+        assert e8m0.eoffset == 0
+        assert e8m0.emin == -127
+        assert e8m0.emax == 127
+        assert e8m0.ebias == 127
 
         e8m0_p1 = fp.ExpContext(8, 1)
-        self.assertEqual(e8m0_p1.nbits, 8)
-        self.assertEqual(e8m0_p1.eoffset, 1)
-        self.assertEqual(e8m0_p1.emin, -126)
-        self.assertEqual(e8m0_p1.emax, 128)
-        self.assertEqual(e8m0_p1.ebias, 126)
+        assert e8m0_p1.nbits == 8
+        assert e8m0_p1.eoffset == 1
+        assert e8m0_p1.emin == -126
+        assert e8m0_p1.emax == 128
+        assert e8m0_p1.ebias == 126
 
         e8m0_m1 = fp.ExpContext(8, -1)
-        self.assertEqual(e8m0_m1.nbits, 8)
-        self.assertEqual(e8m0_m1.eoffset, -1)
-        self.assertEqual(e8m0_m1.emin, -128)
-        self.assertEqual(e8m0_m1.emax, 126)
-        self.assertEqual(e8m0_m1.ebias, 128)
+        assert e8m0_m1.nbits == 8
+        assert e8m0_m1.eoffset == -1
+        assert e8m0_m1.emin == -128
+        assert e8m0_m1.emax == 126
+        assert e8m0_m1.ebias == 128

--- a/tests/unit/number/exponential/test_representable.py
+++ b/tests/unit/number/exponential/test_representable.py
@@ -1,7 +1,6 @@
 import fpy2 as fp
-import unittest
 
-class TestRepresentable(unittest.TestCase):
+class TestRepresentable():
     """Test `ExpContext` representability."""
 
     def test_e8m0(self):
@@ -18,14 +17,14 @@ class TestRepresentable(unittest.TestCase):
         FOUR = fp.Float.from_int(4)
         NEG_ONE = fp.Float.from_int(-1)
 
-        self.assertTrue(E8M0.representable_under(NAN))
-        self.assertFalse(E8M0.representable_under(POS_INF))
-        self.assertFalse(E8M0.representable_under(NEG_INF))
-        self.assertFalse(E8M0.representable_under(ZERO))
-        self.assertTrue(E8M0.representable_under(MAX_VAL))
-        self.assertTrue(E8M0.representable_under(MIN_VAL))
-        self.assertFalse(E8M0.representable_under(HUGE))
-        self.assertFalse(E8M0.representable_under(TINY))
-        self.assertFalse(E8M0.representable_under(THREE_HALF))
-        self.assertTrue(E8M0.representable_under(FOUR))
-        self.assertFalse(E8M0.representable_under(NEG_ONE))
+        assert E8M0.representable_under(NAN)
+        assert not E8M0.representable_under(POS_INF)
+        assert not E8M0.representable_under(NEG_INF)
+        assert not E8M0.representable_under(ZERO)
+        assert E8M0.representable_under(MAX_VAL)
+        assert E8M0.representable_under(MIN_VAL)
+        assert not E8M0.representable_under(HUGE)
+        assert not E8M0.representable_under(TINY)
+        assert not E8M0.representable_under(THREE_HALF)
+        assert E8M0.representable_under(FOUR)
+        assert not E8M0.representable_under(NEG_ONE)

--- a/tests/unit/number/exponential/test_round.py
+++ b/tests/unit/number/exponential/test_round.py
@@ -1,33 +1,32 @@
 import fpy2 as fp
-import unittest
 
 from hypothesis import given, strategies as st
 
 from ...generators import real_floats, floats, rounding_modes
 
-class RoundTestCase(unittest.TestCase):
+class RoundTestCase():
     """Testing rounding behavior of `ExpContext`."""
 
     @given(real_floats(prec_max=8, exp_min=-256, exp_max=256), st.integers(1, 8), st.integers(-8, 8), rounding_modes())
     def test_round_real(self, x: fp.RealFloat, n: int, eoffset: int, rm: fp.RoundingMode):
         ctx = fp.ExpContext(n, eoffset, rm=rm)
         rounded = ctx.round(x)
-        self.assertIsInstance(rounded, fp.Float, f'x={x}, rounded={rounded}')
-        self.assertTrue(ctx.representable_under(fp.Float(x=rounded, ctx=None)), f'x={x}, rounded={rounded}')
+        assert isinstance(rounded, fp.Float), f'x={x}, rounded={rounded}'
+        assert ctx.representable_under(fp.Float(x=rounded, ctx=None)), f'x={x}, rounded={rounded}'
         if x.is_zero():
-            self.assertTrue(rounded.isnan, f'x={x}, rounded={rounded}')
+            assert rounded.isnan, f'x={x}, rounded={rounded}'
         elif x.s:
-            self.assertTrue(rounded.isnan, f'x={x}, rounded={rounded}')
+            assert rounded.isnan, f'x={x}, rounded={rounded}'
 
     @given(floats(prec_max=8, exp_min=-256, exp_max=256), st.integers(1, 8), st.integers(-8, 8), rounding_modes())
     def test_round_float(self, x: fp.Float, n: int, eoffset: int, rm: fp.RoundingMode):
         ctx = fp.ExpContext(n, eoffset, rm=rm)
         rounded = ctx.round(x)
-        self.assertIsInstance(rounded, fp.Float, f'x={x}, rounded={rounded}')
-        self.assertTrue(ctx.representable_under(rounded), f'x={x}, rounded={rounded}')
+        assert isinstance(rounded, fp.Float), f'x={x}, rounded={rounded}'
+        assert ctx.representable_under(rounded), f'x={x}, rounded={rounded}'
         if x.is_zero():
-            self.assertTrue(rounded.isnan, f'x={x}, rounded={rounded}')
+            assert rounded.isnan, f'x={x}, rounded={rounded}'
         elif x.s:
-            self.assertTrue(rounded.isnan, f'x={x}, rounded={rounded}')
+            assert rounded.isnan, f'x={x}, rounded={rounded}'
         elif x.isinf:
-            self.assertTrue(rounded.isnan, f'x={x}, rounded={rounded}')
+            assert rounded.isnan, f'x={x}, rounded={rounded}'

--- a/tests/unit/number/fixed/test_encode.py
+++ b/tests/unit/number/fixed/test_encode.py
@@ -1,8 +1,7 @@
-import unittest
 
 import fpy2 as fp
 
-class EncodeTestCase(unittest.TestCase):
+class EncodeTestCase():
     """Testing `FixedContext.encode()`"""
 
     def test_encode_u4(self):
@@ -10,16 +9,16 @@ class EncodeTestCase(unittest.TestCase):
         for i in range(1 << ctx.nbits):
             x = fp.Float.from_int(i, ctx=ctx)
             encoded = ctx.encode(x)
-            self.assertIsInstance(encoded, int, f'x={x}, encoded={encoded}')
-            self.assertEqual(encoded, i, f'x={x}, encoded={encoded}')
+            assert isinstance(encoded, int), f'x={x}, encoded={encoded}'
+            assert encoded == i, f'x={x}, encoded={encoded}'
 
     def test_encode_u4_scale2(self):
         ctx = fp.FixedContext(False, 2, 4)
         for i in range(1 << ctx.nbits):
             x = fp.Float(False, 2, i, ctx=ctx)
             encoded = ctx.encode(x)
-            self.assertIsInstance(encoded, int, f'x={x}, encoded={encoded}')
-            self.assertEqual(encoded, i, f'x={x}, encoded={encoded}')
+            assert isinstance(encoded, int), f'x={x}, encoded={encoded}'
+            assert encoded == i, f'x={x}, encoded={encoded}'
 
     def test_encode_s4(self):
         ctx = fp.FixedContext(True, 0, 4)
@@ -27,14 +26,14 @@ class EncodeTestCase(unittest.TestCase):
         for i in range(1 << (ctx.nbits - 1)):
             x = fp.Float.from_int(i, ctx=ctx)
             encoded = ctx.encode(x)
-            self.assertIsInstance(encoded, int, f'x={x}, encoded={encoded}')
-            self.assertEqual(encoded, i, f'x={x}, encoded={encoded}')
+            assert isinstance(encoded, int), f'x={x}, encoded={encoded}'
+            assert encoded == i, f'x={x}, encoded={encoded}'
         # negative values
         for i in range(-(1 << (ctx.nbits - 1)), 0):
             x = fp.Float.from_int(i, ctx=ctx)
             encoded = ctx.encode(x)
-            self.assertIsInstance(encoded, int, f'x={x}, encoded={encoded}')
-            self.assertEqual(encoded, (1 << ctx.nbits) - abs(i), f'x={x}, encoded={encoded}')
+            assert isinstance(encoded, int), f'x={x}, encoded={encoded}'
+            assert encoded == (1 << ctx.nbits) - abs(i), f'x={x}, encoded={encoded}'
 
     def test_encode_s4_scale2(self):
         ctx = fp.FixedContext(True, 2, 4)
@@ -42,55 +41,55 @@ class EncodeTestCase(unittest.TestCase):
         for i in range(1 << (ctx.nbits - 1)):
             x = fp.Float(False, 2, i, ctx=ctx)
             encoded = ctx.encode(x)
-            self.assertIsInstance(encoded, int, f'x={x}, encoded={encoded}')
-            self.assertEqual(encoded, i, f'x={x}, encoded={encoded}')
+            assert isinstance(encoded, int), f'x={x}, encoded={encoded}'
+            assert encoded == i, f'x={x}, encoded={encoded}'
         # negative values
         for i in range(-(1 << (ctx.nbits - 1)), 0):
             x = fp.Float(True, 2, abs(i), ctx=ctx)
             encoded = ctx.encode(x)
-            self.assertIsInstance(encoded, int, f'x={x}, encoded={encoded}')
-            self.assertEqual(encoded, (1 << ctx.nbits) - abs(i), f'x={x}, encoded={encoded}')
+            assert isinstance(encoded, int), f'x={x}, encoded={encoded}'
+            assert encoded == (1 << ctx.nbits) - abs(i), f'x={x}, encoded={encoded}'
 
 
-class DecodeTestCase(unittest.TestCase):
+class DecodeTestCase():
     """Testing `FixedContext.decode()`"""
 
     def test_decode_u4(self):
         ctx = fp.FixedContext(False, 0, 4)
         for i in range(1 << ctx.nbits):
             decoded = ctx.decode(i)
-            self.assertIsInstance(decoded, fp.Float, f'i={i}, decoded={decoded}')
-            self.assertEqual(int(decoded), i, f'i={i}, decoded={decoded}')
+            assert isinstance(decoded, fp.Float), f'i={i}, decoded={decoded}'
+            assert int(decoded) == i, f'i={i}, decoded={decoded}'
 
     def test_decode_u4_scale2(self):
         ctx = fp.FixedContext(False, 2, 4)
         for i in range(1 << ctx.nbits):
             decoded = ctx.decode(i)
-            self.assertIsInstance(decoded, fp.Float, f'i={i}, decoded={decoded}')
-            self.assertEqual(decoded, fp.Float(exp=2, c=i), f'i={i}, decoded={decoded}')
+            assert isinstance(decoded, fp.Float), f'i={i}, decoded={decoded}'
+            assert decoded == fp.Float(exp=2, c=i), f'i={i}, decoded={decoded}'
 
     def test_decode_s4(self):
         ctx = fp.FixedContext(True, 0, 4)
         # non-negative values
         for i in range(1 << (ctx.nbits - 1)):
             decoded = ctx.decode(i)
-            self.assertIsInstance(decoded, fp.Float, f'i={i}, decoded={decoded}')
-            self.assertEqual(int(decoded), i, f'i={i}, decoded={decoded}')
+            assert isinstance(decoded, fp.Float), f'i={i}, decoded={decoded}'
+            assert int(decoded) == i, f'i={i}, decoded={decoded}'
         # negative values
         for i in range(1 << (ctx.nbits - 1), 1 << ctx.nbits):
             decoded = ctx.decode(i)
-            self.assertIsInstance(decoded, fp.Float, f'i={i}, decoded={decoded}')
-            self.assertEqual(int(decoded), i - (1 << ctx.nbits), f'i={i}, decoded={decoded}')
+            assert isinstance(decoded, fp.Float), f'i={i}, decoded={decoded}'
+            assert int(decoded) == i - (1 << ctx.nbits), f'i={i}, decoded={decoded}'
 
     def test_decode_s4_scale2(self):
         ctx = fp.FixedContext(True, 2, 4)
         # non-negative values
         for i in range(1 << (ctx.nbits - 1)):
             decoded = ctx.decode(i)
-            self.assertIsInstance(decoded, fp.Float, f'i={i}, decoded={decoded}')
-            self.assertEqual(decoded, fp.Float(False, 2, i), f'i={i}, decoded={decoded}')
+            assert isinstance(decoded, fp.Float), f'i={i}, decoded={decoded}'
+            assert decoded == fp.Float(False, 2, i), f'i={i}, decoded={decoded}'
         # negative values
         for i in range(1 << (ctx.nbits - 1), 1 << ctx.nbits):
             decoded = ctx.decode(i)
-            self.assertIsInstance(decoded, fp.Float, f'i={i}, decoded={decoded}')
-            self.assertEqual(decoded, fp.Float(True, 2, (1 << ctx.nbits) - i), f'i={i}, decoded={decoded}')
+            assert isinstance(decoded, fp.Float), f'i={i}, decoded={decoded}'
+            assert decoded == fp.Float(True, 2, (1 << ctx.nbits) - i), f'i={i}, decoded={decoded}'

--- a/tests/unit/number/fixed/test_params.py
+++ b/tests/unit/number/fixed/test_params.py
@@ -1,4 +1,3 @@
-import unittest
 
 from fpy2 import (
     UINT8, UINT16, UINT32, UINT64,
@@ -6,56 +5,56 @@ from fpy2 import (
     RealFloat
 )
 
-class TestIntegerParams(unittest.TestCase):
+class TestIntegerParams():
     """Test integer parameters."""
 
     def test_sint8_params(self):
-        self.assertEqual(SINT8.nbits, 8)
-        self.assertEqual(SINT8.maxval(s=True), RealFloat.from_int(-128))
-        self.assertEqual(SINT8.maxval(), RealFloat.from_int(127))
-        self.assertEqual(SINT8.largest(), RealFloat.from_int(127))
-        self.assertEqual(SINT8.smallest(), RealFloat.from_int(-128))
+        assert SINT8.nbits == 8
+        assert SINT8.maxval(s=True) == RealFloat.from_int(-128)
+        assert SINT8.maxval() == RealFloat.from_int(127)
+        assert SINT8.largest() == RealFloat.from_int(127)
+        assert SINT8.smallest() == RealFloat.from_int(-128)
 
     def test_sint16_params(self):
-        self.assertEqual(SINT16.nbits, 16)
-        self.assertEqual(SINT16.maxval(s=True), RealFloat.from_int(-32768))
-        self.assertEqual(SINT16.maxval(), RealFloat.from_int(32767))
-        self.assertEqual(SINT16.largest(), RealFloat.from_int(32767))
-        self.assertEqual(SINT16.smallest(), RealFloat.from_int(-32768))
+        assert SINT16.nbits == 16
+        assert SINT16.maxval(s=True) == RealFloat.from_int(-32768)
+        assert SINT16.maxval() == RealFloat.from_int(32767)
+        assert SINT16.largest() == RealFloat.from_int(32767)
+        assert SINT16.smallest() == RealFloat.from_int(-32768)
 
     def test_sint32_params(self):
-        self.assertEqual(SINT32.nbits, 32)
-        self.assertEqual(SINT32.maxval(s=True), RealFloat.from_int(-2147483648))
-        self.assertEqual(SINT32.maxval(), RealFloat.from_int(2147483647))
-        self.assertEqual(SINT32.largest(), RealFloat.from_int(2147483647))
+        assert SINT32.nbits == 32
+        assert SINT32.maxval(s=True) == RealFloat.from_int(-2147483648)
+        assert SINT32.maxval() == RealFloat.from_int(2147483647)
+        assert SINT32.largest() == RealFloat.from_int(2147483647)
 
     def test_sint64_params(self):
-        self.assertEqual(SINT64.nbits, 64)
-        self.assertEqual(SINT64.maxval(s=True), RealFloat.from_int(-9223372036854775808))
-        self.assertEqual(SINT64.maxval(), RealFloat.from_int(9223372036854775807))
-        self.assertEqual(SINT64.largest(), RealFloat.from_int(9223372036854775807))
-        self.assertEqual(SINT64.smallest(), RealFloat.from_int(-9223372036854775808))
+        assert SINT64.nbits == 64
+        assert SINT64.maxval(s=True) == RealFloat.from_int(-9223372036854775808)
+        assert SINT64.maxval() == RealFloat.from_int(9223372036854775807)
+        assert SINT64.largest() == RealFloat.from_int(9223372036854775807)
+        assert SINT64.smallest() == RealFloat.from_int(-9223372036854775808)
 
     def test_uint8_params(self):
-        self.assertEqual(UINT8.nbits, 8)
-        self.assertEqual(UINT8.maxval(), RealFloat.from_int(255))
-        self.assertEqual(UINT8.largest(), RealFloat.from_int(255))
-        self.assertEqual(UINT8.smallest(), RealFloat.from_int(0))
+        assert UINT8.nbits == 8
+        assert UINT8.maxval() == RealFloat.from_int(255)
+        assert UINT8.largest() == RealFloat.from_int(255)
+        assert UINT8.smallest() == RealFloat.from_int(0)
 
     def test_uint16_params(self):
-        self.assertEqual(UINT16.nbits, 16)
-        self.assertEqual(UINT16.maxval(), RealFloat.from_int(65535))
-        self.assertEqual(UINT16.largest(), RealFloat.from_int(65535))
-        self.assertEqual(UINT16.smallest(), RealFloat.from_int(0))
+        assert UINT16.nbits == 16
+        assert UINT16.maxval() == RealFloat.from_int(65535)
+        assert UINT16.largest() == RealFloat.from_int(65535)
+        assert UINT16.smallest() == RealFloat.from_int(0)
 
     def test_uint32_params(self):
-        self.assertEqual(UINT32.nbits, 32)
-        self.assertEqual(UINT32.maxval(), RealFloat.from_int(4294967295))
-        self.assertEqual(UINT32.largest(), RealFloat.from_int(4294967295))
-        self.assertEqual(UINT32.smallest(), RealFloat.from_int(0))
+        assert UINT32.nbits == 32
+        assert UINT32.maxval() == RealFloat.from_int(4294967295)
+        assert UINT32.largest() == RealFloat.from_int(4294967295)
+        assert UINT32.smallest() == RealFloat.from_int(0)
 
     def test_uint64_params(self):
-        self.assertEqual(UINT64.nbits, 64)
-        self.assertEqual(UINT64.maxval(), RealFloat.from_int(18446744073709551615))
-        self.assertEqual(UINT64.largest(), RealFloat.from_int(18446744073709551615))
-        self.assertEqual(UINT64.smallest(), RealFloat.from_int(0))
+        assert UINT64.nbits == 64
+        assert UINT64.maxval() == RealFloat.from_int(18446744073709551615)
+        assert UINT64.largest() == RealFloat.from_int(18446744073709551615)
+        assert UINT64.smallest() == RealFloat.from_int(0)

--- a/tests/unit/number/ieee754/test_encode.py
+++ b/tests/unit/number/ieee754/test_encode.py
@@ -1,4 +1,3 @@
-import unittest
 import random
 
 from fpy2 import Float, IEEEContext, RM, FP64
@@ -7,7 +6,7 @@ from hypothesis import given, strategies as st
 from ...generators import floats
 
 
-class DecodeTestCase(unittest.TestCase):
+class DecodeTestCase():
     """Testing `IEEEContext.decode()`"""
 
     def test_native(self, num_encodings: int = 10_000):
@@ -17,7 +16,7 @@ class DecodeTestCase(unittest.TestCase):
         # run decode
         for i in encodings:
             x = FP64.decode(i)
-            self.assertIsInstance(x, Float, f'i={i}, x={x}')
+            assert isinstance(x, Float), f'i={i}, x={x}'
 
     def test_small(self, es_max: int = 6, nbits_max: int = 8):
         # iterate over possible contexts
@@ -27,9 +26,9 @@ class DecodeTestCase(unittest.TestCase):
                 # for ctx, decode all possible encodings
                 for i in range(1 << ctx.nbits):
                     x = ctx.decode(i)
-                    self.assertIsInstance(x, Float, f'i={i}, x={x}')
+                    assert isinstance(x, Float), f'i={i}, x={x}'
 
-class EncodeTestCase(unittest.TestCase):
+class EncodeTestCase():
     """Testing `IEEEContext.encode()`"""
 
     def test_native(self, num_encodings: int = 10_000):
@@ -46,9 +45,9 @@ class EncodeTestCase(unittest.TestCase):
         # run encoding
         for x in xs:
             i = FP64.encode(x)
-            self.assertIsInstance(i, int, f'x={x}, i={i}')
-            self.assertGreaterEqual(i, 0, f'x={x}, i={i}')
-            self.assertLess(i, 1 << FP64.nbits, f'x={x}, i={i}')
+            assert isinstance(i, int), f'x={x}, i={i}'
+            assert i >= 0, f'x={x}, i={i}'
+            assert i < 1 << FP64.nbits, f'x={x}, i={i}'
 
     def test_small_exhaustive(self, es_max: int = 6, nbits_max: int = 8):
         # iterate over possible contexts
@@ -63,21 +62,21 @@ class EncodeTestCase(unittest.TestCase):
                             assert ctx.representable_under(x)
 
                             i = ctx.encode(x)
-                            self.assertIsInstance(i, int, f'x={x}, i={i}')
-                            self.assertGreaterEqual(i, 0, f'x={x}, i={i}')
-                            self.assertLess(i, 1 << ctx.nbits, f'x={x}, i={i}')
+                            assert isinstance(i, int), f'x={x}, i={i}'
+                            assert i >= 0, f'x={x}, i={i}'
+                            assert i < 1 << ctx.nbits, f'x={x}, i={i}'
 
     @given(floats(prec_max=3, exp_min=-10, exp_max=10, ctx=IEEEContext(2, 5)))
     def test_ieee2_5(self, x: Float):
         """Test encoding for IEEEContext(2, 5)"""
         ctx = IEEEContext(2, 5)
         i = ctx.encode(x)
-        self.assertIsInstance(i, int, f'x={x}, i={i}')
-        self.assertGreaterEqual(i, 0, f'x={x}, i={i}')
-        self.assertLess(i, 1 << ctx.nbits, f'x={x}, i={i}')
+        assert isinstance(i, int), f'x={x}, i={i}'
+        assert i >= 0, f'x={x}, i={i}'
+        assert i < 1 << ctx.nbits, f'x={x}, i={i}'
 
 
-class EncodeRoundTripTestCase(unittest.TestCase):
+class EncodeRoundTripTestCase():
     """Ensure `IEEEContext.decode()` and `IEEEContext.encode()` roundtrips."""
 
     def test_native(self, num_encodings: int = 10_000):
@@ -91,9 +90,9 @@ class EncodeRoundTripTestCase(unittest.TestCase):
             if x.isnan:
                 # mapped to +/-qNaN(0)
                 y = FP64.decode(j)
-                self.assertTrue(y.isnan, f'i={i}, j={j}, y={y}')
+                assert y.isnan, f'i={i}, j={j}, y={y}'
             else:
-                self.assertEqual(i, j, f'i={i}, j={j}')
+                assert i == j, f'i={i}, j={j}'
 
     def test_small(self, es_max: int = 6, nbits_max: int = 8):
         # iterate over possible contexts
@@ -107,6 +106,6 @@ class EncodeRoundTripTestCase(unittest.TestCase):
                     if x.isnan:
                         # mapped to +/-qNaN(0)
                         y = ctx.decode(j)
-                        self.assertTrue(y.isnan, f'i={i}, j={j}, y={y}')
+                        assert y.isnan, f'i={i}, j={j}, y={y}'
                     else:
-                        self.assertEqual(i, j, f'i={i}, j={j}')
+                        assert i == j, f'i={i}, j={j}'

--- a/tests/unit/number/ieee754/test_ordinal.py
+++ b/tests/unit/number/ieee754/test_ordinal.py
@@ -1,4 +1,3 @@
-import unittest
 import random
 
 from fpy2 import Float, IEEEContext, RM
@@ -9,7 +8,7 @@ def _maxval_ordinal(ctx: IEEEContext):
     return (num_binades << (ctx.pmax - 1)) - 1
 
 
-class ToOrdinalTestCase(unittest.TestCase):
+class ToOrdinalTestCase():
     """Testing `IEEEContext.to_ordinal()`"""
 
     def test_native(self, num_encodings: int = 10_000):
@@ -28,9 +27,9 @@ class ToOrdinalTestCase(unittest.TestCase):
         # run ordinal conversion
         for x in xs:
             i = fp64.to_ordinal(x)
-            self.assertIsInstance(i, int, f'x={x}, i={i}')
-            self.assertGreaterEqual(i, -(1 << fp64.nbits - 1), f'x={x}, i={i}')
-            self.assertLess(i, 1 << fp64.nbits - 1, f'x={x}, i={i}')
+            assert isinstance(i, int), f'x={x}, i={i}'
+            assert i >= -(1 << fp64.nbits - 1), f'x={x}, i={i}'
+            assert i < 1 << fp64.nbits - 1, f'x={x}, i={i}'
 
     def test_small(self, es_max: int = 6, nbits_max: int = 8):
         # iterate over possible contexts
@@ -45,9 +44,9 @@ class ToOrdinalTestCase(unittest.TestCase):
                             assert ctx.representable_under(x)
 
                             i = ctx.to_ordinal(x)
-                            self.assertIsInstance(i, int, f'x={x}, i={i}')
-                            self.assertGreaterEqual(i, -(1 << ctx.nbits - 1), f'x={x}, i={i}')
-                            self.assertLess(i, 1 << ctx.nbits - 1, f'x={x}, i={i}')
+                            assert isinstance(i, int), f'x={x}, i={i}'
+                            assert i >= -(1 << ctx.nbits - 1), f'x={x}, i={i}'
+                            assert i < 1 << ctx.nbits - 1, f'x={x}, i={i}'
 
     def test_values_native(self):
         # rounding context for native Python floats
@@ -64,7 +63,7 @@ class ToOrdinalTestCase(unittest.TestCase):
 
         for x, expect in tests:
             i = fp64.to_ordinal(x)
-            self.assertEqual(i, expect, f'x={x}, i={i}, expect={expect}')
+            assert i == expect, f'x={x}, i={i}, expect={expect}'
 
     def test_values_small(self, es_max: int = 6, nbits_max: int = 8):
         # rounding context for native Python floats
@@ -84,10 +83,10 @@ class ToOrdinalTestCase(unittest.TestCase):
 
                 for x, expect in tests:
                     i = ctx.to_ordinal(x)
-                    self.assertEqual(i, expect, f'x={x}, i={i}, expect={expect}')
+                    assert i == expect, f'x={x}, i={i}, expect={expect}'
 
 
-class OrdinalRoundTripTestCase(unittest.TestCase):
+class OrdinalRoundTripTestCase():
     """Ensure `IEEEContext.to_ordinal()` and `IEEEContext.from_ordinal()` roundtrips."""
     
     def test_native(self, num_encodings: int = 10_000):
@@ -107,8 +106,8 @@ class OrdinalRoundTripTestCase(unittest.TestCase):
         for x in xs:
             i = fp64.to_ordinal(x)
             y = fp64.from_ordinal(i)
-            self.assertIsInstance(y, Float, f'x={x}, i={i}, y={y}')
-            self.assertEqual(x, y, f'x={x}, i={i}, y={y}')
+            assert isinstance(y, Float), f'x={x}, i={i}, y={y}'
+            assert x == y, f'x={x}, i={i}, y={y}'
 
     def test_small(self, es_max: int = 6, nbits_max: int = 8):
         # iterate over possible contexts
@@ -125,7 +124,7 @@ class OrdinalRoundTripTestCase(unittest.TestCase):
                             # run ordinal conversion
                             i = ctx.to_ordinal(x)
                             y = ctx.from_ordinal(i)
-                            self.assertIsInstance(y, Float, f'x={x}, i={i}, y={y}')
-                            self.assertEqual(x, y, f'x={x}, i={i}, y={y}')
+                            assert isinstance(y, Float), f'x={x}, i={i}, y={y}'
+                            assert x == y, f'x={x}, i={i}, y={y}'
 
 

--- a/tests/unit/number/ieee754/test_params.py
+++ b/tests/unit/number/ieee754/test_params.py
@@ -1,39 +1,38 @@
-import unittest
 
 from fpy2 import FP128, FP32, FP64, FP16
 
 
-class TestIEEE754Params(unittest.TestCase):
+class TestIEEE754Params():
     """Test IEEE-754 floating-point parameters."""
 
     def test_fp128_params(self):
-        self.assertEqual(FP128.nbits, 128)
-        self.assertEqual(FP128.pmax, 113)
-        self.assertEqual(FP128.emin, -16382)
-        self.assertEqual(FP128.emax, 16383)
-        self.assertEqual(FP128.expmin, -16494)
-        self.assertEqual(FP128.expmax, 16271)
+        assert FP128.nbits == 128
+        assert FP128.pmax == 113
+        assert FP128.emin == -16382
+        assert FP128.emax == 16383
+        assert FP128.expmin == -16494
+        assert FP128.expmax == 16271
 
     def test_fp64_params(self):
-        self.assertEqual(FP64.nbits, 64)
-        self.assertEqual(FP64.pmax, 53)
-        self.assertEqual(FP64.emin, -1022)
-        self.assertEqual(FP64.emax, 1023)
-        self.assertEqual(FP64.expmin, -1074)
-        self.assertEqual(FP64.expmax, 971)
+        assert FP64.nbits == 64
+        assert FP64.pmax == 53
+        assert FP64.emin == -1022
+        assert FP64.emax == 1023
+        assert FP64.expmin == -1074
+        assert FP64.expmax == 971
 
     def test_fp32_params(self):
-        self.assertEqual(FP32.nbits, 32)
-        self.assertEqual(FP32.pmax, 24)
-        self.assertEqual(FP32.emin, -126)
-        self.assertEqual(FP32.emax, 127)
-        self.assertEqual(FP32.expmin, -149)
-        self.assertEqual(FP32.expmax, 104)
+        assert FP32.nbits == 32
+        assert FP32.pmax == 24
+        assert FP32.emin == -126
+        assert FP32.emax == 127
+        assert FP32.expmin == -149
+        assert FP32.expmax == 104
 
     def test_fp16_params(self):
-        self.assertEqual(FP16.nbits, 16)
-        self.assertEqual(FP16.pmax, 11)
-        self.assertEqual(FP16.emin, -14)
-        self.assertEqual(FP16.emax, 15)
-        self.assertEqual(FP16.expmin, -24)
-        self.assertEqual(FP16.expmax, 5)
+        assert FP16.nbits == 16
+        assert FP16.pmax == 11
+        assert FP16.emin == -14
+        assert FP16.emax == 15
+        assert FP16.expmin == -24
+        assert FP16.expmax == 5

--- a/tests/unit/number/ieee754/test_round.py
+++ b/tests/unit/number/ieee754/test_round.py
@@ -1,7 +1,6 @@
 import math
 import random
 import re
-import unittest
 
 from fpy2 import Float, IEEEContext, RM
 
@@ -27,7 +26,7 @@ def _float_as_real(x: float):
         exp = int(e_str) - 4 * len(c_str)
         return Float(s=s, exp=exp, c=c)
 
-class RoundTestCase(unittest.TestCase):
+class RoundTestCase():
     """Testing `IEEEContext.round()`"""
 
     def test_native(self, num_values: int = 10_000, mantissa_len=128):
@@ -46,4 +45,4 @@ class RoundTestCase(unittest.TestCase):
         for x in xs:
             f1 = _float_as_real(float(x))
             f2 = fp64.round(x)
-            self.assertEqual(f1, f2, f'x={x}, f1={f1}, f2={f2}')
+            assert f1 == f2, f'x={x}, f1={f1}, f2={f2}'

--- a/tests/unit/number/mp_fixed/test_ordinal.py
+++ b/tests/unit/number/mp_fixed/test_ordinal.py
@@ -1,6 +1,5 @@
 
 import fpy2 as fp
-import unittest
 
 from fractions import Fraction
 from hypothesis import given, strategies as st
@@ -18,24 +17,24 @@ EXT_EXPMIN = 2 * EXPMIN
 CTX = fp.MPFixedContext(EXPMIN - 1)
 
 
-class OrdinalTestCase(unittest.TestCase):
+class OrdinalTestCase():
     """Testing ordinal methods of `MPSFloatContext`."""
 
     @given(floats(prec_max=PREC, exp_min=CTX.expmin, exp_max=EXPMAX, allow_nan=False, allow_infinity=False))
     def test_to_ordinal(self, x: fp.Float):
         ord = CTX.to_ordinal(x)
-        self.assertIsInstance(ord, int)
+        assert isinstance(ord, int)
 
     @given(st.integers())
     def test_from_ordinal(self, ord: int):
         x = CTX.from_ordinal(ord)
-        self.assertIsInstance(x, fp.Float)
+        assert isinstance(x, fp.Float)
 
     @given(st.integers())
     def test_round_trip(self, ord: int):
         x = CTX.from_ordinal(ord)
         ord2 = CTX.to_ordinal(x)
-        self.assertEqual(ord, ord2)
+        assert ord == ord2
 
     @given(floats(prec_max=EXT_PREC, exp_min=EXT_EXPMIN, exp_max=EXT_EXPMAX, allow_nan=False, allow_infinity=False))
     def test_to_fractional_ordinal(self, x: fp.Float):
@@ -43,6 +42,6 @@ class OrdinalTestCase(unittest.TestCase):
         ord_above = CTX.to_ordinal(CTX.with_params(rm=fp.RM.RTP).round(x))
         ord_below = CTX.to_ordinal(CTX.with_params(rm=fp.RM.RTN).round(x))
 
-        self.assertIsInstance(ord, Fraction)
-        self.assertGreaterEqual(ord, ord_below)
-        self.assertLessEqual(ord, ord_above)
+        assert isinstance(ord, Fraction)
+        assert ord >= ord_below
+        assert ord <= ord_above

--- a/tests/unit/number/mp_fixed/test_round.py
+++ b/tests/unit/number/mp_fixed/test_round.py
@@ -1,14 +1,13 @@
 import fpy2 as fp
 import numpy as np
 import random
-import unittest
 
 from hypothesis import given, strategies as st
 
 from ...generators import floats
 
 
-class RoundTestCase(unittest.TestCase):
+class RoundTestCase():
     """Testing rounding methods of `MPFixedContext`."""
 
     @given(
@@ -23,9 +22,9 @@ class RoundTestCase(unittest.TestCase):
         rounded = ctx.round(x)
         rtz = ctx_rtz.round(x)
         raz = ctx_raz.round(x)
-        self.assertIsInstance(rounded, fp.Float)
-        self.assertTrue(rounded == rtz or rounded == raz)
-        self.assertEqual(rtz == raz, not rounded.inexact)
+        assert isinstance(rounded, fp.Float)
+        assert rounded == rtz or rounded == raz
+        assert rtz == raz == not rounded.inexact
 
     @given(
         floats(prec_max=16, exp_min=-32, exp_max=32, allow_nan=False, allow_infinity=False),
@@ -40,6 +39,6 @@ class RoundTestCase(unittest.TestCase):
         rounded = ctx.round(x)
         rtz = ctx_rtz.round(x)
         raz = ctx_raz.round(x)
-        self.assertIsInstance(rounded, fp.Float)
-        self.assertTrue(rounded == rtz or rounded == raz)
-        self.assertEqual(rtz == raz, not rounded.inexact)
+        assert isinstance(rounded, fp.Float)
+        assert rounded == rtz or rounded == raz
+        assert rtz == raz == not rounded.inexact

--- a/tests/unit/number/mp_fixed/test_round.py
+++ b/tests/unit/number/mp_fixed/test_round.py
@@ -24,7 +24,7 @@ class RoundTestCase():
         raz = ctx_raz.round(x)
         assert isinstance(rounded, fp.Float)
         assert rounded == rtz or rounded == raz
-        assert rtz == raz == not rounded.inexact
+        assert (rtz == raz) == (not rounded.inexact)
 
     @given(
         floats(prec_max=16, exp_min=-32, exp_max=32, allow_nan=False, allow_infinity=False),
@@ -41,4 +41,4 @@ class RoundTestCase():
         raz = ctx_raz.round(x)
         assert isinstance(rounded, fp.Float)
         assert rounded == rtz or rounded == raz
-        assert rtz == raz == not rounded.inexact
+        assert (rtz == raz) == (not rounded.inexact)

--- a/tests/unit/number/mp_float/test_normalize.py
+++ b/tests/unit/number/mp_float/test_normalize.py
@@ -1,9 +1,8 @@
 import random
-import unittest
 
 from fpy2 import Float, MPFloatContext, RM
 
-class NormalizeTestCase(unittest.TestCase):
+class NormalizeTestCase():
     """Testing `IEEEContext.normalize()`"""
 
     def test_normalize(self, num_values: int = 10_000, p_max: int = 128):
@@ -24,7 +23,7 @@ class NormalizeTestCase(unittest.TestCase):
 
             # check expected
             if x.is_zero():
-                self.assertTrue(y.is_zero(), f'x={x}, y={y}')
+                assert y.is_zero(), f'x={x}, y={y}'
             else:
-                self.assertEqual(x, y, f'x={x}, y={y}')
-                self.assertEqual(y.p, p_max, f'x={x}, y={y} (p={y.p})')
+                assert x == y, f'x={x}, y={y}'
+                assert y.p == p_max, f'x={x}, y={y} (p={y.p})'

--- a/tests/unit/number/mp_float/test_round.py
+++ b/tests/unit/number/mp_float/test_round.py
@@ -1,6 +1,5 @@
 import gmpy2 as gmp
 import random
-import unittest
 
 from fpy2 import RealFloat, MPFloatContext, RM
 
@@ -42,7 +41,7 @@ def _round_mpfr(x: RealFloat, ctx: MPFloatContext) -> RealFloat:
 
     return RealFloat(s=s, exp=exp, c=c)
 
-class RoundTestCase(unittest.TestCase):
+class RoundTestCase():
     """Testing `IEEEContext.round()`"""
 
     def test_mpfr(self, num_values: int = 10_000, p_max: int = 128, e_max=1024):
@@ -66,4 +65,4 @@ class RoundTestCase(unittest.TestCase):
             yf = _round_mpfr(x, ctx)
 
             # check that they are equal
-            self.assertEqual(y, yf, f'x={x}, y={y}, yf={yf}')
+            assert y == yf, f'x={x}, y={y}, yf={yf}'

--- a/tests/unit/number/mpb_fixed/test_round.py
+++ b/tests/unit/number/mpb_fixed/test_round.py
@@ -1,9 +1,8 @@
 import random
-import unittest
 
 from fpy2 import MPBFixedContext, RealFloat, RM, OV
 
-class RoundTestCase(unittest.TestCase):
+class RoundTestCase():
     """Testing `MPBFixedContext.round()`"""
 
     def test_fuzz(self, num_values: int = 10_000, expmin: int = -24, expmax: int = 24, pmax: int = 12):
@@ -38,11 +37,11 @@ class RoundTestCase(unittest.TestCase):
 
         # saturation
         sat_ctx = MPBFixedContext(-1, limit, RM.RTZ, OV.SATURATE)
-        self.assertEqual(sat_ctx.round(x), limit)
-        self.assertEqual(sat_ctx.round(neg_x), -limit)
+        assert sat_ctx.round(x) == limit
+        assert sat_ctx.round(neg_x) == -limit
 
         # wrap
         wrap_ctx = MPBFixedContext(-1, limit, RM.RTZ, OV.WRAP)
-        self.assertEqual(wrap_ctx.round(x), -limit)
-        self.assertEqual(wrap_ctx.round(neg_x), limit)
+        assert wrap_ctx.round(x) == -limit
+        assert wrap_ctx.round(neg_x) == limit
 

--- a/tests/unit/number/mps_float/test_ordinal.py
+++ b/tests/unit/number/mps_float/test_ordinal.py
@@ -1,6 +1,5 @@
 
 import fpy2 as fp
-import unittest
 
 from fractions import Fraction
 from hypothesis import given, strategies as st
@@ -18,24 +17,24 @@ EXT_EXPMIN = 2 * EXPMIN
 CTX = fp.MPSFloatContext(PREC, EXPMIN - 1)
 
 
-class OrdinalTestCast(unittest.TestCase):
+class OrdinalTestCast():
     """Testing ordinal methods of `MPSFloatContext`."""
 
     @given(floats(prec_max=CTX.pmax, exp_min=CTX.expmin, exp_max=EXPMAX, allow_nan=False, allow_infinity=False))
     def test_to_ordinal(self, x: fp.Float):
         ord = CTX.to_ordinal(x)
-        self.assertIsInstance(ord, int)
+        assert isinstance(ord, int)
 
     @given(st.integers())
     def test_from_ordinal(self, ord: int):
         x = CTX.from_ordinal(ord)
-        self.assertIsInstance(x, fp.Float)
+        assert isinstance(x, fp.Float)
 
     @given(st.integers())
     def test_round_trip(self, ord: int):
         x = CTX.from_ordinal(ord)
         ord2 = CTX.to_ordinal(x)
-        self.assertEqual(ord, ord2)
+        assert ord == ord2
 
     @given(floats(prec_max=EXT_PREC, exp_min=EXT_EXPMIN, exp_max=EXT_EXPMAX, allow_nan=False, allow_infinity=False))
     def test_to_fractional_ordinal(self, x: fp.Float):
@@ -43,6 +42,6 @@ class OrdinalTestCast(unittest.TestCase):
         ord_above = CTX.to_ordinal(CTX.with_params(rm=fp.RM.RTP).round(x))
         ord_below = CTX.to_ordinal(CTX.with_params(rm=fp.RM.RTN).round(x))
 
-        self.assertIsInstance(ord, Fraction)
-        self.assertGreaterEqual(ord, ord_below)
-        self.assertLessEqual(ord, ord_above)
+        assert isinstance(ord, Fraction)
+        assert ord >= ord_below
+        assert ord <= ord_above

--- a/tests/unit/number/mps_float/test_ordinal.py
+++ b/tests/unit/number/mps_float/test_ordinal.py
@@ -17,7 +17,7 @@ EXT_EXPMIN = 2 * EXPMIN
 CTX = fp.MPSFloatContext(PREC, EXPMIN - 1)
 
 
-class OrdinalTestCast():
+class TestOrdinal():
     """Testing ordinal methods of `MPSFloatContext`."""
 
     @given(floats(prec_max=CTX.pmax, exp_min=CTX.expmin, exp_max=EXPMAX, allow_nan=False, allow_infinity=False))

--- a/tests/unit/number/number/test_compare.py
+++ b/tests/unit/number/number/test_compare.py
@@ -64,34 +64,34 @@ class TestCompareMethods():
     def test_compare_eq(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        assert a == b == af == bf, f'Failed comparison: {a} == {b} ({af} == {bf})'
+        assert (a == b) == (af == bf), f'Failed comparison: {a} == {b} ({af} == {bf})'
 
     @given(number(), number())
     def test_compare_ne(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        assert a != b == af != bf, f'Failed comparison: {a} != {b} ({af} != {bf})'
+        assert (a != b) == (af != bf), f'Failed comparison: {a} != {b} ({af} != {bf})'
 
     @given(number(), number())
     def test_compare_lt(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        assert a < b == af < bf, f'Failed comparison: {a} < {b} ({af} < {bf})'
+        assert (a < b) == (af < bf), f'Failed comparison: {a} < {b} ({af} < {bf})'
 
     @given(number(), number())
     def test_compare_le(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        assert a <= b == af <= bf, f'Failed comparison: {a} <= {b} ({af} <= {bf})'
+        assert (a <= b) == (af <= bf), f'Failed comparison: {a} <= {b} ({af} <= {bf})'
 
     @given(number(), number())
     def test_compare_gt(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        assert a > b == af > bf, f'Failed comparison: {a} > {b} ({af} > {bf})'
+        assert (a > b) == (af > bf), f'Failed comparison: {a} > {b} ({af} > {bf})'
 
     @given(number(), number())
     def test_compare_ge(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        assert a >= b == af >= bf, f'Failed comparison: {a} >= {b}  ({af} >= {bf})'
+        assert (a >= b) == (af >= bf), f'Failed comparison: {a} >= {b}  ({af} >= {bf})'

--- a/tests/unit/number/number/test_compare.py
+++ b/tests/unit/number/number/test_compare.py
@@ -3,7 +3,6 @@ Testing `Float` and `REalFloat` comparison methods.
 """
 
 import fpy2 as fp
-import unittest
 
 from fractions import Fraction
 from hypothesis import given, strategies as st
@@ -59,40 +58,40 @@ def _cvt_to_frac(x: int | float | Fraction | fp.RealFloat | fp.Float) -> float |
             raise TypeError(f'cannot convert {type(x)} to Fraction or float')
 
 
-class TestCompareMethods(unittest.TestCase):
+class TestCompareMethods():
 
     @given(number(), number())
     def test_compare_eq(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        self.assertEqual(a == b, af == bf, f'Failed comparison: {a} == {b} ({af} == {bf})')
+        assert a == b == af == bf, f'Failed comparison: {a} == {b} ({af} == {bf})'
 
     @given(number(), number())
     def test_compare_ne(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        self.assertEqual(a != b, af != bf, f'Failed comparison: {a} != {b} ({af} != {bf})')
+        assert a != b == af != bf, f'Failed comparison: {a} != {b} ({af} != {bf})'
 
     @given(number(), number())
     def test_compare_lt(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        self.assertEqual(a < b, af < bf, f'Failed comparison: {a} < {b} ({af} < {bf})')
+        assert a < b == af < bf, f'Failed comparison: {a} < {b} ({af} < {bf})'
 
     @given(number(), number())
     def test_compare_le(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        self.assertEqual(a <= b, af <= bf, f'Failed comparison: {a} <= {b} ({af} <= {bf})')
+        assert a <= b == af <= bf, f'Failed comparison: {a} <= {b} ({af} <= {bf})'
 
     @given(number(), number())
     def test_compare_gt(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        self.assertEqual(a > b, af > bf, f'Failed comparison: {a} > {b} ({af} > {bf})')
+        assert a > b == af > bf, f'Failed comparison: {a} > {b} ({af} > {bf})'
 
     @given(number(), number())
     def test_compare_ge(self, a, b):
         af = _cvt_to_frac(a)
         bf = _cvt_to_frac(b)
-        self.assertEqual(a >= b, af >= bf, f'Failed comparison: {a} >= {b}  ({af} >= {bf})')
+        assert a >= b == af >= bf, f'Failed comparison: {a} >= {b}  ({af} >= {bf})'

--- a/tests/unit/number/number/test_flags.py
+++ b/tests/unit/number/number/test_flags.py
@@ -1,5 +1,4 @@
 import fpy2 as fp
-import unittest
 
 from hypothesis import assume, given, strategies as st
 from ...generators import real_floats
@@ -51,7 +50,7 @@ class ReferenceFlags:
         return tiny_post and inexact
 
 
-class TestRoundFlags(unittest.TestCase):
+class TestRoundFlags():
     """Testing status flags set by `RealFloat.round()`."""
 
     @given(
@@ -64,7 +63,7 @@ class TestRoundFlags(unittest.TestCase):
         assume(p is not None or n is not None)
         rounded = x.round(max_p=p, min_n=n, rm=rm)
         inexact = ReferenceFlags.inexact(x, p, n, rm)
-        self.assertEqual(rounded.inexact, inexact, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, inexact={inexact}')
+        assert rounded.inexact == inexact, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, inexact={inexact}'
 
     @given(
         real_floats(prec_max=16, exp_min=-16, exp_max=16),
@@ -76,7 +75,7 @@ class TestRoundFlags(unittest.TestCase):
         assume(p is not None or n is not None)
         rounded = x.round(max_p=p, min_n=n, rm=rm)
         carry = ReferenceFlags.carry(x, p, n, rm)
-        self.assertEqual(rounded.carry, carry, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, carry={carry}')
+        assert rounded.carry == carry, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, carry={carry}'
 
     @given(
         real_floats(prec_max=16, exp_min=-16, exp_max=16),
@@ -88,7 +87,7 @@ class TestRoundFlags(unittest.TestCase):
         assume(p is not None or n is not None)
         rounded = x.round(max_p=p, min_n=n, rm=rm)
         tiny_pre = ReferenceFlags.tiny_pre(x, p, n, rm)
-        self.assertEqual(rounded.tiny_pre, tiny_pre, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, tiny_pre={tiny_pre}')
+        assert rounded.tiny_pre == tiny_pre, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, tiny_pre={tiny_pre}'
 
     @given(
         real_floats(prec_max=16, exp_min=-16, exp_max=16),
@@ -100,7 +99,7 @@ class TestRoundFlags(unittest.TestCase):
         assume(p is not None or n is not None)
         rounded = x.round(max_p=p, min_n=n, rm=rm)
         tiny_post = ReferenceFlags.tiny_post(x, p, n, rm)
-        self.assertEqual(rounded.tiny_post, tiny_post, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, tiny_post={tiny_post}')
+        assert rounded.tiny_post == tiny_post, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, tiny_post={tiny_post}'
 
     @given(
         real_floats(prec_max=16, exp_min=-16, exp_max=16),
@@ -112,7 +111,7 @@ class TestRoundFlags(unittest.TestCase):
         assume(p is not None or n is not None)
         rounded = x.round(max_p=p, min_n=n, rm=rm)
         underflow_pre = ReferenceFlags.underflow_pre(x, p, n, rm)
-        self.assertEqual(rounded.underflow_pre, underflow_pre, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, underflow_pre={underflow_pre}')
+        assert rounded.underflow_pre == underflow_pre, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, underflow_pre={underflow_pre}'
 
     @given(
         real_floats(prec_max=16, exp_min=-16, exp_max=16),
@@ -124,10 +123,10 @@ class TestRoundFlags(unittest.TestCase):
         assume(p is not None or n is not None)
         rounded = x.round(max_p=p, min_n=n, rm=rm)
         underflow_post = ReferenceFlags.underflow_post(x, p, n, rm)
-        self.assertEqual(rounded.underflow_post, underflow_post, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, underflow_post={underflow_post}')
+        assert rounded.underflow_post == underflow_post, f'x={x}, p={p}, n={n}, rm={rm!r}, rounded={rounded!r}, underflow_post={underflow_post}'
 
 
-class TestArithmeticFlags(unittest.TestCase):
+class TestArithmeticFlags():
     """Testing `invalid` and `divzero` flags set by mathematical operations."""
 
     _CTX = fp.FP64
@@ -139,13 +138,13 @@ class TestArithmeticFlags(unittest.TestCase):
         # no invalid: NaN result propagated from a NaN input
         nan = fp.Float.nan()
         r = fp.add(nan, fp.Float.from_int(1), self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertFalse(r.invalid, f'unexpected invalid flag when NaN propagated from input')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert not r.invalid, f'unexpected invalid flag when NaN propagated from input'
         # no divzero: Inf result propagated from an Inf input
         inf = fp.Float.inf(s=False)
         r = fp.add(inf, fp.Float.from_int(1), self._CTX)
-        self.assertTrue(r.isinf, f'expected Inf, got {r!r}')
-        self.assertFalse(r.divzero, f'unexpected divzero flag when Inf propagated from input')
+        assert r.isinf, f'expected Inf, got {r!r}'
+        assert not r.divzero, f'unexpected divzero flag when Inf propagated from input'
 
     # ------------------------------------------------------------------
     # sub
@@ -154,8 +153,8 @@ class TestArithmeticFlags(unittest.TestCase):
         # invalid: inf - inf
         inf = fp.Float.inf(s=False)
         r = fp.sub(inf, inf, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for inf - inf')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for inf - inf'
 
     # ------------------------------------------------------------------
     # mul
@@ -165,8 +164,8 @@ class TestArithmeticFlags(unittest.TestCase):
         zero = fp.Float.from_int(0)
         inf = fp.Float.inf(s=False)
         r = fp.mul(zero, inf, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for 0 * inf')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for 0 * inf'
 
     # ------------------------------------------------------------------
     # div
@@ -175,17 +174,17 @@ class TestArithmeticFlags(unittest.TestCase):
         # invalid: 0/0 and ∞/∞
         zero = fp.Float.from_int(0)
         r = fp.div(zero, zero, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for 0/0')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for 0/0'
         inf = fp.Float.inf(s=False)
         r = fp.div(inf, inf, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for inf/inf')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for inf/inf'
         # divzero: non-zero finite / 0
         one = fp.Float.from_int(1)
         r = fp.div(one, zero, self._CTX)
-        self.assertTrue(r.isinf, f'expected Inf, got {r!r}')
-        self.assertTrue(r.divzero, f'expected divzero flag for 1/0')
+        assert r.isinf, f'expected Inf, got {r!r}'
+        assert r.divzero, f'expected divzero flag for 1/0'
 
     # ------------------------------------------------------------------
     # sqrt
@@ -194,8 +193,8 @@ class TestArithmeticFlags(unittest.TestCase):
         # invalid: sqrt of a negative finite number
         x = fp.Float.from_int(-1)
         r = fp.sqrt(x, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for sqrt(-1)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for sqrt(-1)'
 
     # ------------------------------------------------------------------
     # fma
@@ -206,8 +205,8 @@ class TestArithmeticFlags(unittest.TestCase):
         inf = fp.Float.inf(s=False)
         one = fp.Float.from_int(1)
         r = fp.fma(zero, inf, one, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for fma(0, inf, 1)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for fma(0, inf, 1)'
 
     # ------------------------------------------------------------------
     # remainder
@@ -217,13 +216,13 @@ class TestArithmeticFlags(unittest.TestCase):
         x = fp.Float.from_int(3)
         zero = fp.Float.from_int(0)
         r = fp.remainder(x, zero, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for remainder(3, 0)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for remainder(3, 0)'
         inf = fp.Float.inf(s=False)
         one = fp.Float.from_int(1)
         r = fp.remainder(inf, one, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for remainder(inf, 1)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for remainder(inf, 1)'
 
     # ------------------------------------------------------------------
     # log / log2 / log10 / log1p
@@ -232,34 +231,34 @@ class TestArithmeticFlags(unittest.TestCase):
         # divzero: log(0)
         zero = fp.Float.from_int(0)
         r = fp.log(zero, self._CTX)
-        self.assertTrue(r.isinf, f'expected Inf, got {r!r}')
-        self.assertTrue(r.divzero, f'expected divzero flag for log(0)')
+        assert r.isinf, f'expected Inf, got {r!r}'
+        assert r.divzero, f'expected divzero flag for log(0)'
         # invalid: log(x) for x < 0
         x = fp.Float.from_int(-1)
         r = fp.log(x, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for log(-1)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for log(-1)'
 
     def test_log2(self):
         # divzero: log2(0)
         zero = fp.Float.from_int(0)
         r = fp.log2(zero, self._CTX)
-        self.assertTrue(r.isinf, f'expected Inf, got {r!r}')
-        self.assertTrue(r.divzero, f'expected divzero flag for log2(0)')
+        assert r.isinf, f'expected Inf, got {r!r}'
+        assert r.divzero, f'expected divzero flag for log2(0)'
 
     def test_log10(self):
         # divzero: log10(0)
         zero = fp.Float.from_int(0)
         r = fp.log10(zero, self._CTX)
-        self.assertTrue(r.isinf, f'expected Inf, got {r!r}')
-        self.assertTrue(r.divzero, f'expected divzero flag for log10(0)')
+        assert r.isinf, f'expected Inf, got {r!r}'
+        assert r.divzero, f'expected divzero flag for log10(0)'
 
     def test_log1p(self):
         # divzero: log1p(-1) = log(0)
         x = fp.Float.from_int(-1)
         r = fp.log1p(x, self._CTX)
-        self.assertTrue(r.isinf, f'expected Inf, got {r!r}')
-        self.assertTrue(r.divzero, f'expected divzero flag for log1p(-1)')
+        assert r.isinf, f'expected Inf, got {r!r}'
+        assert r.divzero, f'expected divzero flag for log1p(-1)'
 
     # ------------------------------------------------------------------
     # sin / cos / tan
@@ -268,22 +267,22 @@ class TestArithmeticFlags(unittest.TestCase):
         # invalid: sin(∞)
         inf = fp.Float.inf(s=False)
         r = fp.sin(inf, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for sin(inf)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for sin(inf)'
 
     def test_cos(self):
         # invalid: cos(∞)
         inf = fp.Float.inf(s=False)
         r = fp.cos(inf, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for cos(inf)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for cos(inf)'
 
     def test_tan(self):
         # invalid: tan(∞)
         inf = fp.Float.inf(s=False)
         r = fp.tan(inf, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for tan(inf)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for tan(inf)'
 
     # ------------------------------------------------------------------
     # asin / acos
@@ -292,15 +291,15 @@ class TestArithmeticFlags(unittest.TestCase):
         # invalid: asin(x) for |x| > 1
         x = fp.Float.from_int(2)
         r = fp.asin(x, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for asin(2)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for asin(2)'
 
     def test_acos(self):
         # invalid: acos(x) for |x| > 1
         x = fp.Float.from_int(-2)
         r = fp.acos(x, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for acos(-2)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for acos(-2)'
 
     # ------------------------------------------------------------------
     # atanh / acosh
@@ -309,20 +308,20 @@ class TestArithmeticFlags(unittest.TestCase):
         # divzero: atanh(1)
         one = fp.Float.from_int(1)
         r = fp.atanh(one, self._CTX)
-        self.assertTrue(r.isinf, f'expected Inf, got {r!r}')
-        self.assertTrue(r.divzero, f'expected divzero flag for atanh(1)')
+        assert r.isinf, f'expected Inf, got {r!r}'
+        assert r.divzero, f'expected divzero flag for atanh(1)'
         # invalid: atanh(x) for |x| > 1
         x = fp.Float.from_int(2)
         r = fp.atanh(x, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for atanh(2)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for atanh(2)'
 
     def test_acosh(self):
         # invalid: acosh(x) for x < 1
         x = fp.Float.from_int(0)
         r = fp.acosh(x, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for acosh(0)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for acosh(0)'
 
     # ------------------------------------------------------------------
     # pow
@@ -332,5 +331,5 @@ class TestArithmeticFlags(unittest.TestCase):
         x = fp.Float.from_int(-2)
         y = fp.Float.from_float(0.5)
         r = fp.pow(x, y, self._CTX)
-        self.assertTrue(r.isnan, f'expected NaN, got {r!r}')
-        self.assertTrue(r.invalid, f'expected invalid flag for pow(-2, 0.5)')
+        assert r.isnan, f'expected NaN, got {r!r}'
+        assert r.invalid, f'expected invalid flag for pow(-2, 0.5)'

--- a/tests/unit/number/number/test_float.py
+++ b/tests/unit/number/number/test_float.py
@@ -1,6 +1,6 @@
+import pytest
 import fpy2 as fp
 import math
-import unittest
 
 from fractions import Fraction
 from hypothesis import given, strategies as st
@@ -36,7 +36,7 @@ def _cvt_to_real(x: float | int | Fraction | fp.Float):
             raise TypeError(f"Unsupported type: {type(x)}")
 
 
-class FloatTestCast(unittest.TestCase):
+class FloatTestCast():
 
     def assertEqualOrNan(
         self,
@@ -47,9 +47,9 @@ class FloatTestCast(unittest.TestCase):
         a = _cvt_to_real(first)
         b = _cvt_to_real(second)
         if a.isnan:
-            self.assertTrue(b.isnan, msg=msg)
+            assert b.isnan, msg
         else:
-            self.assertEqual(a, b, msg=msg)
+            assert a == b, msg
 
 
 class TestFloatConstructors(FloatTestCast):
@@ -57,24 +57,24 @@ class TestFloatConstructors(FloatTestCast):
     @given(st.integers())
     def test_from_int(self, x):
         y = fp.Float.from_int(x)
-        self.assertIsInstance(y, fp.Float)
-        self.assertEqual(x, int(y))
+        assert isinstance(y, fp.Float)
+        assert x == int(y)
 
     @given(st.floats(allow_nan=True, allow_infinity=True, allow_subnormal=True))
     def test_from_float(self, x):
         y = fp.Float.from_float(x)
-        self.assertIsInstance(y, fp.Float)
+        assert isinstance(y, fp.Float)
         z = float(y)
-        self.assertTrue(math.isnan(z) if math.isnan(x) else z == x)
+        assert math.isnan(z) if math.isnan(x) else z == x
 
     @given(st.fractions(min_value=-1, max_value=1, max_denominator=1000))
     def test_from_rational(self, x):
         if fp.utils.is_dyadic(x):
             y = fp.Float.from_rational(x)
-            self.assertIsInstance(y, fp.Float)
-            self.assertEqual(x, y)
+            assert isinstance(y, fp.Float)
+            assert x == y
         else:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 fp.Float.from_rational(x)
 
 
@@ -83,34 +83,34 @@ class TestFloatReprMethods(FloatTestCast):
     @given(st.integers())
     def test_as_int(self, x):
         y = fp.Float.from_int(x)
-        self.assertEqual(x, int(y))
+        assert x == int(y)
 
     @given(st.floats(allow_nan=False, allow_infinity=False, allow_subnormal=True))
     def test_as_float(self, x):
         y = fp.Float.from_float(x)
-        self.assertEqual(x, float(y))
+        assert x == float(y)
 
     @given(st.fractions(min_value=-1, max_value=1, max_denominator=1000))
     def test_as_rational(self, x):
         if fp.utils.is_dyadic(x):
             y = fp.Float.from_rational(x)
-            self.assertEqual(x, y.as_rational())
+            assert x == y.as_rational()
         else:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 fp.Float.from_rational(x)
 
     @given(floats(prec_max=64, exp_max=512, exp_min=-512), st.integers(-512, 512))
     def test_split(self, x: fp.Float, n: int):
         hi, lo = x.split(n)
-        self.assertIsInstance(hi, fp.Float)
-        self.assertIsInstance(lo, fp.Float)
+        assert isinstance(hi, fp.Float)
+        assert isinstance(lo, fp.Float)
         if x.is_nar():
             self.assertEqualOrNan(x, hi, f'x={x}, n={n}, hi={hi}, lo={lo}')
             self.assertEqualOrNan(x, lo, f'x={x}, n={n}, hi={hi}, lo={lo}')
         else:
-            self.assertEqual(x, hi + lo, f'x={x}, n={n}, hi={hi}, lo={lo}')
-            self.assertTrue(hi.is_more_significant(n), f'x={x}, n={n}, hi={hi}, lo={lo}')
-            self.assertLessEqual(lo.e, n, f'x={x}, n={n}, hi={hi}, lo={lo}')
+            assert x == hi + lo, f'x={x}, n={n}, hi={hi}, lo={lo}'
+            assert hi.is_more_significant(n), f'x={x}, n={n}, hi={hi}, lo={lo}'
+            assert lo.e <= n, f'x={x}, n={n}, hi={hi}, lo={lo}'
 
     @given(
         floats(prec_max=128, exp_min=-512, exp_max=512, ctx=fp.REAL),
@@ -120,15 +120,15 @@ class TestFloatReprMethods(FloatTestCast):
     def test_normalize(self, x: fp.Float, p: int | None, n: int | None):
         try:
             y = x.normalize(p=p, n=n)
-            self.assertIsInstance(y, fp.Float)
+            assert isinstance(y, fp.Float)
             self.assertEqualOrNan(x, y, f'x={x}, p={p}, n={n}, y={y}')
             if not x.is_nar():
                 if p is not None:
-                    self.assertLessEqual(y.p, p, f'x={x}, p={p}, n={n}, y={y}')
+                    assert y.p <= p, f'x={x}, p={p}, n={n}, y={y}'
                 if n is not None:
-                    self.assertGreater(y.exp, n, f'x={x}, p={p}, n={n}, y={y}')
+                    assert y.exp > n, f'x={x}, p={p}, n={n}, y={y}'
         except ValueError:
-            self.assertTrue(p is not None or n is not None, f'x={x}, p={p}, n={n}')
+            assert p is not None or n is not None, f'x={x}, p={p}, n={n}'
 
             # compute the split point
             match p, n:
@@ -142,7 +142,7 @@ class TestFloatReprMethods(FloatTestCast):
                     raise RuntimeError('unreachable')
 
             _, lo = x.split(n)
-            self.assertNotEqual(lo, 0, f'x={x}, p={p}, n={n}')
+            assert lo != 0, f'x={x}, p={p}, n={n}'
 
 
 class TestFloatArithmetic(FloatTestCast):
@@ -163,45 +163,45 @@ class TestFloatArithmetic(FloatTestCast):
     def test_trunc(self, a: float):
         x = fp.Float.from_float(a)
         if x.is_nar():
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 math.trunc(x)
         else:
             expect = math.trunc(_cvt_to_fraction(a))
             actual = math.trunc(x)
-            self.assertEqual(actual, expect)
+            assert actual == expect
 
     @given(st.floats())
     def test_floor(self, a: float):
         x = fp.Float.from_float(a)
         if x.is_nar():
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 math.floor(x)
         else:
             expect = math.floor(_cvt_to_fraction(a))
             actual = math.floor(x)
-            self.assertEqual(actual, expect)
+            assert actual == expect
 
     @given(st.floats())
     def test_ceil(self, a: float):
         x = fp.Float.from_float(a)
         if x.is_nar():
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 math.ceil(x)
         else:
             expect = math.ceil(_cvt_to_fraction(a))
             actual = math.ceil(x)
-            self.assertEqual(actual, expect)
+            assert actual == expect
 
     @given(st.floats())
     def test_round(self, a: float):
         x = fp.Float.from_float(a)
         if x.is_nar():
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 round(x)
         else:
             expect = round(_cvt_to_fraction(a))
             actual = round(x)
-            self.assertEqual(actual, expect)
+            assert actual == expect
 
     @given(st.floats(), st.floats())
     def test_add(self, a: float, b: float):

--- a/tests/unit/number/number/test_real_float.py
+++ b/tests/unit/number/number/test_real_float.py
@@ -1,6 +1,5 @@
 import fpy2 as fp
 import math
-import unittest
 
 from fractions import Fraction
 from hypothesis import assume, given, strategies as st
@@ -8,56 +7,56 @@ from hypothesis import assume, given, strategies as st
 from ...generators import real_floats, rounding_modes
 
 
-class TestRealFloatConstructors(unittest.TestCase):
+class TestRealFloatConstructors():
     """Testing `RealFloat` constructors."""
 
     @given(st.integers())
     def test_from_int(self, a: int):
         x = fp.RealFloat.from_int(a)
-        self.assertIsInstance(x, fp.RealFloat)
-        self.assertEqual(x, a)
+        assert isinstance(x, fp.RealFloat)
+        assert x == a
 
     @given(st.floats(allow_infinity=False, allow_nan=False))
     def test_from_float(self, a: float):
         x = fp.RealFloat.from_float(a)
-        self.assertIsInstance(x, fp.RealFloat)
-        self.assertEqual(x, a)
+        assert isinstance(x, fp.RealFloat)
+        assert x == a
 
     @given(st.fractions(min_value=-1e6, max_value=1e6, max_denominator=1_000_000).filter(
         lambda x: fp.utils.is_dyadic(x)
     ))
     def test_from_rational(self, a: Fraction):
         x = fp.RealFloat.from_rational(a)
-        self.assertIsInstance(x, fp.RealFloat)
-        self.assertEqual(x, a)
+        assert isinstance(x, fp.RealFloat)
+        assert x == a
 
 
-class TestRealFloatReprMethods(unittest.TestCase):
+class TestRealFloatReprMethods():
     """Testing `RealFloat` representation methods"""
 
     def test_is_more_significant(self):
         x = fp.RealFloat(c=7, exp=0)
-        self.assertTrue(x.is_more_significant(-2))
-        self.assertTrue(x.is_more_significant(-1))
-        self.assertFalse(x.is_more_significant(0))
-        self.assertFalse(x.is_more_significant(1))
+        assert x.is_more_significant(-2)
+        assert x.is_more_significant(-1)
+        assert not x.is_more_significant(0)
+        assert not x.is_more_significant(1)
 
         y = fp.RealFloat(c=3, exp=-2)
-        self.assertTrue(y.is_more_significant(-4))
-        self.assertTrue(y.is_more_significant(-3))
-        self.assertFalse(y.is_more_significant(-2))
-        self.assertFalse(y.is_more_significant(-1))
-        self.assertFalse(y.is_more_significant(0))
+        assert y.is_more_significant(-4)
+        assert y.is_more_significant(-3)
+        assert not y.is_more_significant(-2)
+        assert not y.is_more_significant(-1)
+        assert not y.is_more_significant(0)
 
 
     @given(real_floats(prec_max=64, exp_max=512, exp_min=-512), st.integers(-512, 512))
     def test_split(self, x: fp.RealFloat, n: int):
         hi, lo = x.split(n)
-        self.assertIsInstance(hi, fp.RealFloat)
-        self.assertIsInstance(lo, fp.RealFloat)
-        self.assertEqual(x, hi + lo, f'x={x}, n={n}, hi={hi}, lo={lo}')
-        self.assertTrue(hi.is_more_significant(n), f'x={x}, n={n}, hi={hi}, lo={lo}')
-        self.assertLessEqual(lo.e, n, f'x={x}, n={n}, hi={hi}, lo={lo}')
+        assert isinstance(hi, fp.RealFloat)
+        assert isinstance(lo, fp.RealFloat)
+        assert x == hi + lo, f'x={x}, n={n}, hi={hi}, lo={lo}'
+        assert hi.is_more_significant(n), f'x={x}, n={n}, hi={hi}, lo={lo}'
+        assert lo.e <= n, f'x={x}, n={n}, hi={hi}, lo={lo}'
 
     @given(
         real_floats(prec_max=128, exp_min=-512, exp_max=512),
@@ -67,14 +66,14 @@ class TestRealFloatReprMethods(unittest.TestCase):
     def test_normalize(self, x: fp.RealFloat, p: int | None, n: int | None):
         try:
             y = x.normalize(p=p, n=n)
-            self.assertIsInstance(y, fp.RealFloat)
-            self.assertEqual(x, y, f'x={x}, p={p}, n={n}, y={y}')
+            assert isinstance(y, fp.RealFloat)
+            assert x == y, f'x={x}, p={p}, n={n}, y={y}'
             if p is not None:
-                self.assertLessEqual(y.p, p, f'x={x}, p={p}, n={n}, y={y}')
+                assert y.p <= p, f'x={x}, p={p}, n={n}, y={y}'
             if n is not None:
-                self.assertGreater(y.exp, n, f'x={x}, p={p}, n={n}, y={y}')
+                assert y.exp > n, f'x={x}, p={p}, n={n}, y={y}'
         except ValueError:
-            self.assertTrue(p is not None or n is not None, f'x={x}, p={p}, n={n}')
+            assert p is not None or n is not None, f'x={x}, p={p}, n={n}'
 
             # compute the split point
             match p, n:
@@ -88,7 +87,7 @@ class TestRealFloatReprMethods(unittest.TestCase):
                     raise RuntimeError('unreachable')
 
             _, lo = x.split(n)
-            self.assertNotEqual(lo, 0, f'x={x}, p={p}, n={n}')
+            assert lo != 0, f'x={x}, p={p}, n={n}'
 
     @given(
         real_floats(prec_max=128, exp_min=-512, exp_max=512),
@@ -99,13 +98,13 @@ class TestRealFloatReprMethods(unittest.TestCase):
         assume(n is None or x.exp > n)
         assume(p is None or x.p <= p)
         y = x.next_away_zero(p=p, n=n)
-        self.assertIsInstance(y, fp.RealFloat)
-        self.assertNotEqual(y, 0, f'x={x}, p={p}, n={n}, y={y}')
-        self.assertGreater(abs(y), abs(x), f'x={x}, p={p}, n={n}, y={y}')
+        assert isinstance(y, fp.RealFloat)
+        assert y != 0, f'x={x}, p={p}, n={n}, y={y}'
+        assert abs(y) > abs(x), f'x={x}, p={p}, n={n}, y={y}'
         if p is not None:
-            self.assertLessEqual(y.p, p, f'x={x}, p={p}, n={n}, y={y}')
+            assert y.p <= p, f'x={x}, p={p}, n={n}, y={y}'
         if n is not None:
-            self.assertGreater(y.exp, n, f'x={x}, p={p}, n={n}, y={y}')
+            assert y.exp > n, f'x={x}, p={p}, n={n}, y={y}'
 
     @given(
         real_floats(prec_max=128, exp_min=-512, exp_max=512),
@@ -117,12 +116,12 @@ class TestRealFloatReprMethods(unittest.TestCase):
         assume(p is None or x.p <= p)
         assume(x != 0)
         y = x.next_towards_zero(p=p, n=n)
-        self.assertIsInstance(y, fp.RealFloat)
-        self.assertLess(abs(y), abs(x), f'x={x}, p={p}, n={n}, y={y}')
+        assert isinstance(y, fp.RealFloat)
+        assert abs(y) < abs(x), f'x={x}, p={p}, n={n}, y={y}'
         if p is not None:
-            self.assertLessEqual(y.p, p, f'x={x}, p={p}, n={n}, y={y}')
+            assert y.p <= p, f'x={x}, p={p}, n={n}, y={y}'
         if n is not None:
-            self.assertGreater(y.exp, n, f'x={x}, p={p}, n={n}, y={y}')
+            assert y.exp > n, f'x={x}, p={p}, n={n}, y={y}'
 
     @given(
         real_floats(prec_max=128, exp_min=-512, exp_max=512),
@@ -133,12 +132,12 @@ class TestRealFloatReprMethods(unittest.TestCase):
         assume(n is None or x.exp > n)
         assume(p is None or x.p <= p)
         y = x.next_up(p=p, n=n)
-        self.assertIsInstance(y, fp.RealFloat)
-        self.assertGreater(y, x, f'x={x}, p={p}, n={n}, y={y}')
+        assert isinstance(y, fp.RealFloat)
+        assert y > x, f'x={x}, p={p}, n={n}, y={y}'
         if p is not None:
-            self.assertLessEqual(y.p, p, f'x={x}, p={p}, n={n}, y={y}')
+            assert y.p <= p, f'x={x}, p={p}, n={n}, y={y}'
         if n is not None:
-            self.assertGreater(y.exp, n, f'x={x}, p={p}, n={n}, y={y}')
+            assert y.exp > n, f'x={x}, p={p}, n={n}, y={y}'
 
     @given(
         real_floats(prec_max=128, exp_min=-512, exp_max=512),
@@ -149,52 +148,52 @@ class TestRealFloatReprMethods(unittest.TestCase):
         assume(n is None or x.exp > n)
         assume(p is None or x.p <= p)
         y = x.next_down(p=p, n=n)
-        self.assertIsInstance(y, fp.RealFloat)
-        self.assertLess(y, x, f'x={x}, p={p}, n={n}, y={y}')
+        assert isinstance(y, fp.RealFloat)
+        assert y < x, f'x={x}, p={p}, n={n}, y={y}'
         if p is not None:
-            self.assertLessEqual(y.p, p, f'x={x}, p={p}, n={n}, y={y}')
+            assert y.p <= p, f'x={x}, p={p}, n={n}, y={y}'
         if n is not None:
-            self.assertGreater(y.exp, n, f'x={x}, p={p}, n={n}, y={y}')
+            assert y.exp > n, f'x={x}, p={p}, n={n}, y={y}'
 
 
-class TestRealFloatArithmetic(unittest.TestCase):
+class TestRealFloatArithmetic():
     """Testing `RealFloat` arithmetic operations."""
 
     @given(st.floats(allow_infinity=False, allow_nan=False))
     def test_abs(self, a: float):
         expect = abs(Fraction(a))
         actual = abs(fp.RealFloat.from_float(a))
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(st.floats(allow_infinity=False, allow_nan=False))
     def test_neg(self, a: float):
         expect = -Fraction(a)
         actual = -fp.RealFloat.from_float(a)
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(st.floats(allow_infinity=False, allow_nan=False))
     def test_trunc(self, a: float):
         expect = math.trunc(Fraction(a))
         actual = math.trunc(fp.RealFloat.from_float(a))
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(st.floats(allow_infinity=False, allow_nan=False))
     def test_floor(self, a: float):
         expect = math.floor(Fraction(a))
         actual = math.floor(fp.RealFloat.from_float(a))
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(st.floats(allow_infinity=False, allow_nan=False))
     def test_ceil(self, a: float):
         expect = math.ceil(Fraction(a))
         actual = math.ceil(fp.RealFloat.from_float(a))
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(st.floats(allow_infinity=False, allow_nan=False))
     def test_round(self, a: float):
         expect = round(Fraction(a))
         actual = round(fp.RealFloat.from_float(a))
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(
         st.floats(allow_infinity=False, allow_nan=False),
@@ -203,7 +202,7 @@ class TestRealFloatArithmetic(unittest.TestCase):
     def test_add(self, a: float, b: float):
         expect = Fraction(a) + Fraction(b)
         actual = fp.RealFloat.from_float(a) + fp.RealFloat.from_float(b)
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(
         st.floats(allow_infinity=False, allow_nan=False),
@@ -213,7 +212,7 @@ class TestRealFloatArithmetic(unittest.TestCase):
     )
     def test_add_mixed(self, a: float, b: int | float | Fraction):
         actual = fp.RealFloat.from_float(a) + b
-        self.assertIsInstance(actual, fp.RealFloat)
+        assert isinstance(actual, fp.RealFloat)
 
     @given(
         st.floats(allow_infinity=False, allow_nan=False),
@@ -222,7 +221,7 @@ class TestRealFloatArithmetic(unittest.TestCase):
     def test_sub(self, a: float, b: float):
         expect = Fraction(a) - Fraction(b)
         actual = fp.RealFloat.from_float(a) - fp.RealFloat.from_float(b)
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(
         st.floats(allow_infinity=False, allow_nan=False),
@@ -232,7 +231,7 @@ class TestRealFloatArithmetic(unittest.TestCase):
     )
     def test_sub_mixed(self, a: float, b: int | float | Fraction):
         actual = fp.RealFloat.from_float(a) - b
-        self.assertIsInstance(actual, fp.RealFloat)
+        assert isinstance(actual, fp.RealFloat)
 
     @given(
         st.floats(allow_infinity=False, allow_nan=False),
@@ -241,7 +240,7 @@ class TestRealFloatArithmetic(unittest.TestCase):
     def test_mul(self, a: float, b: float):
         expect = Fraction(a) * Fraction(b)
         actual = fp.RealFloat.from_float(a) * fp.RealFloat.from_float(b)
-        self.assertEqual(actual, expect)
+        assert actual == expect
 
     @given(
         st.floats(allow_infinity=False, allow_nan=False),
@@ -251,7 +250,7 @@ class TestRealFloatArithmetic(unittest.TestCase):
     )
     def test_mul_mixed(self, a: float, b: int | float | Fraction):
         actual = fp.RealFloat.from_float(a) * b
-        self.assertIsInstance(actual, fp.RealFloat)
+        assert isinstance(actual, fp.RealFloat)
 
     @given(
         st.floats(allow_infinity=False, allow_nan=False).filter(lambda x: x != 0.0),
@@ -260,4 +259,4 @@ class TestRealFloatArithmetic(unittest.TestCase):
     def test_pow(self, a: float, b: int):
         expect = Fraction(a) ** b
         actual = fp.RealFloat.from_float(a) ** b
-        self.assertEqual(actual, expect)
+        assert actual == expect

--- a/tests/unit/number/number/test_round.py
+++ b/tests/unit/number/number/test_round.py
@@ -104,7 +104,7 @@ class TestRealFloatRoundMethods():
         x = fp.RealFloat(x=x, inexact=inexact)
         rounded = x.round(max_p=p, min_n=n, rm=rm)
         assert isinstance(rounded, fp.RealFloat)
-        assert x != rounded == rounded.inexact, f'x={x}, p={p}, n={n}, rm={rm!r}, inexact={inexact}, rounded.inexact={rounded.inexact}'
+        assert (x != rounded) == rounded.inexact, f'x={x}, p={p}, n={n}, rm={rm!r}, inexact={inexact}, rounded.inexact={rounded.inexact}'
         if p is not None:
             assert rounded.p <= p, f'x={x}, p={p}, rm={rm!r}, rounded.p={rounded.p}'
         if n is not None:

--- a/tests/unit/number/number/test_round.py
+++ b/tests/unit/number/number/test_round.py
@@ -1,6 +1,5 @@
 import fpy2 as fp
 import random
-import unittest
 
 from fractions import Fraction
 from hypothesis import assume, given, strategies as st
@@ -24,7 +23,7 @@ class FixedRandom(random.Random):
         return self._v & ((1 << k) - 1)
 
 
-class TestRealFloatRoundMethods(unittest.TestCase):
+class TestRealFloatRoundMethods():
     """Testing `RealFloat` rounding methods"""
 
     def test_round_params(self):
@@ -44,8 +43,8 @@ class TestRealFloatRoundMethods(unittest.TestCase):
         for exp, c, max_p, min_n, expect_p, expect_n in inputs:
             x = fp.RealFloat(exp=exp, c=c)
             p, n = x._round_params(max_p=max_p, min_n=min_n)
-            self.assertEqual(p, expect_p, f'x={x}, max_p={max_p}, min_n={min_n}, p={p}, expect_p={expect_p}')
-            self.assertEqual(n, expect_n, f'x={x}, max_p={max_p}, min_n={min_n}, n={n}, expect_n={expect_n}')
+            assert p == expect_p, f'x={x}, max_p={max_p}, min_n={min_n}, p={p}, expect_p={expect_p}'
+            assert n == expect_n, f'x={x}, max_p={max_p}, min_n={min_n}, n={n}, expect_n={expect_n}'
 
     def test_round_examples(self):
         inputs = [
@@ -90,8 +89,8 @@ class TestRealFloatRoundMethods(unittest.TestCase):
             x = fp.RealFloat(exp=exp, c=c)
             x_rounded = x.round(max_p=2, rm=rm)
             expect = fp.RealFloat(exp=exp_rounded, c=c_rounded)
-            self.assertEqual(x_rounded, expect, f'x={x}, rm={rm!r}, x_rounded={x_rounded}, expect={expect}')
-            self.assertLessEqual(x_rounded.p, 2, f'x={x}, rm={rm!r}, x_rounded.p={x_rounded.p}')
+            assert x_rounded == expect, f'x={x}, rm={rm!r}, x_rounded={x_rounded}, expect={expect}'
+            assert x_rounded.p <= 2, f'x={x}, rm={rm!r}, x_rounded.p={x_rounded.p}'
 
     @given(
         real_floats(prec_max=100),
@@ -104,12 +103,12 @@ class TestRealFloatRoundMethods(unittest.TestCase):
         assume(p is not None or n is not None)
         x = fp.RealFloat(x=x, inexact=inexact)
         rounded = x.round(max_p=p, min_n=n, rm=rm)
-        self.assertIsInstance(rounded, fp.RealFloat)
-        self.assertEqual(x != rounded, rounded.inexact, f'x={x}, p={p}, n={n}, rm={rm!r}, inexact={inexact}, rounded.inexact={rounded.inexact}')
+        assert isinstance(rounded, fp.RealFloat)
+        assert x != rounded == rounded.inexact, f'x={x}, p={p}, n={n}, rm={rm!r}, inexact={inexact}, rounded.inexact={rounded.inexact}'
         if p is not None:
-            self.assertLessEqual(rounded.p, p, f'x={x}, p={p}, rm={rm!r}, rounded.p={rounded.p}')
+            assert rounded.p <= p, f'x={x}, p={p}, rm={rm!r}, rounded.p={rounded.p}'
         if n is not None:
-            self.assertGreater(rounded.exp, n, f'x={x}, n={n}, rm={rm!r}, rounded.n={rounded.n}')
+            assert rounded.exp > n, f'x={x}, n={n}, rm={rm!r}, rounded.n={rounded.n}'
 
     def test_round_stochastic_examples(self):
         inputs = [
@@ -145,9 +144,9 @@ class TestRealFloatRoundMethods(unittest.TestCase):
             x = fp.RealFloat(exp=exp, c=c)
             x_rounded = x.round(max_p=2, num_randbits=2, rng=rng)
             expect = fp.RealFloat(exp=exp_rounded, c=c_rounded)
-            self.assertEqual(x_rounded, expect, f'x={x}, randbits={randbits}, x_rounded={x_rounded}, expect={expect}')
-            self.assertLessEqual(x_rounded.p, 2, f'x={x}, randbits={randbits}, x_rounded.p={x_rounded.p}')
-            self.assertEqual(rng.num_calls, 1, f'x={x}, randbits={randbits}, rng.num_calls={rng.num_calls}')
+            assert x_rounded == expect, f'x={x}, randbits={randbits}, x_rounded={x_rounded}, expect={expect}'
+            assert x_rounded.p <= 2, f'x={x}, randbits={randbits}, x_rounded.p={x_rounded.p}'
+            assert rng.num_calls == 1, f'x={x}, randbits={randbits}, rng.num_calls={rng.num_calls}'
 
     @given(
         real_floats(prec_max=100, exp_min=-16, exp_max=16),
@@ -166,11 +165,11 @@ class TestRealFloatRoundMethods(unittest.TestCase):
     ):
         assume(p is not None or n is not None)
         rounded = x.round(max_p=p, min_n=n, rm=rm, num_randbits=num_randbits)
-        self.assertIsInstance(rounded, fp.RealFloat)
+        assert isinstance(rounded, fp.RealFloat)
         if p is not None:
-            self.assertLessEqual(rounded.p, p, f'x={x}, p={p}, rm={rm!r}, rounded.p={rounded.p}')
+            assert rounded.p <= p, f'x={x}, p={p}, rm={rm!r}, rounded.p={rounded.p}'
         if n is not None:
-            self.assertGreater(rounded.exp, n, f'x={x}, n={n}, rm={rm!r}, rounded.n={rounded.n}')
+            assert rounded.exp > n, f'x={x}, n={n}, rm={rm!r}, rounded.n={rounded.n}'
 
     def test_round_at_examples(self):
         inputs = [
@@ -215,8 +214,8 @@ class TestRealFloatRoundMethods(unittest.TestCase):
             x = fp.RealFloat(exp=exp, c=c)
             x_rounded = x.round_at(n=-2, rm=rm)
             expect = fp.RealFloat(exp=exp_rounded, c=c_rounded)
-            self.assertEqual(x_rounded, expect, f'x={x}, rm={rm!r}, x_rounded={x_rounded}, expect={expect}')
-            self.assertGreater(x_rounded.exp, -2, f'x={x}, rm={rm!r}, x_rounded.exp={x_rounded.exp}')
+            assert x_rounded == expect, f'x={x}, rm={rm!r}, x_rounded={x_rounded}, expect={expect}'
+            assert x_rounded.exp > -2, f'x={x}, rm={rm!r}, x_rounded.exp={x_rounded.exp}'
 
     @given(
         real_floats(prec_max=100),
@@ -226,7 +225,7 @@ class TestRealFloatRoundMethods(unittest.TestCase):
     )
     def test_round_at(self, x: fp.RealFloat, n: int, p: int | None, rm: fp.RoundingMode):
         rounded = x.round_at(n=n, rm=rm)
-        self.assertIsInstance(rounded, fp.RealFloat)
+        assert isinstance(rounded, fp.RealFloat)
 
     def test_round_at_stochastic_examples(self):
         inputs = [
@@ -262,9 +261,9 @@ class TestRealFloatRoundMethods(unittest.TestCase):
             x = fp.RealFloat(exp=exp, c=c)
             x_rounded = x.round_at(n=-2, num_randbits=2, rng=rng)
             expect = fp.RealFloat(exp=exp_rounded, c=c_rounded)
-            self.assertEqual(x_rounded, expect, f'x={x}, randbits={randbits}, x_rounded={x_rounded}, expect={expect}')
-            self.assertGreater(x_rounded.exp, -2, f'x={x}, randbits={randbits}, x_rounded.exp={x_rounded.exp}')
-            self.assertEqual(rng.num_calls, 1, f'x={x}, randbits={randbits}, rng.num_calls={rng.num_calls}')
+            assert x_rounded == expect, f'x={x}, randbits={randbits}, x_rounded={x_rounded}, expect={expect}'
+            assert x_rounded.exp > -2, f'x={x}, randbits={randbits}, x_rounded.exp={x_rounded.exp}'
+            assert rng.num_calls == 1, f'x={x}, randbits={randbits}, rng.num_calls={rng.num_calls}'
 
     @given(
         real_floats(prec_max=100, exp_min=-16, exp_max=16),
@@ -280,8 +279,8 @@ class TestRealFloatRoundMethods(unittest.TestCase):
         rm: fp.RoundingMode
     ):
         rounded = x.round_at(n=n, rm=rm, num_randbits=num_randbits)
-        self.assertIsInstance(rounded, fp.RealFloat)
-        self.assertGreater(rounded.exp, n, f'x={x}, randbits={num_randbits}, rounded.exp={rounded.exp}')
+        assert isinstance(rounded, fp.RealFloat)
+        assert rounded.exp > n, f'x={x}, randbits={num_randbits}, rounded.exp={rounded.exp}'
 
 
 _MAX_PRECISION = 100
@@ -306,47 +305,47 @@ def _all_contexts():
     return common + inst
 
 
-class ContextRoundTestCase(unittest.TestCase):
+class ContextRoundTestCase():
     """Testing `Context.round()`"""
 
     @given(st.integers())
     def test_round_int(self, x: int):
         for ctx in _all_contexts():
             y = ctx.round(x)
-            self.assertIsInstance(y, fp.Float)
-            self.assertIs(y.ctx, ctx)
+            assert isinstance(y, fp.Float)
+            assert y.ctx is ctx
 
     @given(st.fractions())
     def test_round_fraction(self, x: Fraction):
         for ctx in _all_contexts():
             if ctx is not fp.REAL:
                 y = ctx.round(x)
-                self.assertIsInstance(y, fp.Float)
-                self.assertIs(y.ctx, ctx)
+                assert isinstance(y, fp.Float)
+                assert y.ctx is ctx
 
     @given(st.floats(allow_nan=True, allow_infinity=True, allow_subnormal=True))
     def test_round_python_float(self, x: float):
         for ctx in _all_contexts():
             if not isinstance(ctx, fp.MPFixedContext | fp.MPBFixedContext | fp.FixedContext):
                 y = ctx.round(x)
-                self.assertIsInstance(y, fp.Float)
-                self.assertIs(y.ctx, ctx)
+                assert isinstance(y, fp.Float)
+                assert y.ctx is ctx
 
     @given(real_floats(prec_max=_MAX_PRECISION, exp_min=-_EXP_LIMIT, exp_max=_EXP_LIMIT))
     def test_round_real_float(self, x: fp.RealFloat):
         for ctx in _all_contexts():
             y = ctx.round(x)
-            self.assertIsInstance(y, fp.Float)
-            self.assertIs(y.ctx, ctx)
+            assert isinstance(y, fp.Float)
+            assert y.ctx is ctx
 
     @given(floats(53, allow_nan=False, allow_infinity=False, ctx=fp.FP64))
     def test_round_float(self, x: fp.Float):
         for ctx in _all_contexts():
             y = ctx.round(x)
-            self.assertIsInstance(y, fp.Float)
-            self.assertIs(y.ctx, ctx)
+            assert isinstance(y, fp.Float)
+            assert y.ctx is ctx
 
-class ContextRoundAtTestCase(unittest.TestCase):
+class ContextRoundAtTestCase():
     """Testing `Context.round_at()`"""
 
     @given(st.integers(), st.integers())
@@ -354,37 +353,37 @@ class ContextRoundAtTestCase(unittest.TestCase):
         for ctx in _all_contexts():
             if ctx is not fp.REAL:
                 y = ctx.round_at(x, n)
-                self.assertIsInstance(y, fp.Float)
-                self.assertIs(y.ctx, ctx)
+                assert isinstance(y, fp.Float)
+                assert y.ctx is ctx
 
     @given(st.fractions(), st.integers())
     def test_round_fraction(self, x: Fraction,n: int):
         for ctx in _all_contexts():
             if ctx is not fp.REAL:
                 y = ctx.round_at(x, n)
-                self.assertIsInstance(y, fp.Float)
-                self.assertIs(y.ctx, ctx)
+                assert isinstance(y, fp.Float)
+                assert y.ctx is ctx
 
     @given(st.floats(allow_nan=True, allow_infinity=True, allow_subnormal=True), st.integers())
     def test_round_python_float(self, x: float, n: int):
         for ctx in _all_contexts():
             if ctx is not fp.REAL and not isinstance(ctx, fp.MPFixedContext | fp.MPBFixedContext | fp.FixedContext):
                 y = ctx.round_at(x, n)
-                self.assertIsInstance(y, fp.Float)
-                self.assertIs(y.ctx, ctx)
+                assert isinstance(y, fp.Float)
+                assert y.ctx is ctx
 
     @given(real_floats(prec_max=_MAX_PRECISION, exp_min=-_EXP_LIMIT, exp_max=_EXP_LIMIT), st.integers())
     def test_round_real_float(self, x: fp.RealFloat, n: int):
         for ctx in _all_contexts():
             if ctx is not fp.REAL:
                 y = ctx.round_at(x, n)
-                self.assertIsInstance(y, fp.Float)
-                self.assertIs(y.ctx, ctx)
+                assert isinstance(y, fp.Float)
+                assert y.ctx is ctx
 
     @given(floats(53, allow_nan=False, allow_infinity=False, ctx=fp.FP64), st.integers())
     def test_round_float(self, x: fp.Float, n: int):
         for ctx in _all_contexts():
             if ctx is not fp.REAL:
                 y = ctx.round_at(x, n)
-                self.assertIsInstance(y, fp.Float)
-                self.assertIs(y.ctx, ctx)
+                assert isinstance(y, fp.Float)
+                assert y.ctx is ctx

--- a/tests/unit/number/sm_fixed/test_encode.py
+++ b/tests/unit/number/sm_fixed/test_encode.py
@@ -1,9 +1,8 @@
 import fpy2 as fp
-import unittest
 
 from hypothesis import given, strategies as st
 
-class EncodeTestCase(unittest.TestCase):
+class EncodeTestCase():
     """Testing `SMFixedContext.encode()`"""
 
     @given(st.integers(-3, 3), st.integers(2, 8))
@@ -11,16 +10,16 @@ class EncodeTestCase(unittest.TestCase):
         ctx = fp.SMFixedContext(scale, nbits)
         for i in range(1 - (1 << (ctx.nbits - 1)), 1 << (ctx.nbits - 1)):
             x = fp.Float(exp=scale, m=i, ctx=ctx)
-            self.assertTrue(ctx.representable_under(x), f'x={x} is not representable under ctx={ctx}')
+            assert ctx.representable_under(x), f'x={x} is not representable under ctx={ctx}'
 
             expect = (1 if x.s else 0) << (ctx.nbits - 1) | abs(x.c)
 
             encoded = ctx.encode(x)
-            self.assertIsInstance(encoded, int, f'x={x}, encoded={encoded}')
-            self.assertEqual(encoded, expect, f'x={x}, encoded={encoded}')
+            assert isinstance(encoded, int), f'x={x}, encoded={encoded}'
+            assert encoded == expect, f'x={x}, encoded={encoded}'
 
 
-class DecodeTestCase(unittest.TestCase):
+class DecodeTestCase():
     """Testing `SMFixedContext.decode()`"""
 
     @given(st.integers(-3, 3), st.integers(2, 8))
@@ -34,12 +33,12 @@ class DecodeTestCase(unittest.TestCase):
             c = i & fp.utils.bitmask(ctx.nbits - 1)
             expect = fp.Float(s, exp, c)
 
-            self.assertIsInstance(decoded, fp.Float, f'i={i}, decoded={decoded}')
-            self.assertTrue(ctx.representable_under(decoded), f'i={i}, decoded={decoded}')
-            self.assertEqual(decoded, expect, f'i={i}, decoded={decoded}')
+            assert isinstance(decoded, fp.Float), f'i={i}, decoded={decoded}'
+            assert ctx.representable_under(decoded), f'i={i}, decoded={decoded}'
+            assert decoded == expect, f'i={i}, decoded={decoded}'
 
 
-class EncodeRoundTripTestCase(unittest.TestCase):
+class EncodeRoundTripTestCase():
     """Ensure `SMFixedContext.decode()` and `SMFixedContext.encode()` roundtrips."""
 
     @given(st.integers(-3, 3), st.integers(2, 8))
@@ -48,5 +47,5 @@ class EncodeRoundTripTestCase(unittest.TestCase):
         for i in range(1 << ctx.nbits):
             x = ctx.decode(i)
             j = ctx.encode(x)
-            self.assertIsInstance(j, int, f'i={i}, x={x}, j={j}')
-            self.assertEqual(j, i, f'i={i}, x={x}, j={j}')
+            assert isinstance(j, int), f'i={i}, x={x}, j={j}'
+            assert j == i, f'i={i}, x={x}, j={j}'

--- a/tests/unit/number/test_context.py
+++ b/tests/unit/number/test_context.py
@@ -3,7 +3,6 @@ Testing `Context` methods.
 """
 
 import fpy2 as fp
-import unittest
 
 from fractions import Fraction
 from hypothesis import assume, given, strategies as st
@@ -30,32 +29,32 @@ def _encodable_contexts():
     return _sized_contexts()
 
 
-class TestOrdinalContext(unittest.TestCase):
+class TestOrdinalContext():
     """Testing `OrdinalContext` methods."""
 
     @given(common_contexts().filter(lambda ctx: isinstance(ctx, fp.OrdinalContext)))
     def test_minval_common(self, ctx: fp.OrdinalContext):
         pos_min = ctx.minval()
-        self.assertIsInstance(pos_min, fp.Float)
-        self.assertTrue(pos_min.is_positive())
+        assert isinstance(pos_min, fp.Float)
+        assert pos_min.is_positive()
 
         try:
             neg_min = ctx.minval(s=True)
-            self.assertIsInstance(neg_min, fp.Float)
-            self.assertTrue(neg_min.is_negative())
+            assert isinstance(neg_min, fp.Float)
+            assert neg_min.is_negative()
         except ValueError:
             pass
 
     @given(_ordinal_contexts().filter(lambda ctx: not isinstance(ctx, fp.EFloatContext) or ctx.has_nonzero()))
     def test_minval(self, ctx: fp.EncodableContext):
         pos_min = ctx.minval()
-        self.assertIsInstance(pos_min, fp.Float)
-        self.assertTrue(pos_min.is_positive())
+        assert isinstance(pos_min, fp.Float)
+        assert pos_min.is_positive()
 
         try:
             neg_min = ctx.minval(s=True)
-            self.assertIsInstance(neg_min, fp.Float)
-            self.assertTrue(neg_min.is_negative())
+            assert isinstance(neg_min, fp.Float)
+            assert neg_min.is_negative()
         except ValueError:
             pass
 
@@ -69,7 +68,7 @@ class TestOrdinalContext(unittest.TestCase):
     def test_to_ordinal_common(self, ctx_x: tuple[fp.OrdinalContext, fp.Float]):
         ctx, x = ctx_x
         ord = ctx.to_ordinal(x)
-        self.assertIsInstance(ord, int)
+        assert isinstance(ord, int)
 
     @given(
         _ordinal_contexts().flatmap(
@@ -80,7 +79,7 @@ class TestOrdinalContext(unittest.TestCase):
     def test_to_ordinal(self, ctx_x: tuple[fp.EncodableContext, fp.Float]):
         ctx, x = ctx_x
         ord = ctx.to_ordinal(x)
-        self.assertIsInstance(ord, int)
+        assert isinstance(ord, int)
 
 
     @given(
@@ -93,7 +92,7 @@ class TestOrdinalContext(unittest.TestCase):
     )
     def test_from_ordinal_common(self, ctx: fp.OrdinalContext, ord: int):
         x = ctx.from_ordinal(ord)
-        self.assertIsInstance(x, fp.Float)
+        assert isinstance(x, fp.Float)
 
     @given(
         _ordinal_contexts().filter(lambda ctx: not isinstance(ctx, fp.SizedContext)),
@@ -101,7 +100,7 @@ class TestOrdinalContext(unittest.TestCase):
     )
     def test_from_ordinal(self, ctx: fp.EncodableContext, ord: int):
         x = ctx.from_ordinal(ord)
-        self.assertIsInstance(x, fp.Float)
+        assert isinstance(x, fp.Float)
 
     @given(
         common_contexts().filter(
@@ -110,7 +109,7 @@ class TestOrdinalContext(unittest.TestCase):
     )
     def test_to_fractional_ordinal_common(self, ctx: fp.OrdinalContext, x: fp.Float):
         frac_ord = ctx.to_fractional_ordinal(x)
-        self.assertIsInstance(frac_ord, Fraction)
+        assert isinstance(frac_ord, Fraction)
 
     @given(
         common_contexts().filter(
@@ -124,8 +123,8 @@ class TestOrdinalContext(unittest.TestCase):
         ctx, x, y = ctx_x_y
         if x != y:
             next_towards = ctx.next_towards(x, y)
-            self.assertIsInstance(next_towards, fp.Float)
-            self.assertTrue(abs(ctx.to_ordinal(next_towards) - ctx.to_ordinal(x)) == 1)
+            assert isinstance(next_towards, fp.Float)
+            assert abs(ctx.to_ordinal(next_towards) - ctx.to_ordinal(x)) == 1
 
     @given(
         _ordinal_contexts().flatmap(
@@ -138,8 +137,8 @@ class TestOrdinalContext(unittest.TestCase):
         ctx, x, y = ctx_x_y
         if x != y:
             next_towards = ctx.next_towards(x, y)
-            self.assertIsInstance(next_towards, fp.Float)
-            self.assertTrue(abs(ctx.to_ordinal(next_towards) - ctx.to_ordinal(x)) == 1)
+            assert isinstance(next_towards, fp.Float)
+            assert abs(ctx.to_ordinal(next_towards) - ctx.to_ordinal(x)) == 1
 
     @given(
         common_contexts().filter(
@@ -152,9 +151,9 @@ class TestOrdinalContext(unittest.TestCase):
         ctx, x = ctx_x
         if x != 0:
             y = ctx.next_towards_zero(x)
-            self.assertIsInstance(y, fp.Float)
-            self.assertTrue(abs(y) < abs(x))
-            self.assertTrue(abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1)
+            assert isinstance(y, fp.Float)
+            assert abs(y) < abs(x)
+            assert abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1
 
     @given(
         _ordinal_contexts().flatmap(
@@ -166,9 +165,9 @@ class TestOrdinalContext(unittest.TestCase):
         ctx, x = ctx_x
         if x != 0:
             y = ctx.next_towards_zero(x)
-            self.assertIsInstance(y, fp.Float)
-            self.assertTrue(abs(y) < abs(x))
-            self.assertTrue(abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1)
+            assert isinstance(y, fp.Float)
+            assert abs(y) < abs(x)
+            assert abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1
 
     @given(
         common_contexts().filter(
@@ -182,9 +181,9 @@ class TestOrdinalContext(unittest.TestCase):
         assume(not isinstance(ctx, fp.SizedContext) or ctx.smallest() < x < ctx.largest())
         if x != 0:
             y = ctx.next_away_zero(x)
-            self.assertIsInstance(y, fp.Float)
-            self.assertTrue(abs(y) > abs(x))
-            self.assertTrue(abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1)
+            assert isinstance(y, fp.Float)
+            assert abs(y) > abs(x)
+            assert abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1
 
     @given(
         _ordinal_contexts().flatmap(
@@ -197,9 +196,9 @@ class TestOrdinalContext(unittest.TestCase):
         assume(not isinstance(ctx, fp.SizedContext) or ctx.smallest() < x < ctx.largest())
         if x != 0:
             y = ctx.next_away_zero(x)
-            self.assertIsInstance(y, fp.Float)
-            self.assertTrue(abs(y) > abs(x))
-            self.assertTrue(abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1)
+            assert isinstance(y, fp.Float)
+            assert abs(y) > abs(x)
+            assert abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1
 
     @given(
         common_contexts().filter(
@@ -212,9 +211,9 @@ class TestOrdinalContext(unittest.TestCase):
         ctx, x = ctx_x
         assume(not isinstance(ctx, fp.SizedContext) or x < ctx.largest())
         y = ctx.next_up(x)
-        self.assertIsInstance(y, fp.Float)
-        self.assertTrue(y >= x)
-        self.assertTrue(abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1)
+        assert isinstance(y, fp.Float)
+        assert y >= x
+        assert abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1
 
     @given(
         _ordinal_contexts().flatmap(
@@ -226,9 +225,9 @@ class TestOrdinalContext(unittest.TestCase):
         ctx, x = ctx_x
         assume(not isinstance(ctx, fp.SizedContext) or x < ctx.largest())
         y = ctx.next_up(x) 
-        self.assertIsInstance(y, fp.Float)
-        self.assertTrue(y >= x)
-        self.assertTrue(abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1)
+        assert isinstance(y, fp.Float)
+        assert y >= x
+        assert abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1
 
     @given(
         common_contexts().filter(
@@ -241,9 +240,9 @@ class TestOrdinalContext(unittest.TestCase):
         ctx, x = ctx_x
         assume(not isinstance(ctx, fp.SizedContext) or x > ctx.smallest())
         y = ctx.next_down(x)
-        self.assertIsInstance(y, fp.Float)
-        self.assertTrue(y <= x)
-        self.assertTrue(abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1)
+        assert isinstance(y, fp.Float)
+        assert y <= x
+        assert abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1
 
     @given(
         _ordinal_contexts().flatmap(
@@ -255,12 +254,12 @@ class TestOrdinalContext(unittest.TestCase):
         ctx, x = ctx_x
         assume(not isinstance(ctx, fp.SizedContext) or x > ctx.smallest())
         y = ctx.next_down(x)
-        self.assertIsInstance(y, fp.Float)
-        self.assertTrue(y <= x)
-        self.assertTrue(abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1)
+        assert isinstance(y, fp.Float)
+        assert y <= x
+        assert abs(ctx.to_ordinal(y) - ctx.to_ordinal(x)) == 1
 
 
-class TestSizedContext(unittest.TestCase):
+class TestSizedContext():
     """Testing `SizedContext` methods."""
 
     @given(
@@ -269,31 +268,31 @@ class TestSizedContext(unittest.TestCase):
     )
     def test_maxval_common(self, ctx: fp.SizedContext):
         pos_max = ctx.maxval()
-        self.assertIsInstance(pos_max, fp.Float)
-        self.assertFalse(pos_max.is_negative())
+        assert isinstance(pos_max, fp.Float)
+        assert not pos_max.is_negative()
 
         try:
             neg_max = ctx.maxval(s=True)
-            self.assertIsInstance(neg_max, fp.Float)
-            self.assertFalse(neg_max.is_positive())
+            assert isinstance(neg_max, fp.Float)
+            assert not neg_max.is_positive()
         except ValueError: 
             pass
 
     @given(_sized_contexts())
     def test_maxval(self, ctx: fp.SizedContext):
         pos_max = ctx.maxval()
-        self.assertIsInstance(pos_max, fp.Float)
-        self.assertFalse(pos_max.is_negative())
+        assert isinstance(pos_max, fp.Float)
+        assert not pos_max.is_negative()
 
         try:
             neg_max = ctx.maxval(s=True)
-            self.assertIsInstance(neg_max, fp.Float)
-            self.assertFalse(neg_max.is_positive())
+            assert isinstance(neg_max, fp.Float)
+            assert not neg_max.is_positive()
         except ValueError: 
             pass
 
 
-class TestEncodableContext(unittest.TestCase):
+class TestEncodableContext():
     """Testing `EncodableContext` methods."""
 
     @given(
@@ -306,8 +305,8 @@ class TestEncodableContext(unittest.TestCase):
     def test_encode_common(self, ctx_x: tuple[fp.EncodableContext, fp.Float]):
         ctx, x = ctx_x
         encoded = ctx.encode(x)
-        self.assertIsInstance(encoded, int)
-        self.assertTrue(0 <= encoded)
+        assert isinstance(encoded, int)
+        assert 0 <= encoded
 
     @given(
         _encodable_contexts().flatmap(
@@ -318,8 +317,8 @@ class TestEncodableContext(unittest.TestCase):
     def test_encode(self, ctx_x: tuple[fp.EncodableContext, fp.Float]):
         ctx, x = ctx_x
         encoded = ctx.encode(x)
-        self.assertIsInstance(encoded, int)
-        self.assertTrue(0 <= encoded)
+        assert isinstance(encoded, int)
+        assert 0 <= encoded
 
 
     @given(
@@ -333,8 +332,8 @@ class TestEncodableContext(unittest.TestCase):
         ctx, x = ctx_x
         encoded = ctx.encode(x)
         decoded = ctx.decode(encoded)
-        self.assertIsInstance(decoded, fp.Float)
-        self.assertEqual(x, decoded)
+        assert isinstance(decoded, fp.Float)
+        assert x == decoded
 
     @given(
         _encodable_contexts().flatmap(
@@ -346,5 +345,5 @@ class TestEncodableContext(unittest.TestCase):
         ctx, x = ctx_x
         encoded = ctx.encode(x)
         decoded = ctx.decode(encoded)
-        self.assertIsInstance(decoded, fp.Float)
-        self.assertEqual(x, decoded)
+        assert isinstance(decoded, fp.Float)
+        assert x == decoded

--- a/tests/unit/number/test_gmp.py
+++ b/tests/unit/number/test_gmp.py
@@ -1,5 +1,4 @@
 import fpy2 as fp
-import unittest
 
 from fpy2.number.gmputils import float_to_mpfr, mpfr_to_float
 from hypothesis import given
@@ -7,18 +6,18 @@ from hypothesis import given
 from ..generators import floats
 
 
-class TestGMPConversion(unittest.TestCase):
+class TestGMPConversion():
     """Testing conversion between `fpy2` number and `gmpy2` numbers."""
 
     def assertEqualOrNan(self, a: fp.Float, b: fp.Float, msg = None):
         if a.isnan or b.isnan:
-            self.assertTrue(a.isnan and b.isnan, msg)
+            assert a.isnan and b.isnan, msg
         else:
-            self.assertEqual(a, b, msg)
+            assert a == b, msg
 
     @given(floats(prec_max=32, exp_min=-100, exp_max=100))
     def test_to_gmp(self, x: fp.Float):
         y = float_to_mpfr(x)
         x2 = mpfr_to_float(y)
-        self.assertIsInstance(x2, fp.Float)
+        assert isinstance(x2, fp.Float)
         self.assertEqualOrNan(x, x2)

--- a/tests/unit/number/test_ops.py
+++ b/tests/unit/number/test_ops.py
@@ -4,7 +4,6 @@ Tests for `fpy2/ops.py` with `RealContext`.
 
 import fpy2 as fp
 import math
-import unittest
 
 from fractions import Fraction
 from hypothesis import given, strategies as st
@@ -78,13 +77,13 @@ def number(
         return draw(floats(prec_max=prec, exp_min=exp_min, exp_max=exp_max, allow_nan=True, allow_infinity=True))
 
 
-class TestOps(unittest.TestCase):
+class TestOps():
 
     def assertEqualOrNan(self, a: Fraction | float, b: Fraction | float, msg: str = ''):
         if math.isnan(a) or math.isnan(b):
-            self.assertTrue(math.isnan(a) and math.isnan(b), msg)
+            assert math.isnan(a) and math.isnan(b), msg
         else:
-            self.assertEqual(a, b, msg)
+            assert a == b, msg
 
     @given(number())
     def test_neg(self, a):
@@ -146,14 +145,14 @@ class TestOps(unittest.TestCase):
         self.assertEqualOrNan(op, _trunc(af), f'Failed truncation: {a} ({af})')
 
 
-class TestModOp(unittest.TestCase):
+class TestModOp():
     """Tests FPy's modulus operator."""
 
     def assertEqualOrNan(self, a: Fraction | float, b: Fraction | float, msg: str = ''):
         if math.isnan(a) or math.isnan(b):
-            self.assertTrue(math.isnan(a) and math.isnan(b), msg)
+            assert math.isnan(a) and math.isnan(b), msg
         else:
-            self.assertEqual(a, b, msg)
+            assert a == b, msg
 
     def test_mod_fixed(self):
         CTX = fp.MPFixedContext(nmin=-1, enable_inf=True, enable_nan=True)

--- a/tests/unit/rewrite/test_applier.py
+++ b/tests/unit/rewrite/test_applier.py
@@ -1,4 +1,3 @@
-import unittest
 
 from fpy2 import *
 from fpy2.ast import Expr, Stmt, StmtBlock, FuncDef, Fma, Var, NamedId, Assign, Call
@@ -26,14 +25,14 @@ def g(x, y, z):
     return t
 
 
-class _ApplierTestCase(unittest.TestCase):
+class _ApplierTestCase():
 
     def assertAstEqual(
         self,
         a: Expr | Stmt | StmtBlock | FuncDef,
         b: Expr | Stmt | StmtBlock | FuncDef
     ):
-        self.assertTrue(a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n')
+        assert a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n'
 
 
 class ApplierExprTestCase(_ApplierTestCase):

--- a/tests/unit/rewrite/test_matcher.py
+++ b/tests/unit/rewrite/test_matcher.py
@@ -1,4 +1,3 @@
-import unittest
 
 from fpy2 import fpy, pattern, Function
 from fpy2.ast import Add, Var, NamedId, Integer, Expr, Stmt, StmtBlock, FuncDef
@@ -25,14 +24,14 @@ def h(x, y, z):
     return t
 
 
-class _MatcherTestCase(unittest.TestCase):
+class _MatcherTestCase():
 
     def assertAstEqual(
         self,
         a: Expr | Stmt | StmtBlock | FuncDef,
         b: Expr | Stmt | StmtBlock | FuncDef
     ):
-        self.assertTrue(a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n')
+        assert a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n'
 
 class MatchExprTestCase(_MatcherTestCase):
     """Testing `Matcher.match()` for expressions"""
@@ -49,7 +48,7 @@ class MatchExprTestCase(_MatcherTestCase):
         assert isinstance(f1, Function)
         m = Matcher(compare_pattern1)
         matches = m.match(f1)
-        self.assertEqual(len(matches), 1)
+        assert len(matches) == 1
         self.assertAstEqual(matches[0].subst['a'], Var(NamedId('x'), None))
         self.assertAstEqual(matches[0].subst['b'], Var(NamedId('y'), None))
 
@@ -58,7 +57,7 @@ class MatchExprTestCase(_MatcherTestCase):
         assert isinstance(f, Function)
         m = Matcher(insert_fma_l)
         matches = m.match(f)
-        self.assertEqual(len(matches), 1)
+        assert len(matches) == 1
         self.assertAstEqual(matches[0].subst['a'], Var(NamedId('x'), None))
         self.assertAstEqual(matches[0].subst['b'], Var(NamedId('y'), None))
         self.assertAstEqual(matches[0].subst['c'], Var(NamedId('z'), None))
@@ -67,7 +66,7 @@ class MatchExprTestCase(_MatcherTestCase):
         assert isinstance(g, Function)
         m = Matcher(insert_fma_l)
         matches = m.match(g)
-        self.assertEqual(len(matches), 1)
+        assert len(matches) == 1
         self.assertAstEqual(matches[0].subst['a'], Var(NamedId('y'), None))
         self.assertAstEqual(matches[0].subst['b'], Var(NamedId('z'), None))
         self.assertAstEqual(matches[0].subst['c'], Var(NamedId('x'), None))
@@ -76,7 +75,7 @@ class MatchExprTestCase(_MatcherTestCase):
         assert isinstance(h, Function)
         m = Matcher(insert_fma_l)
         matches = m.match(h)
-        self.assertEqual(len(matches), 2)
+        assert len(matches) == 2
 
         m0 = matches[0]
         self.assertAstEqual(m0.subst['a'], Var(NamedId('x'), None))
@@ -123,13 +122,13 @@ class MatchStmtTestCase(_MatcherTestCase):
         assert isinstance(f1, Function)
         m = Matcher(unpack_pattern1)
         matches = m.match(f1)
-        self.assertEqual(len(matches), 1)
+        assert len(matches) == 1
         self.assertAstEqual(matches[0].subst['a'], Var(NamedId('x'), None))
         self.assertAstEqual(matches[0].subst['b'], Var(NamedId('y'), None))
 
         m = Matcher(unpack_pattern2)
         matches = m.match(f1)
-        self.assertEqual(len(matches), 1)
+        assert len(matches) == 1
         self.assertAstEqual(matches[0].subst['a'], Var(NamedId('x'), None))
 
     def test_if(self):
@@ -151,7 +150,7 @@ class MatchStmtTestCase(_MatcherTestCase):
         assert isinstance(f, Function)
         m = Matcher(if_pattern1)
         matches = m.match(f)
-        self.assertEqual(len(matches), 1)
+        assert len(matches) == 1
         self.assertAstEqual(matches[0].subst['t'], Var(NamedId('x'), None))
         self.assertAstEqual(matches[0].subst['c1'], Integer(1, None))
         self.assertAstEqual(matches[0].subst['c2'], Integer(2, None))
@@ -173,7 +172,7 @@ class MatchStmtTestCase(_MatcherTestCase):
         assert isinstance(f, Function)
         m = Matcher(while_pattern1)
         matches = m.match(f)
-        self.assertEqual(len(matches), 1)
+        assert len(matches) == 1
         self.assertAstEqual(matches[0].subst['t'], Var(NamedId('x'), None))
         self.assertAstEqual(matches[0].subst['N'], Integer(100, None))
         self.assertAstEqual(matches[0].subst['e'], Add(Var(NamedId('x'), None), Integer(1, None), None))
@@ -184,7 +183,7 @@ class MatchStmtTestCase(_MatcherTestCase):
         m = Matcher(insert_sum_l)
         matches = m.match(f2)
 
-        self.assertEqual(len(matches), 1)
+        assert len(matches) == 1
         self.assertAstEqual(matches[0].subst['y'], Var(NamedId('sum'), None))
         self.assertAstEqual(matches[0].subst['x'], Var(NamedId('n'), None))
         self.assertAstEqual(matches[0].subst['xs'], Var(NamedId('lst'), None))

--- a/tests/unit/rewrite/test_pattern.py
+++ b/tests/unit/rewrite/test_pattern.py
@@ -1,25 +1,24 @@
-import unittest
 
 from fpy2 import *
 from fpy2.rewrite.pattern import Pattern
 
-class ParseSimpleTestCase(unittest.TestCase):
+class ParseSimpleTestCase():
     """Testing `Pattern` parsing"""
 
     def test_const_pat(self):
         @pattern
         def const_pat():
             1
-        self.assertIsInstance(const_pat, Pattern)
+        assert isinstance(const_pat, Pattern)
 
     def test_identity_pat(self):
         @pattern
         def identity_pat(x):
             x
-        self.assertIsInstance(identity_pat, Pattern)
+        assert isinstance(identity_pat, Pattern)
 
 
-class ParseExampleTestCase(unittest.TestCase):
+class ParseExampleTestCase():
     """Testing `Pattern` parsing for examples"""
 
     def test_fma_example(self):
@@ -30,8 +29,8 @@ class ParseExampleTestCase(unittest.TestCase):
         def insert_fma_pat(a, b, c):
             fma(a, b, c)
 
-        self.assertIsInstance(insert_mad_pat, Pattern)
-        self.assertIsInstance(insert_fma_pat, Pattern)
+        assert isinstance(insert_mad_pat, Pattern)
+        assert isinstance(insert_fma_pat, Pattern)
 
     def test_sum_example(self):
         @pattern
@@ -43,8 +42,8 @@ class ParseExampleTestCase(unittest.TestCase):
         def insert_sum_op_pat(xs):
             y = sum(xs)
 
-        self.assertIsInstance(insert_sum_pat, Pattern)
-        self.assertIsInstance(insert_sum_op_pat, Pattern)
+        assert isinstance(insert_sum_pat, Pattern)
+        assert isinstance(insert_sum_op_pat, Pattern)
 
     def test_sum_bad_example(self):
         @pattern
@@ -57,7 +56,7 @@ class ParseExampleTestCase(unittest.TestCase):
             for x in xs:
                 y += x
 
-        self.assertIsInstance(expand_sum_bad, Pattern)
+        assert isinstance(expand_sum_bad, Pattern)
 
 
     def test_while_unroll(self):
@@ -72,5 +71,5 @@ class ParseExampleTestCase(unittest.TestCase):
             while t > 0:
                 t = e
 
-        self.assertIsInstance(unroll_while_l, Pattern)
-        self.assertIsInstance(unroll_while_r, Pattern)
+        assert isinstance(unroll_while_l, Pattern)
+        assert isinstance(unroll_while_r, Pattern)

--- a/tests/unit/rewrite/test_rewrite.py
+++ b/tests/unit/rewrite/test_rewrite.py
@@ -1,4 +1,3 @@
-import unittest
 
 from typing import TypeAlias
 
@@ -224,7 +223,7 @@ def if_not_test1(c):
     return x
 
 
-class RewriteTestCase(unittest.TestCase):
+class RewriteTestCase():
     """Testing `Pattern` parsing for examples"""
 
     def assertAstEqual(
@@ -232,14 +231,14 @@ class RewriteTestCase(unittest.TestCase):
         a: Expr | Stmt | StmtBlock | FuncDef,
         b: Expr | Stmt | StmtBlock | FuncDef
     ):
-        self.assertTrue(a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n')
+        assert a.is_equiv(b), f'\n### AST 1 ###\n{a.format()}\n### AST 2 ###\n{b.format()}\n'
 
     def test_fma_example1(self):
         assert isinstance(f, Function)
         assert isinstance(f1, Function)
 
         f_rw = rw_fma.apply(f)
-        self.assertIsInstance(f_rw, Function)
+        assert isinstance(f_rw, Function)
         self.assertAstEqual(f_rw.ast.body, f1.ast.body)
 
     def test_fma_example2(self):
@@ -248,7 +247,7 @@ class RewriteTestCase(unittest.TestCase):
 
         f_rw = rw_fma.apply(f)
         f_rw = rw_fma.apply(f_rw)
-        self.assertIsInstance(f_rw, Function)
+        assert isinstance(f_rw, Function)
         self.assertAstEqual(f_rw.ast.body, f2.ast.body)
 
     def test_fma_example3(self):
@@ -256,7 +255,7 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(f2, Function)
 
         f_rw = rw_fma.apply_all(f)
-        self.assertIsInstance(f_rw, Function)
+        assert isinstance(f_rw, Function)
         self.assertAstEqual(f_rw.ast.body, f2.ast.body)
 
     def test_sum_example1(self):
@@ -264,7 +263,7 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(g1, Function)
 
         g_rw = rw_sum.apply(g)
-        self.assertIsInstance(g_rw, Function)
+        assert isinstance(g_rw, Function)
         self.assertAstEqual(g_rw.ast.body, g1.ast.body)
 
     def test_sum_example2(self):
@@ -272,7 +271,7 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(g2, Function)
 
         g_rw = rw_sum_bad.apply(g)
-        self.assertIsInstance(g_rw, Function)
+        assert isinstance(g_rw, Function)
         self.assertAstEqual(g_rw.ast.body, g2.ast.body)
 
     def test_unroll_for_example1(self):
@@ -280,7 +279,7 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(h1, Function)
 
         h_rw = rw_unroll_for.apply(h)
-        self.assertIsInstance(h_rw, Function)
+        assert isinstance(h_rw, Function)
         self.assertAstEqual(h_rw.ast.body, h1.ast.body)
 
     def test_unroll_while_example1(self):
@@ -288,7 +287,7 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(k1, Function)
 
         k_rw = rw_unroll_while.apply(k)
-        self.assertIsInstance(k_rw, Function)
+        assert isinstance(k_rw, Function)
         self.assertAstEqual(k_rw.ast.body, k1.ast.body)
 
     def test_unroll_while_example2(self):
@@ -296,7 +295,7 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(k2, Function)
 
         k_rw = rw_unroll_while.apply(k, repeat=2)
-        self.assertIsInstance(k_rw, Function)
+        assert isinstance(k_rw, Function)
         self.assertAstEqual(k_rw.ast.body, k2.ast.body)
 
     def test_unroll_while_example3(self):
@@ -304,7 +303,7 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(k3, Function)
 
         k_rw = rw_unroll_while.apply(k, repeat=5)
-        self.assertIsInstance(k_rw, Function)
+        assert isinstance(k_rw, Function)
         self.assertAstEqual(k_rw.ast.body, k3.ast.body)
 
     def test_if_test1(self):
@@ -312,7 +311,7 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(ift_test1, Function)
 
         ift_rw = rw_ift.apply(ift_test)
-        self.assertIsInstance(ift_rw, Function)
+        assert isinstance(ift_rw, Function)
         self.assertAstEqual(ift_rw.ast.body, ift_test1.ast.body)
 
     def test_if_test2(self):
@@ -320,5 +319,5 @@ class RewriteTestCase(unittest.TestCase):
         assert isinstance(if_not_test1, Function)
 
         ift_rw = rw_if_not.apply(if_not_test)
-        self.assertIsInstance(ift_rw, Function)
+        assert isinstance(ift_rw, Function)
         self.assertAstEqual(ift_rw.ast.body, if_not_test1.ast.body)

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -3,20 +3,19 @@ Tests for `fpy2/ops.py`.
 """
 
 import fpy2 as fp
-import unittest
 
 from hypothesis import given, strategies as st
 
 from .generators import floats, common_contexts
 
 
-class TestRoundedOps(unittest.TestCase):
+class TestRoundedOps():
 
     def assertEqualOrNan(self, a: fp.Float, b: fp.Float, msg = None):
         if a.isnan or b.isnan:
-            self.assertTrue(a.isnan and b.isnan, msg)
+            assert a.isnan and b.isnan, msg
         else:
-            self.assertEqual(a, b, msg)
+            assert a == b, msg
 
     @given(
         common_contexts(),

--- a/tests/unit/transform/test_const_prop.py
+++ b/tests/unit/transform/test_const_prop.py
@@ -3,10 +3,9 @@ Unit tests for constant propagation.
 """
 
 import fpy2 as fp
-import unittest
 
 
-class TestConstProp(unittest.TestCase):
+class TestConstProp():
 
     def test_example1(self):
         @fp.fpy
@@ -21,10 +20,7 @@ class TestConstProp(unittest.TestCase):
 
         f = fp.transform.ConstPropagate.apply(test.ast)
         f.name = test_expect.name
-        self.assertTrue(
-            f.is_equiv(test_expect.ast),
-            f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'
-        )
+        assert f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'
 
 
     def test_example2(self):
@@ -44,7 +40,4 @@ class TestConstProp(unittest.TestCase):
 
         f = fp.transform.ConstPropagate.apply(test.ast)
         f.name = test_expect.name
-        self.assertTrue(
-            f.is_equiv(test_expect.ast),
-            f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'
-        )
+        assert f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'

--- a/tests/unit/transform/test_dead_code.py
+++ b/tests/unit/transform/test_dead_code.py
@@ -3,7 +3,6 @@ Unit tests for dead code elimination.
 """
 
 import fpy2 as fp
-import unittest
 
 @fp.fpy
 def _example_simple_1():
@@ -284,10 +283,10 @@ _examples: list[tuple[fp.Function, fp.Function]] = [
 ]
 
 
-class TestDeadCode(unittest.TestCase):
+class TestDeadCode():
 
     def test_examples(self):
         for f, f_expect in _examples:
             f_opt = fp.transform.DeadCodeEliminate.apply(f.ast)
             f_opt.name = f_expect.name
-            self.assertTrue(f_opt.is_equiv(f_expect.ast), f'expect:\n{f_expect.format()}\nactual:\n{f_opt.format()}')
+            assert f_opt.is_equiv(f_expect.ast), f'expect:\n{f_expect.format()}\nactual:\n{f_opt.format()}'

--- a/tests/unit/transform/test_dead_code.py
+++ b/tests/unit/transform/test_dead_code.py
@@ -235,26 +235,26 @@ def _example_while_1_expect():
     return x
 
 @fp.fpy
-def test_simple_3():
+def example_simple_3():
     x = 1
     y = 2
     x = 3
     return x
 
 @fp.fpy
-def test_simple_3_expect():
+def example_simple_3_expect():
     x = 3
     return x
 
 @fp.fpy
-def test_simple_4():
+def example_simple_4():
     x = 1
     x = 2
     x = 3
     return x
 
 @fp.fpy
-def test_simple_4_expect():
+def example_simple_4_expect():
     x = 3
     return x
 
@@ -278,8 +278,8 @@ _examples: list[tuple[fp.Function, fp.Function]] = [
     (_example_dead_while_1, _example_dead_while_1_expect),
     (_example_dead_while_2, _example_dead_while_2_expect),
     (_example_while_1, _example_while_1_expect),
-    (test_simple_3, test_simple_3_expect),
-    (test_simple_4, test_simple_4_expect)
+    (example_simple_3, example_simple_3_expect),
+    (example_simple_4, example_simple_4_expect)
 ]
 
 

--- a/tests/unit/transform/test_for_unroll.py
+++ b/tests/unit/transform/test_for_unroll.py
@@ -3,9 +3,8 @@ Unit tests for loop unrolling.
 """
 
 import fpy2 as fp
-import unittest
 
-class TestForUnroll(unittest.TestCase):
+class TestForUnroll():
 
     def test_example1(self):
         @fp.fpy
@@ -27,10 +26,7 @@ class TestForUnroll(unittest.TestCase):
 
         h = fp.transform.ConstFold.apply(h, enable_op=False)
         e = fp.transform.ConstFold.apply(test_expect.ast, enable_op=False)
-        self.assertTrue(
-            h.is_equiv(e),
-            f'expect:\n{e.format()}\nactual:\n{h.format()}'
-        )
+        assert h.is_equiv(e), f'expect:\n{e.format()}\nactual:\n{h.format()}'
 
     def test_example2(self):
         @fp.fpy
@@ -60,10 +56,7 @@ class TestForUnroll(unittest.TestCase):
 
         h = fp.transform.ConstFold.apply(h, enable_op=False)
         e = fp.transform.ConstFold.apply(test_expect.ast, enable_op=False)
-        self.assertTrue(
-            h.is_equiv(e),
-            f'expect:\n{e.format()}\nactual:\n{h.format()}'
-        )
+        assert h.is_equiv(e), f'expect:\n{e.format()}\nactual:\n{h.format()}'
 
     def test_example3(self):
         @fp.fpy
@@ -97,7 +90,4 @@ class TestForUnroll(unittest.TestCase):
 
         h = fp.transform.ConstFold.apply(h, enable_op=False)
         e = fp.transform.ConstFold.apply(test_expect.ast, enable_op=False)
-        self.assertTrue(
-            h.is_equiv(e),
-            f'expect:\n{e.format()}\nactual:\n{h.format()}'
-        )
+        assert h.is_equiv(e), f'expect:\n{e.format()}\nactual:\n{h.format()}'

--- a/tests/unit/transform/test_inline.py
+++ b/tests/unit/transform/test_inline.py
@@ -3,15 +3,11 @@ Unit tests for function inlining
 """
 
 import fpy2 as fp
-import unittest
 
-class TestFuncInline(unittest.TestCase):
+class TestFuncInline():
 
     def assertASTEquiv(self, f: fp.ast.FuncDef, g: fp.ast.FuncDef, msg: str = ''):
-        self.assertTrue(
-            f.is_equiv(g),
-            f'AST not equivalent:\nexpect:\n{g.format()}\nactual:\n{f.format()}\n{msg}'
-        )
+        assert f.is_equiv(g), f'AST not equivalent:\nexpect:\n{g.format()}\nactual:\n{f.format()}\n{msg}'
 
     def test_example1(self):
         @fp.fpy

--- a/tests/unit/transform/test_subst_var.py
+++ b/tests/unit/transform/test_subst_var.py
@@ -3,10 +3,9 @@ Unit tests for variable substitution.
 """
 
 import fpy2 as fp
-import unittest
 
 
-class TestSubstVar(unittest.TestCase):
+class TestSubstVar():
 
     def test_example1(self):
         @fp.fpy
@@ -28,7 +27,7 @@ class TestSubstVar(unittest.TestCase):
 
         f = fp.transform.SubstVar.apply(test.ast, def_use, subst)
         f.name = test_expect.name
-        self.assertTrue(f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}')
+        assert f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'
 
 
     def test_example2(self):
@@ -59,7 +58,7 @@ class TestSubstVar(unittest.TestCase):
 
         f = fp.transform.SubstVar.apply(test.ast, def_use, subst)
         f.name = test_expect.name
-        self.assertTrue(f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}')
+        assert f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'
 
     def test_example3(self):
         @fp.fpy
@@ -91,4 +90,4 @@ class TestSubstVar(unittest.TestCase):
 
         f = fp.transform.SubstVar.apply(test.ast, def_use, subst)
         f.name = test_expect.name
-        self.assertTrue(f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}')
+        assert f.is_equiv(test_expect.ast), f'expect:\n{test_expect.format()}\nactual:\n{f.format()}'

--- a/tests/unit/transform/test_while_unroll.py
+++ b/tests/unit/transform/test_while_unroll.py
@@ -3,9 +3,8 @@ Unit tests for loop unrolling.
 """
 
 import fpy2 as fp
-import unittest
 
-class TestForUnroll(unittest.TestCase):
+class TestForUnroll():
 
     def test_example1(self):
         @fp.fpy
@@ -26,10 +25,7 @@ class TestForUnroll(unittest.TestCase):
 
         h = fp.transform.WhileUnroll.apply(test.ast, times=0)
         h.name = test_expect.name
-        self.assertTrue(
-            h.is_equiv(test_expect.ast),
-            f'expect:\n{test_expect.ast.format()}\nactual:\n{h.format()}'
-        )
+        assert h.is_equiv(test_expect.ast), f'expect:\n{test_expect.ast.format()}\nactual:\n{h.format()}'
 
     def test_example2(self):
         @fp.fpy
@@ -53,10 +49,7 @@ class TestForUnroll(unittest.TestCase):
 
         h = fp.transform.WhileUnroll.apply(test.ast, times=1)
         h.name = test_expect.name
-        self.assertTrue(
-            h.is_equiv(test_expect.ast),
-            f'expect:\n{test_expect.ast.format()}\nactual:\n{h.format()}'
-        )
+        assert h.is_equiv(test_expect.ast), f'expect:\n{test_expect.ast.format()}\nactual:\n{h.format()}'
 
     def test_example3(self):
         @fp.fpy
@@ -83,7 +76,4 @@ class TestForUnroll(unittest.TestCase):
 
         h = fp.transform.WhileUnroll.apply(test.ast, times=2)
         h.name = test_expect.name
-        self.assertTrue(
-            h.is_equiv(test_expect.ast),
-            f'expect:\n{test_expect.ast.format()}\nactual:\n{h.format()}'
-        )
+        assert h.is_equiv(test_expect.ast), f'expect:\n{test_expect.ast.format()}\nactual:\n{h.format()}'

--- a/tests/unit/transform/test_while_unroll.py
+++ b/tests/unit/transform/test_while_unroll.py
@@ -4,7 +4,7 @@ Unit tests for loop unrolling.
 
 import fpy2 as fp
 
-class TestForUnroll():
+class TestWhileUnroll():
 
     def test_example1(self):
         @fp.fpy

--- a/tests/unit/utils/test_unionfind.py
+++ b/tests/unit/utils/test_unionfind.py
@@ -1,11 +1,11 @@
 """Unit tests for Unionfind data structure."""
+import pytest
 from hypothesis import given, strategies as st
 from fpy2.utils.unionfind import Unionfind
 
 
 class TestUnionfindBasic():
     """Basic unit tests for Unionfind."""
-import pytest
 
     def test_empty_initialization(self):
         """Test creating an empty unionfind."""
@@ -297,5 +297,4 @@ class TestUnionfindProperties():
             x, y = string_elements[0], string_elements[1]
             uf.union(x, y)
             assert uf.find(x) == uf.find(y)
-
 

--- a/tests/unit/utils/test_unionfind.py
+++ b/tests/unit/utils/test_unionfind.py
@@ -1,83 +1,82 @@
 """Unit tests for Unionfind data structure."""
-
-import unittest
 from hypothesis import given, strategies as st
 from fpy2.utils.unionfind import Unionfind
 
 
-class TestUnionfindBasic(unittest.TestCase):
+class TestUnionfindBasic():
     """Basic unit tests for Unionfind."""
+import pytest
 
     def test_empty_initialization(self):
         """Test creating an empty unionfind."""
         uf: Unionfind[int] = Unionfind()
-        self.assertEqual(len(uf), 0)
-        self.assertEqual(list(uf), [])
+        assert len(uf) == 0
+        assert list(uf) == []
 
     def test_initialization_with_elements(self):
         """Test creating unionfind with initial elements."""
         uf: Unionfind[int] = Unionfind([1, 2, 3, 4])
-        self.assertEqual(len(uf), 4)
-        self.assertEqual(uf.representatives(), {1, 2, 3, 4})
+        assert len(uf) == 4
+        assert uf.representatives() == {1, 2, 3, 4}
 
     def test_add_single_element(self):
         """Test adding a single element."""
         uf: Unionfind[int] = Unionfind()
         rep = uf.add(1)
-        self.assertEqual(rep, 1)
-        self.assertEqual(len(uf), 1)
-        self.assertIn(1, uf)
+        assert rep == 1
+        assert len(uf) == 1
+        assert 1 in uf
 
     def test_add_duplicate_element(self):
         """Test adding an element that already exists."""
         uf = Unionfind([1])
         rep = uf.add(1)
-        self.assertEqual(rep, 1)
-        self.assertEqual(len(uf), 1)
+        assert rep == 1
+        assert len(uf) == 1
 
     def test_find_existing_element(self):
         """Test finding an existing element."""
         uf = Unionfind([1, 2, 3])
-        self.assertEqual(uf.find(1), 1)
-        self.assertEqual(uf.find(2), 2)
-        self.assertEqual(uf.find(3), 3)
+        assert uf.find(1) == 1
+        assert uf.find(2) == 2
+        assert uf.find(3) == 3
 
     def test_find_nonexistent_element(self):
         """Test finding a non-existent element raises KeyError."""
         uf = Unionfind([1, 2, 3])
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             uf.find(4)
 
     def test_get_existing_element(self):
         """Test get with existing element."""
         uf = Unionfind([1, 2, 3])
-        self.assertEqual(uf.get(1), 1)
-        self.assertEqual(uf.get(2), 2)
+        assert uf.get(1) == 1
+        assert uf.get(2) == 2
 
     def test_get_nonexistent_element(self):
         """Test get with non-existent element returns default."""
         uf = Unionfind([1, 2, 3])
-        self.assertIsNone(uf.get(4))
-        self.assertEqual(uf.get(4, "default"), "default")
+        assert uf.get(4) is None
+        assert uf.get(4, "default") == "default"
 
     def test_union_two_elements(self):
         """Test union of two elements."""
         uf = Unionfind([1, 2, 3])
         rep = uf.union(1, 2)
-        self.assertEqual(rep, 1)
-        self.assertEqual(uf.find(1), uf.find(2))
-        self.assertEqual(len(uf.representatives()), 2)
+        assert rep == 1
+        assert uf.find(1) == uf.find(2)
+        assert len(uf.representatives()) == 2
 
     def test_union_nonexistent_first(self):
         """Test union with non-existent first element."""
         uf = Unionfind([1, 2])
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             uf.union(3, 1)
 
     def test_union_nonexistent_second(self):
         """Test union with non-existent second element."""
         uf = Unionfind([1, 2])
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             uf.union(1, 3)
 
     def test_union_chain(self):
@@ -88,35 +87,35 @@ class TestUnionfindBasic(unittest.TestCase):
         uf.union(3, 4)
         # All should have same representative
         rep = uf.find(1)
-        self.assertEqual(uf.find(2), rep)
-        self.assertEqual(uf.find(3), rep)
-        self.assertEqual(uf.find(4), rep)
+        assert uf.find(2) == rep
+        assert uf.find(3) == rep
+        assert uf.find(4) == rep
         # 5 should be separate
-        self.assertNotEqual(uf.find(5), rep)
-        self.assertEqual(len(uf.representatives()), 2)
+        assert uf.find(5) != rep
+        assert len(uf.representatives()) == 2
 
     def test_contains(self):
         """Test membership checking."""
         uf = Unionfind([1, 2, 3])
-        self.assertIn(1, uf)
-        self.assertIn(2, uf)
-        self.assertNotIn(4, uf)
+        assert 1 in uf
+        assert 2 in uf
+        assert 4 not in uf
 
     def test_iter(self):
         """Test iteration over elements."""
         uf = Unionfind([1, 2, 3])
         uf.union(1, 2)
         reps = list(uf)
-        self.assertEqual(len(reps), 3)
-        self.assertIn(uf.find(1), reps)
-        self.assertIn(uf.find(2), reps)
-        self.assertIn(uf.find(3), reps)
+        assert len(reps) == 3
+        assert uf.find(1) in reps
+        assert uf.find(2) in reps
+        assert uf.find(3) in reps
 
     def test_repr(self):
         """Test string representation."""
         uf = Unionfind([1, 2])
         repr_str = repr(uf)
-        self.assertIn("Unionfind", repr_str)
+        assert "Unionfind" in repr_str
 
     def test_representatives_after_unions(self):
         """Test representatives after performing unions."""
@@ -128,17 +127,17 @@ class TestUnionfindBasic(unittest.TestCase):
             uf.union(i, i + 1)
         
         reps = uf.representatives()
-        self.assertEqual(len(reps), 2)
+        assert len(reps) == 2
 
     def test_string_elements(self):
         """Test unionfind with string elements."""
         uf = Unionfind(["a", "b", "c"])
         uf.union("a", "b")
-        self.assertEqual(uf.find("a"), uf.find("b"))
-        self.assertNotEqual(uf.find("a"), uf.find("c"))
+        assert uf.find("a") == uf.find("b")
+        assert uf.find("a") != uf.find("c")
 
 
-class TestUnionfindProperties(unittest.TestCase):
+class TestUnionfindProperties():
     """Property-based tests using hypothesis."""
 
     @given(st.lists(st.integers(), min_size=1, max_size=50, unique=True))
@@ -146,20 +145,20 @@ class TestUnionfindProperties(unittest.TestCase):
         """All elements should be findable after initialization."""
         uf = Unionfind(elements)
         for elem in elements:
-            self.assertIn(elem, uf)
-            self.assertEqual(uf.find(elem), elem)
+            assert elem in uf
+            assert uf.find(elem) == elem
 
     @given(st.lists(st.integers(), min_size=0, max_size=50, unique=True))
     def test_length_matches_elements(self, elements: list[int]):
         """Length should match number of elements."""
         uf = Unionfind(elements)
-        self.assertEqual(len(uf), len(elements))
+        assert len(uf) == len(elements)
 
     @given(st.lists(st.integers(), min_size=1, max_size=50, unique=True))
     def test_initial_representatives_equal_elements(self, elements: list[int]):
         """Initially, each element is its own representative."""
         uf = Unionfind(elements)
-        self.assertEqual(uf.representatives(), set(elements))
+        assert uf.representatives() == set(elements)
 
     @given(
         st.lists(st.integers(min_value=-100, max_value=100), min_size=2, max_size=50, unique=True)
@@ -170,8 +169,8 @@ class TestUnionfindProperties(unittest.TestCase):
         x = elements[0]
         original_rep = uf.find(x)
         uf.union(x, x)
-        self.assertEqual(uf.find(x), original_rep)
-        self.assertEqual(len(uf.representatives()), len(elements))
+        assert uf.find(x) == original_rep
+        assert len(uf.representatives()) == len(elements)
 
     @given(
         st.lists(st.integers(min_value=-100, max_value=100), min_size=3, max_size=50, unique=True)
@@ -182,7 +181,7 @@ class TestUnionfindProperties(unittest.TestCase):
         a, b, c = elements[0], elements[1], elements[2]
         uf.union(a, b)
         uf.union(b, c)
-        self.assertEqual(uf.find(a), uf.find(c))
+        assert uf.find(a) == uf.find(c)
 
     @given(
         st.lists(st.integers(min_value=-100, max_value=100), min_size=2, max_size=50, unique=True)
@@ -197,8 +196,8 @@ class TestUnionfindProperties(unittest.TestCase):
         uf2.union(y, x)
         
         # Both should be in same set
-        self.assertEqual(uf1.find(x), uf1.find(y))
-        self.assertEqual(uf2.find(x), uf2.find(y))
+        assert uf1.find(x) == uf1.find(y)
+        assert uf2.find(x) == uf2.find(y)
 
     @given(
         st.lists(st.integers(min_value=-100, max_value=100), min_size=2, max_size=50, unique=True)
@@ -212,7 +211,7 @@ class TestUnionfindProperties(unittest.TestCase):
         if uf.find(x) != uf.find(y):
             uf.union(x, y)
             final_reps = len(uf.representatives())
-            self.assertEqual(final_reps, initial_reps - 1)
+            assert final_reps == initial_reps - 1
 
     @given(st.lists(st.integers(), min_size=1, max_size=50, unique=True))
     def test_add_then_find(self, elements: list[int]):
@@ -220,8 +219,8 @@ class TestUnionfindProperties(unittest.TestCase):
         uf: Unionfind[int] = Unionfind()
         for elem in elements:
             rep = uf.add(elem)
-            self.assertEqual(rep, elem)
-            self.assertEqual(uf.find(elem), elem)
+            assert rep == elem
+            assert uf.find(elem) == elem
 
     @given(
         st.lists(st.integers(min_value=-100, max_value=100), min_size=2, max_size=30, unique=True),
@@ -240,14 +239,14 @@ class TestUnionfindProperties(unittest.TestCase):
         
         # All elements should still be findable
         for elem in elements:
-            self.assertIn(elem, uf)
+            assert elem in uf
             rep = uf.find(elem)
-            self.assertIn(rep, elements)
+            assert rep in elements
         
         # Number of representatives should be valid
         num_reps = len(uf.representatives())
-        self.assertGreater(num_reps, 0)
-        self.assertLessEqual(num_reps, len(elements))
+        assert num_reps > 0
+        assert num_reps <= len(elements)
 
     @given(st.integers(min_value=-1000, max_value=1000))
     def test_add_idempotent(self, value: int):
@@ -256,9 +255,9 @@ class TestUnionfindProperties(unittest.TestCase):
         rep1 = uf.add(value)
         rep2 = uf.add(value)
         rep3 = uf.add(value)
-        self.assertEqual(rep1, rep2)
-        self.assertEqual(rep2, rep3)
-        self.assertEqual(len(uf), 1)
+        assert rep1 == rep2
+        assert rep2 == rep3
+        assert len(uf) == 1
 
     @given(
         st.lists(st.integers(min_value=-100, max_value=100), min_size=4, max_size=50, unique=True)
@@ -280,25 +279,23 @@ class TestUnionfindProperties(unittest.TestCase):
         uf2.union(a, d)
         
         # All four should be in same set in both cases
-        self.assertEqual(uf1.find(a), uf1.find(b))
-        self.assertEqual(uf1.find(a), uf1.find(c))
-        self.assertEqual(uf1.find(a), uf1.find(d))
+        assert uf1.find(a) == uf1.find(b)
+        assert uf1.find(a) == uf1.find(c)
+        assert uf1.find(a) == uf1.find(d)
         
-        self.assertEqual(uf2.find(a), uf2.find(b))
-        self.assertEqual(uf2.find(a), uf2.find(c))
-        self.assertEqual(uf2.find(a), uf2.find(d))
+        assert uf2.find(a) == uf2.find(b)
+        assert uf2.find(a) == uf2.find(c)
+        assert uf2.find(a) == uf2.find(d)
 
     @given(st.lists(st.text(min_size=1, max_size=10), min_size=2, max_size=30, unique=True))
     def test_works_with_strings(self, string_elements: list[str]):
         """Unionfind should work with string elements."""
         uf = Unionfind(string_elements)
-        self.assertEqual(len(uf), len(string_elements))
+        assert len(uf) == len(string_elements)
         
         if len(string_elements) >= 2:
             x, y = string_elements[0], string_elements[1]
             uf.union(x, y)
-            self.assertEqual(uf.find(x), uf.find(y))
+            assert uf.find(x) == uf.find(y)
 
 
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This PR switches the unit test framework from Python's `unittest` to the `pytest` package.