### PR TITLE
Treat IndexedAssign node as a functional update

### DIFF
--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -319,20 +319,28 @@ class _ArraySizeVisitor(DefaultVisitor):
         self._visit_binding(stmt, stmt.target, ty)
 
     def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: None):
-        d = self.def_use.find_def_from_use(stmt)
+        # ``xs[i1]…[iN] = expr`` is treated as a functional update:
+        # ``xs = update(xs, [i1, …, iN], expr)``.  The use of ``xs`` reads
+        # the pre-mutation bound; the fresh def at this site (introduced
+        # by ``reaching_defs``) receives the widened bound — the inserted
+        # value's bound joined into the element bound at depth
+        # ``len(indices)``.
+        d_use = self.def_use.find_def_from_use(stmt)
+        target_ty = self.by_def[d_use]
 
-        def recur(indices: tuple[Expr, ...], target_ty: _Type) -> _Type:
+        def recur(indices: tuple[Expr, ...], cur_ty: _Type) -> _Type:
             if len(indices) == 0:
                 ty = self._visit_expr(stmt.expr, ctx)
-                return self._unify(target_ty, ty)
+                return self._unify(cur_ty, ty)
             else:
                 self._visit_expr(indices[0], ctx)
-                assert isinstance(target_ty, _Array), f'Expected array type for indexed assignment, got {target_ty} for {stmt}'
-                elt_ty = recur(indices[1:], target_ty.elt)
-                return _Array(elt_ty, target_ty.size)
+                assert isinstance(cur_ty, _Array), f'Expected array type for indexed assignment, got {cur_ty} for {stmt}'
+                elt_ty = recur(indices[1:], cur_ty.elt)
+                return _Array(elt_ty, cur_ty.size)
 
-        ty = recur(stmt.indices, self.by_def[d])
-        self.by_def[d] = ty
+        new_ty = recur(stmt.indices, target_ty)
+        d_def = self.def_use.find_def_from_site(stmt.var, stmt)
+        self.by_def[d_def] = new_ty
 
 
     def _visit_if1(self, stmt: If1Stmt, ctx: None):

--- a/fpy2/analysis/context_infer.py
+++ b/fpy2/analysis/context_infer.py
@@ -617,6 +617,10 @@ class ContextTypeInferInstance(Visitor):
 
         elt_ty = self._visit_expr(stmt.expr, ctx)
         self._unify(ty, elt_ty)
+        # Propagate the variable's context type to the fresh SSA def
+        # introduced by ``reaching_defs`` for this IndexedAssign.
+        d_new = self.def_use.find_def_from_site(stmt.var, stmt)
+        self.by_def[d_new] = self.by_def[d]
         return ctx
 
     def _visit_if1(self, stmt: If1Stmt, ctx: ContextParam):

--- a/fpy2/analysis/defs.py
+++ b/fpy2/analysis/defs.py
@@ -32,8 +32,10 @@ class _DefAnalysis(DefaultVisitor):
         return defs
 
     def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: None):
-        # does not introduce bindings
-        return set()
+        # ``xs[i] = e`` is treated as a fresh definition of ``xs``
+        # (semantically ``xs = update(xs, [i], e)``); reaching_defs
+        # uses this set for phi insertion at loop heads.
+        return {stmt.var}
 
     def _visit_if1(self, stmt: If1Stmt, ctx: None):
         # does not introduce bindings but body might

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -637,10 +637,21 @@ class _FormatInferInstance(Visitor):
         self._visit_binding(stmt, stmt.target, fmt)
 
     def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: None):
+        # ``xs[i1]…[iN] = expr`` is treated as ``xs = update(xs, …, expr)``
+        # — a fresh SSA def of ``xs`` (per ``reaching_defs``).  The new
+        # def's format is the original element format widened with the
+        # inserted value's format at depth ``len(indices)``, matching the
+        # semantics of ``ListSet`` (see :func:`_list_set_widen`).
+        d_use = self.def_use.find_def_from_use(stmt)
+        value_fmt = self._bound_of_def(d_use)
         for s in stmt.indices:
             self._visit_expr(s, ctx)
-        self._visit_expr(stmt.expr, ctx)
-        # The list variable's definition format is unchanged by element mutation.
+        insert_fmt = self._visit_expr(stmt.expr, ctx)
+        new_fmt = _list_set_widen(
+            value_fmt, len(stmt.indices), insert_fmt, widen=self._widen
+        )
+        d_def = self.def_use.find_def_from_site(stmt.var, stmt)
+        self._set_def_bound(d_def, new_fmt)
 
     def _visit_if1(self, stmt: If1Stmt, ctx: None):
         self._visit_expr(stmt.cond, ctx)

--- a/fpy2/analysis/reaching_defs.py
+++ b/fpy2/analysis/reaching_defs.py
@@ -25,7 +25,24 @@ __all__ = [
 
 
 DefSite: TypeAlias = FuncDef | Argument | Assign | IndexedAssign | ForStmt | ContextStmt | ListComp
-"""AST nodes that can define variables"""
+"""
+AST nodes that can define variables.
+
+``IndexedAssign`` is a slightly special case worth flagging: ``xs[i] = e``
+is modelled as a *fresh* SSA def of ``xs``, semantically
+``xs = update(xs, [i], e)``.  This is the right abstraction for any
+**value-tracking** analysis (types, formats, sizes, contexts, …) — the
+post-mutation value is conceptually distinct from the pre-mutation value,
+and the new def's ``prev`` field chains back to that previous def so the
+history is recoverable.
+
+For **physical-property** analyses (allocation tracking, alias analysis,
+lifetime/escape, borrow checking, …) the underlying storage is the *same*
+as the previous def's — no allocation occurs at an ``IndexedAssign``-sited
+def.  Such analyses should dispatch on ``isinstance(d.site, IndexedAssign)``
+to recognize in-place mutations and walk ``d.prev`` to find the original
+allocation site.
+"""
 PhiSite: TypeAlias = If1Stmt | IfStmt | WhileStmt | ForStmt
 """AST nodes that can introduce phi nodes"""
 

--- a/fpy2/analysis/reaching_defs.py
+++ b/fpy2/analysis/reaching_defs.py
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 
-DefSite: TypeAlias = FuncDef | Argument | Assign | ForStmt | ContextStmt | ListComp
+DefSite: TypeAlias = FuncDef | Argument | Assign | IndexedAssign | ForStmt | ContextStmt | ListComp
 """AST nodes that can define variables"""
 PhiSite: TypeAlias = If1Stmt | IfStmt | WhileStmt | ForStmt
 """AST nodes that can introduce phi nodes"""
@@ -351,9 +351,16 @@ class _ReachingDefs(DefaultVisitor):
         return ctx
 
     def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: _DefCtx):
+        # Visit children first so reads of stmt.var (or anything else)
+        # resolve to the pre-mutation context.
         for index in stmt.indices:
             self._visit_expr(index, ctx)
         self._visit_expr(stmt.expr, ctx)
+        # ``xs[i] = e`` creates a fresh definition of ``xs``: semantically
+        # ``xs = update(xs, [i], e)``.  The new def is what subsequent uses
+        # of ``xs`` resolve to, and it's what loop phis pick up via the
+        # back-edge.
+        _, ctx = self._add_assign(stmt.var, stmt, ctx)
         return ctx
 
     def _visit_if1(self, stmt: If1Stmt, ctx: _DefCtx):

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -591,6 +591,12 @@ class _TypeInferInstance(Visitor):
         val_ty = self._visit_expr(stmt.expr, None)
         self._unify(val_ty, arr_ty)
 
+        # ``xs[i] = e`` produces a fresh SSA def of ``xs`` (per
+        # ``reaching_defs``).  The static type of ``xs`` is unchanged by
+        # element mutation, so propagate the same type.
+        d_new = self.def_use.find_def_from_site(stmt.var, stmt)
+        self.by_def[d_new] = self.by_def[d]
+
     def _visit_if1(self, stmt: If1Stmt, ctx: None):
         # type check condition
         cond_ty = self._visit_expr(stmt.cond, None)

--- a/fpy2/transform/dead_code.py
+++ b/fpy2/transform/dead_code.py
@@ -218,6 +218,14 @@ class _DeadCodeEliminate:
                         ):
                             # assignment
                             unused_assign.add(d.site)
+                        # TODO: IndexedAssign-sited defs are not eliminated
+                        # here.  ``xs[i] = e`` creates a fresh SSA def of
+                        # ``xs`` (per ``reaching_defs``), and if no later
+                        # statement reads ``xs`` the def is technically
+                        # unused — but eliminating the IndexedAssign would
+                        # be unsound without alias analysis (a different
+                        # name aliasing the same list might still observe
+                        # the mutation).  Conservatively leave them in.
                     case PhiDef():
                         # phi variable with no uses
                         unused_phi.add(d)

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -9,6 +9,8 @@ from fractions import Fraction
 from fpy2.analysis import ContextUseAnalysis, FormatInfer, TypeAnalysis
 from fpy2.analysis.format_infer import AbstractFormat, ListFormat, SetFormat
 from fpy2.analysis.format_infer.analysis import _join_bounds, _list_set_widen
+from fpy2.analysis.reaching_defs import AssignDef
+from fpy2.ast.fpyast import IndexedAssign
 from fpy2.number.context.format import Format
 from fpy2.number.context.real import REAL_FORMAT
 from fpy2.transform import FuncUpdate
@@ -663,6 +665,63 @@ class TestFormatInfer:
         assert ListFormat(REAL_FORMAT) in xs_bounds, (
             f"expected post-update xs to be ListFormat(REAL_FORMAT), got {xs_bounds}"
         )
+
+    def test_indexed_assign_widens_format_at_fresh_def(self):
+        """
+        ``xs[i] = x`` (raw ``IndexedAssign``, no ``FuncUpdate`` applied)
+        creates a *fresh* SSA def of ``xs`` (per ``reaching_defs``'s
+        treatment of indexed assignment as ``xs = update(xs, [i], x)``).
+        The new def's format must be widened to match the inserted value's
+        format — i.e., the same semantics as the post-FuncUpdate
+        ``ListSet`` path tested above.
+        """
+        @fp.fpy
+        def f(x: fp.Real) -> list[fp.Real]:
+            xs = [1.0, 2.0]
+            xs[0] = x
+            return xs
+
+        # NOTE: no FuncUpdate applied — IndexedAssign survives in the AST.
+        info = FormatInfer.analyze(f.ast)
+
+        # Two distinct defs for xs: the original Assign-sited binding and
+        # the IndexedAssign-sited fresh def.
+        xs_defs = [d for d in info.by_def if d.name.base == 'xs']
+        assert len(xs_defs) == 2, f"expected 2 xs defs, got {xs_defs}"
+
+        # Identify each by site kind.
+        assign_defs = [
+            d for d in xs_defs
+            if isinstance(d, AssignDef) and not isinstance(d.site, IndexedAssign)
+        ]
+        idx_defs = [
+            d for d in xs_defs
+            if isinstance(d, AssignDef) and isinstance(d.site, IndexedAssign)
+        ]
+        assert len(assign_defs) == 1, f"expected 1 Assign-sited xs def, got {assign_defs}"
+        assert len(idx_defs) == 1, f"expected 1 IndexedAssign-sited xs def, got {idx_defs}"
+
+        # Pre-mutation: ListFormat over the literal element SetFormat.
+        pre_bound = info.by_def[assign_defs[0]]
+        assert isinstance(pre_bound, ListFormat)
+        assert isinstance(pre_bound.elt, SetFormat)
+
+        # Post-mutation (the fresh def at the IndexedAssign): the element
+        # format must widen to REAL_FORMAT (the format of x), matching the
+        # ListSet-path semantics asserted in
+        # ``test_list_set_widens_element_format`` above.
+        post_bound = info.by_def[idx_defs[0]]
+        assert post_bound == ListFormat(REAL_FORMAT), (
+            f"expected fresh IndexedAssign-sited xs def to widen to "
+            f"ListFormat(REAL_FORMAT), got {post_bound}"
+        )
+
+        # Sanity: the IndexedAssign and post-FuncUpdate ListSet paths agree.
+        funcupdate_info = FormatInfer.analyze(FuncUpdate.apply(f.ast))
+        funcupdate_xs = [
+            b for d, b in funcupdate_info.by_def.items() if d.name.base == 'xs'
+        ]
+        assert ListFormat(REAL_FORMAT) in funcupdate_xs
 
     def test_list_set_widen_helper_leaf(self):
         """``_list_set_widen`` at depth 0 is just a join."""


### PR DESCRIPTION
This PR changes how program analyses treat `IndexedAssign`. In particular, analyses can now view `IndexedAssign` as a _functional update_ to a list rather than an in-place mutation.