### PR TITLE
Update format inference algorithm

### DIFF
--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -176,6 +176,7 @@ class ListFormat:
     elt: 'FormatBound'
 
 
+ScalarFormatBound: TypeAlias = None | SetFormat | Format
 FormatBound: TypeAlias = None | SetFormat | Format | TupleFormat | ListFormat
 """
 Inferred format for an expression or variable definition.
@@ -265,7 +266,7 @@ def _setformat_to_abstract(s: SetFormat) -> AbstractFormat | None:
     return AbstractFormat(prec, exp, pos_bound, neg_bound=neg_bound)
 
 
-def _to_abstract(f: FormatBound) -> AbstractFormat | None:
+def _to_abstract(f: ScalarFormatBound) -> AbstractFormat | None:
     """
     Lifts an abstractable :class:`FormatBound` to an
     :class:`AbstractFormat`.  Returns ``None`` for variants that the
@@ -524,6 +525,7 @@ class _FormatInferInstance(Visitor):
             case Neg():
                 assert len(operands) == 1
                 op_fmt, = operands
+                assert isinstance(op_fmt, ScalarFormatBound), f'expected scalar format for operand of Neg, got {op_fmt!r}'
                 if isinstance(op_fmt, AbstractableFormat):
                     return (-AbstractFormat.from_format(op_fmt)).format()
                 elif isinstance(op_fmt, SetFormat):
@@ -533,6 +535,7 @@ class _FormatInferInstance(Visitor):
             case Abs():
                 assert len(operands) == 1
                 op_fmt, = operands
+                assert isinstance(op_fmt, ScalarFormatBound), f'expected scalar format for operand of Abs, got {op_fmt!r}'
                 if isinstance(op_fmt, AbstractableFormat):
                     return abs(AbstractFormat.from_format(op_fmt)).format()
                 elif isinstance(op_fmt, SetFormat):
@@ -542,6 +545,8 @@ class _FormatInferInstance(Visitor):
             case Add():
                 assert len(operands) == 2
                 a, b = operands
+                assert isinstance(a, ScalarFormatBound), f'expected scalar format for first operand of Add, got {a!r}'
+                assert isinstance(b, ScalarFormatBound), f'expected scalar format for second operand of Add, got {b!r}'
                 # Both SetFormat: keep precision by pairwise sum.
                 if isinstance(a, SetFormat) and isinstance(b, SetFormat):
                     return SetFormat(frozenset(va + vb for va in a.values for vb in b.values))
@@ -554,6 +559,8 @@ class _FormatInferInstance(Visitor):
             case Sub():
                 assert len(operands) == 2
                 a, b = operands
+                assert isinstance(a, ScalarFormatBound), f'expected scalar format for first operand of Sub, got {a!r}'
+                assert isinstance(b, ScalarFormatBound), f'expected scalar format for second operand of Sub, got {b!r}'
                 if isinstance(a, SetFormat) and isinstance(b, SetFormat):
                     return SetFormat(frozenset(va - vb for va in a.values for vb in b.values))
                 af_a = _to_abstract(a)
@@ -564,6 +571,8 @@ class _FormatInferInstance(Visitor):
             case Mul():
                 assert len(operands) == 2
                 a, b = operands
+                assert isinstance(a, ScalarFormatBound), f'expected scalar format for first operand of Mul, got {a!r}'
+                assert isinstance(b, ScalarFormatBound), f'expected scalar format for second operand of Mul, got {b!r}'
                 if isinstance(a, SetFormat) and isinstance(b, SetFormat):
                     return SetFormat(frozenset(va * vb for va in a.values for vb in b.values))
                 af_a = _to_abstract(a)
@@ -646,11 +655,12 @@ class _FormatInferInstance(Visitor):
     def _visit_unaryop(self, e: UnaryOp, ctx: None) -> FormatBound:
         arg_fmt = self._visit_expr(e.arg, ctx)
         if isinstance(e, Sum):
+            assert isinstance(arg_fmt, ListFormat), f'expected ListFormat for argument of Sum, got {arg_fmt!r}'
             return self._sum_bound(e, arg_fmt)
         tight = self._exact_arith_bound(e, (arg_fmt,))
         return tight if tight is not None else self._op_bound(e)
 
-    def _sum_bound(self, e: Sum, arg_fmt: FormatBound) -> FormatBound:
+    def _sum_bound(self, e: Sum, arg_fmt: ListFormat) -> FormatBound:
         """
         Format of ``Sum(xs)`` — reduce-by-pairwise-addition with rounding
         under the active context at each step.
@@ -666,8 +676,6 @@ class _FormatInferInstance(Visitor):
         """
         if not self._is_real_scope(e):
             return self._op_bound(e)
-        if not isinstance(arg_fmt, ListFormat):
-            return self._op_bound(e)
         n = self._known_iter_count(e.arg)
         if n is None:
             return self._op_bound(e)
@@ -679,6 +687,7 @@ class _FormatInferInstance(Visitor):
             # No addition occurs; the lone element passes through.
             return elt_fmt
         # Lift the element format once and accumulate ``n - 1`` times.
+        assert isinstance(elt_fmt, ScalarFormatBound), f'expected scalar format for elements of sum operand, got {elt_fmt!r}'
         af_elt = _to_abstract(elt_fmt)
         if af_elt is None:
             return self._op_bound(e)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -111,7 +111,6 @@ Format inference rules
 from dataclasses import dataclass
 from fractions import Fraction
 from functools import reduce
-from re import match
 from typing import Callable, Iterable, TypeAlias
 
 from ...ast.fpyast import *
@@ -1012,13 +1011,23 @@ class FormatInfer:
 
     This rule is applied at all control-flow merge points (phi nodes), including
     branch merges (``if``/``if1``) and loop back-edges (``while``/``for``).
-    Loops iterate body + join until phi bounds stop changing.  The
-    AbstractFormat-mediated scalar join introduces infinite ascending chains
-    when exact arithmetic (``+``/``-``/``*`` under :class:`RealContext`) is
-    applied to a phi'd value, so each loop fixpoint runs at most
-    ``loop_iter_limit`` iterations before switching joins to widen-mode
-    (distinct scalar Formats fall back to ``REAL_FORMAT``) to force
-    convergence.
+
+    **Loops** are handled in one of two modes:
+
+    - **Bounded iteration**: when a ``for`` loop's iterable has a
+      statically-known length (per :class:`ArraySizeAnalysis`), the
+      analysis drives the phi update for *exactly* that many body
+      executions.  This mirrors runtime semantics and avoids any
+      widening fall-back — important for the exact-arithmetic lattice,
+      which has infinite ascending chains.
+    - **Fixpoint + widening**: ``while`` loops and ``for`` loops over
+      symbolic-length iterables iterate body + join until phi bounds
+      stop changing.  The AbstractFormat-mediated scalar join introduces
+      infinite ascending chains when exact arithmetic
+      (``+``/``-``/``*`` under :class:`RealContext`) is applied to a
+      phi'd value, so the fixpoint runs at most ``loop_iter_limit``
+      iterations before switching joins to widen-mode (distinct scalar
+      Formats fall back to ``REAL_FORMAT``) to force convergence.
 
     **Usage**::
 

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -86,6 +86,12 @@ Format inference rules
   :class:`AbstractFormat`'s arithmetic
   (``(AbstractFormat.from_format(f1) ⊕ AbstractFormat.from_format(f2)).format()``)
   rather than widening to ``REAL_FORMAT``.
+- **Sum reduction** (``Sum`` under a concrete :class:`RealContext` over a
+  list whose size is statically known via :class:`ArraySizeAnalysis`):
+  simulates ``n - 1`` exact pairwise additions through
+  :class:`AbstractFormat` instead of widening.  Under non-REAL contexts
+  every pairwise add rounds to the scope's format, so the result is just
+  the scope's format (the default rule).
 - **Function calls** (``Call``): conservatively the top format of the callee's
   return type.
 - **Variable references** (``Var``): the format of the variable's definition.
@@ -639,8 +645,47 @@ class _FormatInferInstance(Visitor):
 
     def _visit_unaryop(self, e: UnaryOp, ctx: None) -> FormatBound:
         arg_fmt = self._visit_expr(e.arg, ctx)
+        if isinstance(e, Sum):
+            return self._sum_bound(e, arg_fmt)
         tight = self._exact_arith_bound(e, (arg_fmt,))
         return tight if tight is not None else self._op_bound(e)
+
+    def _sum_bound(self, e: Sum, arg_fmt: FormatBound) -> FormatBound:
+        """
+        Format of ``Sum(xs)`` — reduce-by-pairwise-addition with rounding
+        under the active context at each step.
+
+        - **Non-REAL scope**: each pairwise add rounds to the scope's
+          format, so the accumulator equals the scope's format
+          throughout.  Falls back to :meth:`_op_bound`.
+        - **REAL scope**: no rounding.  Simulate ``n - 1`` exact
+          additions through :class:`AbstractFormat` to produce a precise
+          containing format.  Requires the list size to be statically
+          known via :class:`ArraySizeAnalysis`; otherwise falls back to
+          ``REAL_FORMAT`` via :meth:`_op_bound`.
+        """
+        if not self._is_real_scope(e):
+            return self._op_bound(e)
+        if not isinstance(arg_fmt, ListFormat):
+            return self._op_bound(e)
+        n = self._known_iter_count(e.arg)
+        if n is None:
+            return self._op_bound(e)
+        elt_fmt = arg_fmt.elt
+        if n == 0:
+            # ``sum([])`` is conventionally 0.
+            return SetFormat(frozenset((Fraction(0),)))
+        if n == 1:
+            # No addition occurs; the lone element passes through.
+            return elt_fmt
+        # Lift the element format once and accumulate ``n - 1`` times.
+        af_elt = _to_abstract(elt_fmt)
+        if af_elt is None:
+            return self._op_bound(e)
+        af_acc = af_elt
+        for _ in range(n - 1):
+            af_acc = af_acc + af_elt
+        return af_acc.format()
 
     def _visit_binaryop(self, e: BinaryOp, ctx: None) -> FormatBound:
         lhs = self._visit_expr(e.first, ctx)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -846,17 +846,20 @@ class _FormatInferInstance(Visitor):
         return None
 
     def _visit_while(self, stmt: WhileStmt, ctx: None):
-        def body():
+        def iterate():
             self._visit_expr(stmt.cond, ctx)
             self._visit_block(stmt.body, ctx)
 
-        self._fixpoint(self.def_use.phis[stmt], body)
+        self._fixpoint(self.def_use.phis[stmt], iterate)
 
     def _visit_for(self, stmt: ForStmt, ctx: None):
         iter_fmt = self._visit_expr(stmt.iterable, ctx)
         assert isinstance(iter_fmt, ListFormat)
         self._visit_binding(stmt, stmt.target, iter_fmt.elt)
-        body = lambda: self._visit_block(stmt.body, ctx)
+
+        def iterate():
+            self._visit_block(stmt.body, ctx)
+
         # If the iterable's length is statically known, drive the phi
         # update for exactly that many body executions instead of
         # iterating to a fixpoint.  This matches the runtime semantics
@@ -864,9 +867,9 @@ class _FormatInferInstance(Visitor):
         # exact-arithmetic lattice.
         n = self._known_iter_count(stmt.iterable)
         if n is not None:
-            self._unroll(self.def_use.phis[stmt], body, n)
+            self._unroll(self.def_use.phis[stmt], iterate, n)
         else:
-            self._fixpoint(self.def_use.phis[stmt], body)
+            self._fixpoint(self.def_use.phis[stmt], iterate)
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
         # The context expression itself is not a numerical computation.

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -59,8 +59,17 @@ the body is iterated until the phi bounds stop changing.  The lattice has
 **infinite ascending chains** in the scalar sub-lattice when exact arithmetic
 (``+``/``-``/``*`` under :class:`RealContext`, see below) is applied to a
 phi'd value: each iteration widens the resulting :class:`AbstractFormat`'s
-precision and bounds without bound.  To force termination, each loop
-fixpoint runs at most ``loop_iter_limit`` iterations before switching joins
+precision and bounds without bound.
+
+When a ``for`` loop's iterable has a **statically-known length** (per
+:class:`ArraySizeAnalysis`), the analysis drives the phi update for
+*exactly* that many body executions instead of iterating to a fixpoint.
+This matches the runtime semantics exactly and avoids any widening fall-back
+— important for the exact-arithmetic lattice.
+
+For ``for`` loops with symbolic-length iterables and for ``while`` loops, the
+iteration count isn't known statically.  These fall back to the fixpoint
+loop, which runs at most ``loop_iter_limit`` iterations before switching joins
 to **widen-mode** — distinct scalar :class:`Format` inputs fall back to
 ``REAL_FORMAT`` instead of going through :class:`AbstractFormat` union, at
 which point the fixpoint converges in one more iteration.
@@ -96,6 +105,7 @@ Format inference rules
 from dataclasses import dataclass
 from fractions import Fraction
 from functools import reduce
+from re import match
 from typing import Callable, Iterable, TypeAlias
 
 from ...ast.fpyast import *
@@ -116,6 +126,7 @@ from ...types import (
     VarType,
 )
 
+from ..array_size import ArraySizeAnalysis, ArraySizeInfer, ListSize
 from ..context_use import ContextUse, ContextUseAnalysis, ContextScope, ContextUseSite
 from ..define_use import DefineUse, DefineUseAnalysis
 from ..reaching_defs import PhiDef, Definition, DefSite
@@ -159,7 +170,7 @@ class ListFormat:
     elt: 'FormatBound'
 
 
-FormatBound: TypeAlias = 'None | SetFormat | Format | TupleFormat | ListFormat'
+FormatBound: TypeAlias = None | SetFormat | Format | TupleFormat | ListFormat
 """
 Inferred format for an expression or variable definition.
 
@@ -212,6 +223,54 @@ def _top_bound(ty: Type) -> FormatBound:
             return None
         case _:
             raise RuntimeError(f'unreachable: unknown type {ty!r}')
+
+
+def _setformat_to_abstract(s: SetFormat) -> AbstractFormat | None:
+    """
+    Returns a tight :class:`AbstractFormat` containing every value in *s*,
+    or ``None`` when any value is non-dyadic (and therefore can't be
+    pinned by an :class:`AbstractFormat`'s integer ``prec``/``exp``).
+
+    Used by :meth:`_exact_arith_bound` to bridge a :class:`SetFormat`
+    operand into the :class:`AbstractFormat` arithmetic path so that
+    e.g. ``SetFormat({0}) + EFloatFormat`` doesn't bail to
+    ``REAL_FORMAT`` under exact-arithmetic.
+    """
+    if not s.values:
+        return None
+    if not all(is_dyadic(v) for v in s.values):
+        return None
+    rfs = [RealFloat.from_rational(v) for v in s.values]
+    # Bounds: max non-negative value and min non-positive value, with
+    # zero used when no value falls on the corresponding side.  This
+    # matches AbstractFormat's convention of pos_bound >= 0 and
+    # neg_bound <= 0.
+    pos_rfs = [rf for rf in rfs if not rf.s and not rf.is_zero()]
+    neg_rfs = [rf for rf in rfs if rf.s]
+    pos_bound = max(pos_rfs, default=RealFloat.from_int(0))
+    neg_bound = min(neg_rfs, default=RealFloat.from_int(0))
+    # Precision and exponent: tight enough to represent every value.
+    # ``RealFloat.p`` is 0 for zero values; AbstractFormat requires
+    # ``prec >= 1``, so floor at 1.
+    prec = max((rf.p for rf in rfs), default=1)
+    if prec < 1:
+        prec = 1
+    exp = min((rf.exp for rf in rfs), default=0)
+    return AbstractFormat(prec, exp, pos_bound, neg_bound=neg_bound)
+
+
+def _to_abstract(f: FormatBound) -> AbstractFormat | None:
+    """
+    Lifts an abstractable :class:`FormatBound` to an
+    :class:`AbstractFormat`.  Returns ``None`` for variants that the
+    abstract arithmetic doesn't accept (``None``, ``TupleFormat``,
+    ``ListFormat``, non-dyadic ``SetFormat``).
+    """
+    if isinstance(f, AbstractableFormat):
+        return AbstractFormat.from_format(f)
+    if isinstance(f, SetFormat):
+        return _setformat_to_abstract(f)
+    return None
 
 
 def _join_bounds(
@@ -366,6 +425,7 @@ class _FormatInferInstance(Visitor):
     func: FuncDef
     type_info: TypeAnalysis
     ctx_use: ContextUseAnalysis
+    array_size: ArraySizeAnalysis
 
     by_def: dict[Definition, FormatBound]
     by_expr: dict[Expr, FormatBound]
@@ -375,11 +435,13 @@ class _FormatInferInstance(Visitor):
         func: FuncDef,
         type_info: TypeAnalysis,
         ctx_use: ContextUseAnalysis,
+        array_size: ArraySizeAnalysis,
         loop_iter_limit: int,
     ):
         self.func = func
         self.type_info = type_info
         self.ctx_use = ctx_use
+        self.array_size = array_size
         self.by_def = {}
         self.by_expr = {}
         self._loop_iter_limit = loop_iter_limit
@@ -437,7 +499,7 @@ class _FormatInferInstance(Visitor):
         self,
         e: ContextUseSite,
         operands: tuple[FormatBound, ...],
-    ) -> Format | None:
+    ) -> Format | SetFormat | None:
         """
         Tries to compute a tight format for an exact arithmetic operation.
 
@@ -452,25 +514,60 @@ class _FormatInferInstance(Visitor):
         """
         if not self._is_real_scope(e):
             return None
-        afs: list[AbstractFormat] = []
-        for f in operands:
-            if not isinstance(f, AbstractableFormat):
-                return None
-            afs.append(AbstractFormat.from_format(f))
-        match e, afs:
-            case Neg(), [af]:
-                result = -af
-            case Abs(), [af]:
-                result = abs(af)
-            case Add(), [a, b]:
-                result = a + b
-            case Sub(), [a, b]:
-                result = a - b
-            case Mul(), [a, b]:
-                result = a * b
+        match e:
+            case Neg():
+                assert len(operands) == 1
+                op_fmt, = operands
+                if isinstance(op_fmt, AbstractableFormat):
+                    return (-AbstractFormat.from_format(op_fmt)).format()
+                elif isinstance(op_fmt, SetFormat):
+                    return SetFormat(frozenset(-v for v in op_fmt.values))
+                else:
+                    return None
+            case Abs():
+                assert len(operands) == 1
+                op_fmt, = operands
+                if isinstance(op_fmt, AbstractableFormat):
+                    return abs(AbstractFormat.from_format(op_fmt)).format()
+                elif isinstance(op_fmt, SetFormat):
+                    return SetFormat(frozenset(abs(v) for v in op_fmt.values))
+                else:
+                    return None
+            case Add():
+                assert len(operands) == 2
+                a, b = operands
+                # Both SetFormat: keep precision by pairwise sum.
+                if isinstance(a, SetFormat) and isinstance(b, SetFormat):
+                    return SetFormat(frozenset(va + vb for va in a.values for vb in b.values))
+                # Mixed or both AbstractableFormat: lift to AbstractFormat.
+                af_a = _to_abstract(a)
+                af_b = _to_abstract(b)
+                if af_a is None or af_b is None:
+                    return None
+                return (af_a + af_b).format()
+            case Sub():
+                assert len(operands) == 2
+                a, b = operands
+                if isinstance(a, SetFormat) and isinstance(b, SetFormat):
+                    return SetFormat(frozenset(va - vb for va in a.values for vb in b.values))
+                af_a = _to_abstract(a)
+                af_b = _to_abstract(b)
+                if af_a is None or af_b is None:
+                    return None
+                return (af_a - af_b).format()
+            case Mul():
+                assert len(operands) == 2
+                a, b = operands
+                if isinstance(a, SetFormat) and isinstance(b, SetFormat):
+                    return SetFormat(frozenset(va * vb for va in a.values for vb in b.values))
+                af_a = _to_abstract(a)
+                af_b = _to_abstract(b)
+                if af_a is None or af_b is None:
+                    return None
+                return (af_a * af_b).format()
             case _:
+                # unsupported operation
                 return None
-        return result.format()
 
     def _visit_binding(
         self,
@@ -700,6 +797,54 @@ class _FormatInferInstance(Visitor):
             iter_count += 1
         self._widen = saved_widen
 
+    def _unroll(
+        self,
+        phis: Iterable[PhiDef],
+        run_body: Callable[[], None],
+        n: int,
+    ):
+        """
+        Drive a loop's phi update for *exactly* ``n`` body executions.
+
+        Used when the iterable's length is statically known (via
+        :class:`ArraySizeAnalysis`).  At runtime the loop walks exactly
+        ``n`` body iterations, so the analysis can mirror that walk and
+        avoid widening — important for the exact-arithmetic
+        (``+``/``-``/``*`` under :class:`RealContext`) lattice, which has
+        infinite ascending chains.
+
+        Iter-by-iter visit produces a precise (if potentially wide)
+        bound after exactly ``n`` joins; the result is sound and
+        strictly more precise than the fixpoint+widening fall-back when
+        ``n`` is small.
+        """
+        phis = list(phis)
+        for phi in phis:
+            self._set_def_bound(phi, self._bound_of_def(self.def_use.defs[phi.lhs]))
+        if n == 0:
+            # Body never runs; the phi stays at the pre-loop value.
+            return
+        for _ in range(n):
+            run_body()
+            for phi in phis:
+                lhs = self._bound_of_def(self.def_use.defs[phi.lhs])
+                rhs = self._bound_of_def(self.def_use.defs[phi.rhs])
+                self._set_def_bound(phi, self._join(lhs, rhs))
+
+    def _known_iter_count(self, iterable: Expr) -> int | None:
+        """
+        Returns the iterable's statically-known length, or ``None``.
+
+        Consults :class:`ArraySizeAnalysis`.  Recognises ``ListSize``
+        expressions whose ``size`` is a concrete ``int`` (e.g. ``range``
+        with static bounds, list literals, comprehensions over
+        known-size iterables).
+        """
+        bound = self.array_size.by_expr.get(iterable)
+        if isinstance(bound, ListSize) and isinstance(bound.size, int):
+            return bound.size
+        return None
+
     def _visit_while(self, stmt: WhileStmt, ctx: None):
         def body():
             self._visit_expr(stmt.cond, ctx)
@@ -711,9 +856,17 @@ class _FormatInferInstance(Visitor):
         iter_fmt = self._visit_expr(stmt.iterable, ctx)
         assert isinstance(iter_fmt, ListFormat)
         self._visit_binding(stmt, stmt.target, iter_fmt.elt)
-        self._fixpoint(
-            self.def_use.phis[stmt], lambda: self._visit_block(stmt.body, ctx)
-        )
+        body = lambda: self._visit_block(stmt.body, ctx)
+        # If the iterable's length is statically known, drive the phi
+        # update for exactly that many body executions instead of
+        # iterating to a fixpoint.  This matches the runtime semantics
+        # exactly and avoids the widening fall-back for the
+        # exact-arithmetic lattice.
+        n = self._known_iter_count(stmt.iterable)
+        if n is not None:
+            self._unroll(self.def_use.phis[stmt], body, n)
+        else:
+            self._fixpoint(self.def_use.phis[stmt], body)
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
         # The context expression itself is not a numerical computation.
@@ -834,29 +987,36 @@ class FormatInfer:
         def_use: DefineUseAnalysis | None = None,
         type_info: TypeAnalysis | None = None,
         ctx_use: ContextUseAnalysis | None = None,
-        loop_iter_limit: int | None = None,
+        array_size: ArraySizeAnalysis | None = None,
+        loop_iter_limit: int = DEFAULT_LOOP_ITER_LIMIT,
     ) -> FormatAnalysis:
         """
         Performs format analysis on a compiled FPy function.
 
-        All three pre-analyses (``def_use``, ``type_info``, ``ctx_use``) are
-        computed automatically when not supplied.  Pre-computing them externally
-        is useful when they are also needed for other purposes.
+        All four pre-analyses (``def_use``, ``type_info``, ``ctx_use``,
+        ``array_size``) are computed automatically when not supplied.
+        Pre-computing them externally is useful when they are also needed
+        for other purposes.
 
         Args:
-            func:      The :class:`FuncDef` AST node to analyse.
-            def_use:   Optional pre-computed definition-use analysis.
-            type_info: Optional pre-computed type analysis.
-            ctx_use:   Optional pre-computed context-use analysis.
+            func:        The :class:`FuncDef` AST node to analyse.
+            def_use:     Optional pre-computed definition-use analysis.
+            type_info:   Optional pre-computed type analysis.
+            ctx_use:     Optional pre-computed context-use analysis.
+            array_size:  Optional pre-computed array-size analysis.
+                Used to recognise ``for`` loops whose iterable has a
+                statically-known length, so the phi update can be driven
+                exactly that many times instead of iterating to a
+                fixpoint.  This is strictly more precise — important for
+                the exact-arithmetic lattice (``+``/``-``/``*`` under
+                :class:`RealContext`) which has infinite ascending
+                chains.
             loop_iter_limit:
                 Number of loop body+join iterations to run before forcing
                 joins of distinct scalar Formats to widen to ``REAL_FORMAT``.
-                Required because exact-arithmetic operations (``+``, ``-``,
-                ``*``) under :class:`RealContext` produce ``AbstractFormat``
-                lattices with infinite ascending chains; without a cap, a
-                loop body that performs such arithmetic on a phi'd value
-                would not converge.  Defaults to
-                :attr:`DEFAULT_LOOP_ITER_LIMIT`.
+                Only applies to loops without a known iteration count
+                (``while`` loops, and ``for`` loops over symbolic-size
+                iterables).  Defaults to :attr:`DEFAULT_LOOP_ITER_LIMIT`.
 
         Returns:
             A :class:`FormatAnalysis` result whose ``by_def`` and ``by_expr``
@@ -875,9 +1035,9 @@ class FormatInfer:
             type_info = TypeInfer.check(func, def_use=def_use)
         if ctx_use is None:
             ctx_use = ContextUse.analyze(func, def_use=def_use)
-        if loop_iter_limit is None:
-            loop_iter_limit = FormatInfer.DEFAULT_LOOP_ITER_LIMIT
+        if array_size is None:
+            array_size = ArraySizeInfer.analyze(func, type_info=type_info)
 
         return _FormatInferInstance(
-            func, type_info, ctx_use, loop_iter_limit=loop_iter_limit
+            func, type_info, ctx_use, array_size, loop_iter_limit=loop_iter_limit
         ).analyze()

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -577,6 +577,202 @@ class TestFormatInfer:
             f"expected outer widen-mode to propagate into inner loop, got {z_bounds}"
         )
 
+    # ------------------------------------------------------------------
+    # Bounded-iteration mode for for-loops with statically known length
+
+    def test_for_loop_with_known_count_is_unrolled_precisely(self):
+        """
+        ``for _ in range(0, N)`` where ``N`` is a static int: the analysis
+        drives the phi update for exactly ``N`` body executions instead of
+        iterating to a fixpoint.  Under a body that uses exact arithmetic
+        (``z = z + a`` under ``with fp.REAL``) this avoids the
+        widen-to-REAL_FORMAT fall-back and produces a precise containing
+        Format — the AbstractFormat-mediated bound after exactly N
+        iterations.
+        """
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP32:
+                a = fp.round(x)
+            z = a
+            for _ in range(0, 3):
+                with fp.REAL:
+                    z = z + a
+            return z
+
+        info = self._run(f)
+        z_bounds = [b for d, b in info.by_def.items() if d.name.base == 'z']
+        # The loop phi must be a precise Format containing FP32, *not*
+        # REAL_FORMAT (which would happen if widening kicked in).
+        precise = [
+            b for b in z_bounds
+            if isinstance(b, Format) and b != REAL_FORMAT
+        ]
+        assert precise, (
+            f'expected a precise (non-REAL_FORMAT) z bound, got {z_bounds}'
+        )
+        assert REAL_FORMAT not in z_bounds, (
+            f'bounded iteration must not widen to REAL_FORMAT, got {z_bounds}'
+        )
+
+    def test_for_loop_with_unknown_count_still_widens(self):
+        """
+        Counterpart: when the iterable's length is *not* statically
+        known (here: ``range(0, n)`` with symbolic ``n``), the analysis
+        falls back to fixpoint+widening and the loop phi widens to
+        ``REAL_FORMAT`` because exact arithmetic produces an
+        infinite-height chain.
+        """
+        @fp.fpy
+        def f(x: fp.Real, n: fp.Real) -> fp.Real:
+            with fp.FP32:
+                a = fp.round(x)
+            z = a
+            for _ in range(0, n):  # n symbolic → unknown size
+                with fp.REAL:
+                    z = z + a
+            return z
+
+        info = self._run(f)
+        z_bounds = [b for d, b in info.by_def.items() if d.name.base == 'z']
+        assert REAL_FORMAT in z_bounds, (
+            f'expected fixpoint+widen to widen to REAL_FORMAT, got {z_bounds}'
+        )
+
+    def test_for_loop_with_zero_count_keeps_pre_loop_bound(self):
+        """
+        ``for _ in range(0, 0)`` runs 0 iterations.  The body never
+        executes, so the loop phi stays at the pre-loop value.
+        """
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP32:
+                a = fp.round(x)
+            z = a
+            for _ in range(0, 0):
+                with fp.REAL:
+                    z = z + a
+            return z
+
+        info = self._run(f)
+        # All z-bounds must be FP32 (no widening since body didn't run).
+        z_bounds = [b for d, b in info.by_def.items() if d.name.base == 'z']
+        fp32 = fp.FP32.format()
+        assert all(b == fp32 for b in z_bounds), (
+            f'expected all z bounds to be FP32 with N=0, got {z_bounds}'
+        )
+
+    # ------------------------------------------------------------------
+    # Exact arithmetic with SetFormat operands
+
+    def test_exact_add_setformat_with_format(self):
+        """
+        ``acc + x`` under REAL where ``acc`` starts as ``SetFormat({0})``
+        and ``x`` has a concrete Format.  The SetFormat operand must be
+        lifted to an :class:`AbstractFormat`, allowing exact-arith to
+        produce a precise containing Format instead of falling back to
+        ``REAL_FORMAT``.
+        """
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP32:
+                a = fp.round(x)
+            with fp.REAL:
+                acc = 0
+                acc = acc + a
+            return acc
+
+        info = self._run(f)
+        # The Add expression's format should be a precise Format
+        # (containing FP32), not REAL_FORMAT.
+        adds = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Add']
+        assert adds, 'expected an Add expression'
+        result = adds[-1]
+        assert isinstance(result, Format)
+        assert result != REAL_FORMAT, (
+            f'expected SetFormat({{0}}) + FP32 to lift through AbstractFormat, '
+            f'got {result}'
+        )
+
+    def test_exact_add_two_setformats_stays_precise(self):
+        """
+        ``SetFormat({a}) + SetFormat({b})`` under REAL stays a SetFormat
+        with the pairwise sum — strictly more precise than going through
+        AbstractFormat.
+        """
+        @fp.fpy
+        def f() -> fp.Real:
+            with fp.REAL:
+                z = 1.0 + 2.0
+            return z
+
+        info = self._run(f)
+        adds = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Add']
+        assert adds, 'expected an Add expression'
+        result = adds[-1]
+        assert isinstance(result, SetFormat), f'expected SetFormat, got {result}'
+        assert result.values == frozenset((Fraction(3),)), (
+            f'expected SetFormat({{3}}), got {result}'
+        )
+
+    def test_exact_sub_setformat_with_format(self):
+        """``a - SetFormat({0})`` under REAL preserves a's format."""
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP32:
+                a = fp.round(x)
+            with fp.REAL:
+                z = a - 0
+            return z
+
+        info = self._run(f)
+        subs = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Sub']
+        assert subs, 'expected a Sub expression'
+        assert isinstance(subs[-1], Format) and subs[-1] != REAL_FORMAT
+
+    def test_exact_mul_setformat_with_format(self):
+        """``a * SetFormat({2})`` under REAL produces a containing Format."""
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP32:
+                a = fp.round(x)
+            with fp.REAL:
+                z = a * 2.0
+            return z
+
+        info = self._run(f)
+        muls = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Mul']
+        assert muls, 'expected a Mul expression'
+        assert isinstance(muls[-1], Format) and muls[-1] != REAL_FORMAT
+
+    def test_exact_arith_setformat_accumulator_pattern(self):
+        """
+        End-to-end: the user's block-accumulator pattern.  ``block_acc =
+        0; for j in range(K): block_acc += block[j]`` under REAL must
+        produce a precise containing Format for ``block_acc``, not
+        ``REAL_FORMAT`` (which would happen if ``SetFormat({0}) +
+        EFloatFormat`` bailed to the scope's format).
+        """
+        @fp.fpy(ctx=fp.REAL)
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.MX_E4M3:
+                ys = [fp.round(x) for x in xs]
+            block_acc = 0
+            for j in range(0, 4):
+                block_acc = block_acc + ys[j]
+            return block_acc
+
+        info = self._run(f)
+        block_acc_bounds = [
+            b for d, b in info.by_def.items() if d.name.base == 'block_acc'
+        ]
+        # The loop phi must be a precise (non-REAL_FORMAT) format
+        # containing MX_E4M3 — the SetFormat({0}) initial value lifted
+        # through AbstractFormat into the inner-loop accumulation.
+        assert REAL_FORMAT not in block_acc_bounds, (
+            f'expected block_acc to stay precise, got {block_acc_bounds}'
+        )
+
     def test_exact_arith_skipped_under_concrete_round(self):
         """
         Under a concrete non-REAL context (e.g., FP32), arithmetic results

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -773,6 +773,105 @@ class TestFormatInfer:
             f'expected block_acc to stay precise, got {block_acc_bounds}'
         )
 
+    # ------------------------------------------------------------------
+    # Sum reduction
+
+    def test_sum_under_real_with_known_size(self):
+        """
+        ``sum(ys)`` under ``with fp.REAL`` over a known-size list of
+        MX_E4M3 elements: simulate ``n - 1`` exact pairwise additions
+        through :class:`AbstractFormat`.  Result is a precise containing
+        Format, not ``REAL_FORMAT``.
+        """
+        @fp.fpy(ctx=fp.REAL)
+        def f() -> fp.Real:
+            with fp.MX_E4M3:
+                ys = [fp.round(0.1), fp.round(0.2),
+                      fp.round(0.3), fp.round(0.4)]
+            return sum(ys)
+
+        info = self._run(f)
+        sums = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Sum']
+        assert sums and isinstance(sums[-1], Format) and sums[-1] != REAL_FORMAT, (
+            f'expected precise Sum bound under REAL, got {sums}'
+        )
+        # Bound must contain a single MX_E4M3 element.
+        mx_e4m3 = fp.MX_E4M3.format()
+        assert sums[-1].representable_in(mx_e4m3.maxval()._real)
+
+    def test_sum_under_concrete_ctx_returns_scope_format(self):
+        """
+        Under a concrete non-REAL context, every pairwise add rounds to
+        the scope's format, so ``sum(ys)`` reports the scope's format
+        (the default ``_op_bound`` rule).
+        """
+        @fp.fpy
+        def f() -> fp.Real:
+            with fp.MX_E4M3:
+                ys = [fp.round(0.1), fp.round(0.2),
+                      fp.round(0.3), fp.round(0.4)]
+            with fp.FP32:
+                return sum(ys)
+
+        info = self._run(f)
+        sums = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Sum']
+        assert sums and sums[-1] == fp.FP32.format(), (
+            f'expected Sum to report FP32 (scope format), got {sums}'
+        )
+
+    def test_sum_unknown_size_falls_back(self):
+        """
+        ``sum(xs)`` over a symbolic-size list under REAL: the iteration
+        count isn't known, so the analysis falls back to the default
+        rule which yields ``REAL_FORMAT`` under REAL scope.
+        """
+        @fp.fpy(ctx=fp.REAL)
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.MX_E4M3:
+                ys = [fp.round(x) for x in xs]
+            return sum(ys)
+
+        info = self._run(f)
+        sums = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Sum']
+        assert sums and sums[-1] == REAL_FORMAT, (
+            f'expected REAL_FORMAT fall-back when size is unknown, got {sums}'
+        )
+
+    def test_sum_grows_with_known_size(self):
+        """
+        Sanity: larger N produces a wider precise format under REAL.
+        """
+        @fp.fpy(ctx=fp.REAL)
+        def small() -> fp.Real:
+            with fp.FP32:
+                ys = [fp.round(1.0), fp.round(1.0)]
+            return sum(ys)
+
+        @fp.fpy(ctx=fp.REAL)
+        def big() -> fp.Real:
+            with fp.FP32:
+                ys = [fp.round(1.0), fp.round(1.0), fp.round(1.0),
+                      fp.round(1.0), fp.round(1.0), fp.round(1.0),
+                      fp.round(1.0), fp.round(1.0)]
+            return sum(ys)
+
+        small_sum = [
+            b for e, b in self._run(small).by_expr.items()
+            if type(e).__name__ == 'Sum'
+        ][-1]
+        big_sum = [
+            b for e, b in self._run(big).by_expr.items()
+            if type(e).__name__ == 'Sum'
+        ][-1]
+        # Both must be precise (non-REAL_FORMAT).
+        assert isinstance(small_sum, Format) and small_sum != REAL_FORMAT
+        assert isinstance(big_sum, Format) and big_sum != REAL_FORMAT
+        # Size-8 sum's bound must contain size-2 sum's max value
+        # (since both bounds are non-negative and big_sum is wider).
+        # Concretely: big_sum.representable_in(small_sum.maxval) holds.
+        small_max = small_sum.maxval()._real
+        assert big_sum.representable_in(small_max)
+
     def test_blockwise_quantized_accumulator_end_to_end(self):
         """
         Regression: a realistic blockwise quantized-accumulator pattern.

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -773,6 +773,92 @@ class TestFormatInfer:
             f'expected block_acc to stay precise, got {block_acc_bounds}'
         )
 
+    def test_blockwise_quantized_accumulator_end_to_end(self):
+        """
+        Regression: a realistic blockwise quantized-accumulator pattern.
+
+        - ``ys`` is quantized to MX_E4M3.
+        - Outer loop iterates blocks of K=32; each iteration takes a
+          slice ``block = ys[i:i+K]`` and accumulates K elements under
+          REAL into ``block_acc``.
+        - The block accumulator is then added into ``acc`` under FP32.
+
+        This exercises every load-bearing piece of the analysis at once:
+
+        - ``ListSize`` resolution for ``range(K)`` (= 32) so the inner
+          loop is unrolled exactly 32 times instead of fixpoint+widening.
+        - ``SetFormat({0}) + EFloatFormat`` lifted through
+          :class:`AbstractFormat` so the inner accumulator stays precise.
+        - The FP32 ``with`` block forcing a clean rounded format on
+          ``acc`` regardless of the symbolic outer-loop count.
+
+        Before the SetFormat → AbstractFormat lift and the bounded-iter
+        mode, ``block_acc`` widened to ``REAL_FORMAT`` on the first
+        body pass and contaminated everything downstream.
+        """
+        @fp.fpy(ctx=fp.REAL)
+        def foo(xs: list[fp.Real]):
+            # block size
+            K = 32
+
+            # quantize to E4M3
+            with fp.MX_E4M3:
+                ys = [fp.round(x) for x in xs]
+            # accumulate in blocks of K
+            acc = 0
+            for i in range(0, len(ys), K):
+                block = ys[i : i + K]
+                block_acc = 0
+                for j in range(K):
+                    block_acc += block[j]
+                # quantize block accumulation to FP32
+                with fp.FP32:
+                    acc += block_acc
+            # return final result in FP32
+            return acc
+
+        info = self._run(foo)
+
+        # 1. block_acc must stay precise (no REAL_FORMAT contamination
+        #    from the inner accumulator).
+        block_acc_bounds = [
+            b for d, b in info.by_def.items() if d.name.base == 'block_acc'
+        ]
+        assert REAL_FORMAT not in block_acc_bounds, (
+            f'expected block_acc to stay precise, got {block_acc_bounds}'
+        )
+        # And it must reach a Format strictly tighter than REAL_FORMAT
+        # at the loop phi (the bounded-iter mode produced an
+        # MPB-Float-shaped accumulator that contains 32 × MX_E4M3_max).
+        widened = [
+            b for b in block_acc_bounds
+            if isinstance(b, Format) and b != REAL_FORMAT
+        ]
+        assert widened, (
+            f'expected a precise containing Format among block_acc bounds, '
+            f'got {block_acc_bounds}'
+        )
+
+        # 2. acc must reach FP32 — every write is inside ``with fp.FP32``,
+        #    so the FP32 round dominates regardless of the outer loop's
+        #    symbolic iteration count.
+        acc_bounds = [
+            b for d, b in info.by_def.items() if d.name.base == 'acc'
+        ]
+        assert fp.FP32.format() in acc_bounds, (
+            f'expected FP32 among acc bounds, got {acc_bounds}'
+        )
+
+        # 3. ys is the rounded list — its element format is MX_E4M3.
+        ys_bounds = [
+            b for d, b in info.by_def.items() if d.name.base == 'ys'
+        ]
+        mx_e4m3 = fp.MX_E4M3.format()
+        assert any(
+            isinstance(b, ListFormat) and b.elt == mx_e4m3
+            for b in ys_bounds
+        ), f'expected ListFormat(MX_E4M3) among ys bounds, got {ys_bounds}'
+
     def test_exact_arith_skipped_under_concrete_round(self):
         """
         Under a concrete non-REAL context (e.g., FP32), arithmetic results


### PR DESCRIPTION
This PR integrates array size inference into the format inference algorithm:
 - if for loops have a static size, then the analysis virtually unrolls the loops
 - improves handling of exact arithmetic with `SetFormat` inputs