### PR TITLE
Update format inference algorithm

### DIFF
--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -233,17 +233,30 @@ def _all_representable_in(values: frozenset[Fraction], fmt: Format) -> bool:
     return True
 
 
-def _top_bound(ty: Type) -> FormatBound:
+def _bound_of_type(ty: Type) -> FormatBound:
     """
-    Returns the top of the format lattice for *ty*.
+    Derives the most precise :data:`FormatBound` we can from a static
+    type alone — used to seed argument bindings, free variables, and
+    other places where no expression-level format is yet available.
 
-    For scalar real values this is ``REAL_FORMAT`` by default — but when
-    a monomorphizing pass has embedded a concrete :class:`Context` in
-    ``RealType.ctx``, the precise ``ctx.format()`` is returned instead.
-    For tuples and lists it is a structural format whose leaves are
-    derived recursively (so a list-of-FP32 argument produces
-    ``ListFormat(IEEEFormat(es=8, nbits=32))``).  For non-numeric types
-    (bool, context, function, type variable) it is ``None``.
+    For scalar real values, the result depends on whether the type
+    carries a concrete rounding context (``RealType.ctx``):
+
+    - **No context** (the default for un-monomorphized programs): the
+      format is unknown, so we return the scalar top ``REAL_FORMAT``.
+    - **Concrete context** (typical after a monomorphizing pass): the
+      format is pinned to ``ctx.format()`` directly.
+
+    For tuples and lists this is applied recursively to the element
+    types, so a monomorphized ``list[Real[FP32]]`` becomes
+    ``ListFormat(IEEEFormat(es=8, nbits=32))``.  For non-numeric types
+    (bool, context, function, type variable) the result is ``None``.
+
+    Note: the function is no longer always the *top* of the lattice —
+    when a concrete ctx is present the result is a pinned, possibly
+    non-top format.  The name reflects that it derives a bound *from a
+    type* (parallel to :meth:`_bound_of_def`, which retrieves a bound
+    by definition site).
     """
     match ty:
         case RealType():
@@ -255,9 +268,9 @@ def _top_bound(ty: Type) -> FormatBound:
                 return ty.ctx.format()
             return REAL_FORMAT
         case TupleType():
-            return TupleFormat(tuple(_top_bound(t) for t in ty.elts))
+            return TupleFormat(tuple(_bound_of_type(t) for t in ty.elts))
         case ListType():
-            return ListFormat(_top_bound(ty.elt))
+            return ListFormat(_bound_of_type(ty.elt))
         case BoolType() | ContextType() | FunctionType() | VarType():
             return None
         case _:
@@ -514,7 +527,7 @@ class _FormatInferInstance(Visitor):
         ret_ty = self.type_info.by_expr[e]
         if isinstance(ret_ty, RealType):
             return self._scope_format(e)
-        return _top_bound(ret_ty)
+        return _bound_of_type(ret_ty)
 
     def _is_real_scope(self, e: ContextUseSite) -> bool:
         """Returns True iff *e*'s active scope is the :data:`REAL` singleton.
@@ -733,7 +746,7 @@ class _FormatInferInstance(Visitor):
             self._visit_expr(arg, ctx)
         for _, kwarg in e.kwargs:
             self._visit_expr(kwarg, ctx)
-        return _top_bound(self.type_info.by_expr[e])
+        return _bound_of_type(self.type_info.by_expr[e])
 
     # Comparison: produces a bool, so no numeric format
     def _visit_compare(self, e: Compare, ctx: None) -> FormatBound:
@@ -753,7 +766,7 @@ class _FormatInferInstance(Visitor):
             # Empty list: derive the element format from the inferred list type.
             list_ty = self.type_info.by_expr[e]
             assert isinstance(list_ty, ListType)
-            joined = _top_bound(list_ty.elt)
+            joined = _bound_of_type(list_ty.elt)
         return ListFormat(joined)
 
     def _visit_list_comp(self, e: ListComp, ctx: None) -> FormatBound:
@@ -971,11 +984,11 @@ class _FormatInferInstance(Visitor):
         for arg in func.args:
             if isinstance(arg.name, NamedId):
                 d = self.def_use.find_def_from_site(arg.name, arg)
-                self._set_def_bound(d, _top_bound(self.type_info.by_def[d]))
+                self._set_def_bound(d, _bound_of_type(self.type_info.by_def[d]))
         # Free variables (captured from outer scope): top format of inferred type.
         for v in func.free_vars:
             d = self.def_use.find_def_from_site(v, func)
-            self._set_def_bound(d, _top_bound(self.type_info.by_def[d]))
+            self._set_def_bound(d, _bound_of_type(self.type_info.by_def[d]))
         self._visit_block(func.body, ctx)
 
     def analyze(self) -> FormatAnalysis:

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -57,9 +57,9 @@ The analysis tracks a **format** that mirrors the basic-type structure::
 For loops, phi nodes are initialised from the pre-loop definition's format and
 the body is iterated until the phi bounds stop changing.  The lattice has
 **infinite ascending chains** in the scalar sub-lattice when exact arithmetic
-(``+``/``-``/``*`` under :class:`RealContext`, see below) is applied to a
-phi'd value: each iteration widens the resulting :class:`AbstractFormat`'s
-precision and bounds without bound.
+(``+``/``-``/``*`` under :data:`REAL`, see below) is applied to a phi'd value:
+each iteration widens the resulting :class:`AbstractFormat`'s precision and
+bounds without bound.
 
 When a ``for`` loop's iterable has a **statically-known length** (per
 :class:`ArraySizeAnalysis`), the analysis drives the phi update for
@@ -80,18 +80,20 @@ Format inference rules
   ``TernaryOp``, ``NaryOp``): the result is rounded to the active rounding
   context's format, i.e. ``scope.ctx.format()`` when the context is concrete,
   or ``REAL_FORMAT`` when it is a symbolic variable.
-- **Exact arithmetic** (``Neg``, ``Abs``, ``Add``, ``Sub``, ``Mul`` under a
-  concrete :class:`RealContext`): tighter than the default rule.  When all
+- **Exact arithmetic** (``Neg``, ``Abs``, ``Add``, ``Sub``, ``Mul`` under
+  the :data:`REAL` singleton): tighter than the default rule.  When all
   operand formats are abstractable, the result is computed via
   :class:`AbstractFormat`'s arithmetic
   (``(AbstractFormat.from_format(f1) ⊕ AbstractFormat.from_format(f2)).format()``)
-  rather than widening to ``REAL_FORMAT``.
-- **Sum reduction** (``Sum`` under a concrete :class:`RealContext` over a
-  list whose size is statically known via :class:`ArraySizeAnalysis`):
-  simulates ``n - 1`` exact pairwise additions through
-  :class:`AbstractFormat` instead of widening.  Under non-REAL contexts
-  every pairwise add rounds to the scope's format, so the result is just
-  the scope's format (the default rule).
+  rather than widening to ``REAL_FORMAT``.  The check is identity
+  against the singleton — other :class:`RealContext` instances are not
+  recognised.
+- **Sum reduction** (``Sum`` under :data:`REAL` over a list whose size is
+  statically known via :class:`ArraySizeAnalysis`): simulates ``n - 1``
+  exact pairwise additions through :class:`AbstractFormat` instead of
+  widening.  Under non-REAL contexts every pairwise add rounds to the
+  scope's format, so the result is just the scope's format (the default
+  rule).
 - **Integer-producing operations** (``Len``, ``Dim``, ``Size``,
   ``Range1``/``Range2``/``Range3``, the integer projection of
   ``Enumerate``): the result format is ``INTEGER`` regardless of the
@@ -125,7 +127,8 @@ from ...ast.fpyast import *
 from ...ast.visitor import Visitor
 from ...number import Context, INTEGER
 from ...number.context.format import Format
-from ...number.context.real import REAL_FORMAT, RealContext
+from ...number import REAL
+from ...number.context.real import REAL_FORMAT
 from ...number.number.reals import RealFloat
 from ...utils import is_dyadic
 from ...types import (
@@ -504,13 +507,16 @@ class _FormatInferInstance(Visitor):
         return _top_bound(ret_ty)
 
     def _is_real_scope(self, e: ContextUseSite) -> bool:
-        """Returns True iff *e*'s active scope is a concrete :class:`RealContext`.
+        """Returns True iff *e*'s active scope is the :data:`REAL` singleton.
 
         Distinct from ``_scope_format(e) == REAL_FORMAT`` because the latter
         also fires for symbolic (unresolved) context variables, where we
-        cannot assume the rounding is the identity.
+        cannot assume the rounding is the identity.  ``REAL`` is a unique
+        singleton, so identity comparison is the right check (and avoids
+        accidentally matching other ``RealContext`` instances that this
+        analysis does not support).
         """
-        return isinstance(self.ctx_use.find_scope_from_use(e).ctx, RealContext)
+        return self.ctx_use.find_scope_from_use(e).ctx is REAL
 
     def _visit_binding(
         self,
@@ -862,7 +868,7 @@ class _FormatInferInstance(Visitor):
         :class:`ArraySizeAnalysis`).  At runtime the loop walks exactly
         ``n`` body iterations, so the analysis can mirror that walk and
         avoid widening — important for the exact-arithmetic
-        (``+``/``-``/``*`` under :class:`RealContext`) lattice, which has
+        (``+``/``-``/``*`` under :data:`REAL`) lattice, which has
         infinite ascending chains.
 
         Iter-by-iter visit produces a precise (if potentially wide)
@@ -1023,10 +1029,10 @@ class FormatInfer:
       symbolic-length iterables iterate body + join until phi bounds
       stop changing.  The AbstractFormat-mediated scalar join introduces
       infinite ascending chains when exact arithmetic
-      (``+``/``-``/``*`` under :class:`RealContext`) is applied to a
-      phi'd value, so the fixpoint runs at most ``loop_iter_limit``
-      iterations before switching joins to widen-mode (distinct scalar
-      Formats fall back to ``REAL_FORMAT``) to force convergence.
+      (``+``/``-``/``*`` under :data:`REAL`) is applied to a phi'd
+      value, so the fixpoint runs at most ``loop_iter_limit`` iterations
+      before switching joins to widen-mode (distinct scalar Formats fall
+      back to ``REAL_FORMAT``) to force convergence.
 
     **Usage**::
 
@@ -1074,8 +1080,7 @@ class FormatInfer:
                 exactly that many times instead of iterating to a
                 fixpoint.  This is strictly more precise — important for
                 the exact-arithmetic lattice (``+``/``-``/``*`` under
-                :class:`RealContext`) which has infinite ascending
-                chains.
+                :data:`REAL`) which has infinite ascending chains.
             loop_iter_limit:
                 Number of loop body+join iterations to run before forcing
                 joins of distinct scalar Formats to widen to ``REAL_FORMAT``.

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -92,6 +92,14 @@ Format inference rules
   :class:`AbstractFormat` instead of widening.  Under non-REAL contexts
   every pairwise add rounds to the scope's format, so the result is just
   the scope's format (the default rule).
+- **Integer-producing operations** (``Len``, ``Dim``, ``Size``,
+  ``Range1``/``Range2``/``Range3``, the integer projection of
+  ``Enumerate``): the result format is ``INTEGER`` regardless of the
+  active rounding context.  These ops always produce integer values, so
+  reporting the active context's format would be unnecessarily loose
+  (e.g., ``len(xs)`` under ``with fp.FP32`` is still an integer, not an
+  arbitrary FP32 value).  ``Range`` returns ``ListFormat(INTEGER)``;
+  ``Enumerate(xs)`` returns ``ListFormat(TupleFormat(INTEGER, xs.elt))``.
 - **Function calls** (``Call``): conservatively the top format of the callee's
   return type.
 - **Variable references** (``Var``): the format of the variable's definition.
@@ -115,7 +123,7 @@ from typing import Callable, Iterable, TypeAlias
 
 from ...ast.fpyast import *
 from ...ast.visitor import Visitor
-from ...number import Context
+from ...number import Context, INTEGER
 from ...number.context.format import Format
 from ...number.context.real import REAL_FORMAT, RealContext
 from ...number.number.reals import RealFloat
@@ -188,6 +196,17 @@ Inferred format for an expression or variable definition.
 - :class:`TupleFormat` — heterogeneous tuple, per-element formats preserved.
 - :class:`ListFormat` — homogeneous list, single element format (the join of
   all element formats).
+"""
+
+
+_INTEGER_FORMAT: Format = INTEGER.format()
+"""
+Cached format for the :data:`INTEGER` context — used as the result
+format of integer-producing operations (``Len``, ``Dim``, ``Size``,
+``Range1``/``Range2``/``Range3``, the integer projection of
+``Enumerate``).  These ops always produce integer values regardless of
+the active rounding context, so reporting the active context's format
+would be unnecessarily loose.
 """
 
 
@@ -653,6 +672,19 @@ class _FormatInferInstance(Visitor):
 
     def _visit_unaryop(self, e: UnaryOp, ctx: None) -> FormatBound:
         arg_fmt = self._visit_expr(e.arg, ctx)
+        # Integer-producing scalar ops: result format is INTEGER
+        # regardless of the active rounding context.
+        if isinstance(e, Len | Dim):
+            return _INTEGER_FORMAT
+        # Integer-producing list ops: result is a list of integers.
+        if isinstance(e, Range1):
+            return ListFormat(_INTEGER_FORMAT)
+        # Enumerate(xs) → list of (int, elt) tuples; the int projection
+        # is INTEGER, the original element format is preserved.
+        if isinstance(e, Enumerate):
+            assert isinstance(arg_fmt, ListFormat), \
+                f'expected ListFormat for argument of Enumerate, got {arg_fmt!r}'
+            return ListFormat(TupleFormat((_INTEGER_FORMAT, arg_fmt.elt)))
         if isinstance(e, Sum):
             assert isinstance(arg_fmt, ListFormat), f'expected ListFormat for argument of Sum, got {arg_fmt!r}'
             return self._sum_bound(e, arg_fmt)
@@ -698,6 +730,11 @@ class _FormatInferInstance(Visitor):
     def _visit_binaryop(self, e: BinaryOp, ctx: None) -> FormatBound:
         lhs = self._visit_expr(e.first, ctx)
         rhs = self._visit_expr(e.second, ctx)
+        # Integer-producing ops: result format is INTEGER.
+        if isinstance(e, Size):
+            return _INTEGER_FORMAT
+        if isinstance(e, Range2):
+            return ListFormat(_INTEGER_FORMAT)
         tight = self._exact_arith_bound(e, (lhs, rhs))
         return tight if tight is not None else self._op_bound(e)
 
@@ -705,6 +742,8 @@ class _FormatInferInstance(Visitor):
         self._visit_expr(e.first, ctx)
         self._visit_expr(e.second, ctx)
         self._visit_expr(e.third, ctx)
+        if isinstance(e, Range3):
+            return ListFormat(_INTEGER_FORMAT)
         return self._op_bound(e)
 
     def _visit_naryop(self, e: NaryOp, ctx: None) -> FormatBound:

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -237,12 +237,22 @@ def _top_bound(ty: Type) -> FormatBound:
     """
     Returns the top of the format lattice for *ty*.
 
-    For scalar real values this is ``REAL_FORMAT``; for tuples and lists it is
-    a structural format with ``REAL_FORMAT`` (or ``None``) at the leaves.  For
-    non-numeric types (bool, context, function, type variable) it is ``None``.
+    For scalar real values this is ``REAL_FORMAT`` by default — but when
+    a monomorphizing pass has embedded a concrete :class:`Context` in
+    ``RealType.ctx``, the precise ``ctx.format()`` is returned instead.
+    For tuples and lists it is a structural format whose leaves are
+    derived recursively (so a list-of-FP32 argument produces
+    ``ListFormat(IEEEFormat(es=8, nbits=32))``).  For non-numeric types
+    (bool, context, function, type variable) it is ``None``.
     """
     match ty:
         case RealType():
+            # If the type carries a concrete rounding context, the format
+            # is pinned by that context — typically the case after a
+            # monomorphization pass.  Otherwise (symbolic or absent ctx)
+            # the format is unknown and we report the scalar top.
+            if isinstance(ty.ctx, Context):
+                return ty.ctx.format()
             return REAL_FORMAT
         case TupleType():
             return TupleFormat(tuple(_top_bound(t) for t in ty.elts))

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -659,19 +659,33 @@ class _FormatInferInstance(Visitor):
           containing format.  Requires the list size to be statically
           known via :class:`ArraySizeAnalysis`; otherwise falls back to
           ``REAL_FORMAT`` via :meth:`_op_bound`.
+
+        The branches below are ordered so that the trivial cases
+        (``n == 0`` and ``n == 1``) are decided before any
+        abstractability check on the element format — those cases
+        produce a precise bound independent of whether the elements
+        could be lifted to :class:`AbstractFormat`.
         """
         n = self._known_iter_count(e.arg)
-        elt_fmt = arg_fmt.elt
-        if not self._is_real_scope(e) or n is None or not isinstance(elt_fmt, AbstractableFormatBound):
+        if not self._is_real_scope(e) or n is None:
             return self._op_bound(e)
 
+        # ``sum([])`` is conventionally 0 — independent of what the
+        # (absent) elements would have looked like.
         if n == 0:
-            # ``sum([])`` is conventionally 0.
             return SetFormat(frozenset((Fraction(0),)))
+
+        elt_fmt = arg_fmt.elt
+        # Single-element reduction: no addition occurs, the lone element
+        # passes through with its existing format.  Independent of
+        # abstractability.
         if n == 1:
-            # No addition occurs; the lone element passes through.
             return elt_fmt
-        # Lift the element format once and accumulate ``n - 1`` times.
+
+        # ``n >= 2``: simulate ``n - 1`` pairwise additions through
+        # AbstractFormat.  Requires the element to be abstractable.
+        if not isinstance(elt_fmt, AbstractableFormatBound):
+            return self._op_bound(e)
         af_elt = _to_abstract(elt_fmt)
         if af_elt is None:
             return self._op_bound(e)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -184,6 +184,7 @@ class ListFormat:
 
 
 ScalarFormatBound: TypeAlias = None | SetFormat | Format
+AbstractableFormatBound: TypeAlias = SetFormat | AbstractableFormat
 FormatBound: TypeAlias = None | SetFormat | Format | TupleFormat | ListFormat
 """
 Inferred format for an expression or variable definition.
@@ -256,10 +257,11 @@ def _setformat_to_abstract(s: SetFormat) -> AbstractFormat | None:
     or ``None`` when any value is non-dyadic (and therefore can't be
     pinned by an :class:`AbstractFormat`'s integer ``prec``/``exp``).
 
-    Used by :meth:`_exact_arith_bound` to bridge a :class:`SetFormat`
-    operand into the :class:`AbstractFormat` arithmetic path so that
-    e.g. ``SetFormat({0}) + EFloatFormat`` doesn't bail to
-    ``REAL_FORMAT`` under exact-arithmetic.
+    Used by the exact-arithmetic cases in :meth:`_visit_unaryop` and
+    :meth:`_visit_binaryop` to bridge a :class:`SetFormat` operand into
+    the :class:`AbstractFormat` arithmetic path so that e.g.
+    ``SetFormat({0}) + EFloatFormat`` doesn't bail to ``REAL_FORMAT``
+    under exact-arithmetic.
     """
     if not s.values:
         return None
@@ -284,7 +286,7 @@ def _setformat_to_abstract(s: SetFormat) -> AbstractFormat | None:
     return AbstractFormat(prec, exp, pos_bound, neg_bound=neg_bound)
 
 
-def _to_abstract(f: ScalarFormatBound) -> AbstractFormat | None:
+def _to_abstract(f: AbstractableFormatBound) -> AbstractFormat | None:
     """
     Lifts an abstractable :class:`FormatBound` to an
     :class:`AbstractFormat`.  Returns ``None`` for variants that the
@@ -293,10 +295,8 @@ def _to_abstract(f: ScalarFormatBound) -> AbstractFormat | None:
     """
     if isinstance(f, AbstractableFormat):
         return AbstractFormat.from_format(f)
-    if isinstance(f, SetFormat):
+    else:
         return _setformat_to_abstract(f)
-    return None
-
 
 def _join_bounds(
     s1: FormatBound,
@@ -334,14 +334,6 @@ def _join_bounds(
             if isinstance(s1, AbstractableFormat) and isinstance(s2, AbstractableFormat):
                 af1 = AbstractFormat.from_format(s1)
                 af2 = AbstractFormat.from_format(s2)
-                # Subsumption: if one input contains the other, return the
-                # original (un-canonicalized) Format directly.  This is
-                # important for **fixpoint idempotence**: ``(af | af).format()``
-                # may return an MPB-float that is value-equivalent to the
-                # input but compares unequal under ``==`` (e.g.,
-                # ``IEEEFormat(FP64)`` vs the corresponding
-                # ``MPBFloatFormat``), which would prevent loop phis from
-                # detecting convergence.
                 if af1 <= af2:
                     return s2
                 if af2 <= af1:
@@ -520,88 +512,6 @@ class _FormatInferInstance(Visitor):
         """
         return isinstance(self.ctx_use.find_scope_from_use(e).ctx, RealContext)
 
-    def _exact_arith_bound(
-        self,
-        e: ContextUseSite,
-        operands: tuple[FormatBound, ...],
-    ) -> Format | SetFormat | None:
-        """
-        Tries to compute a tight format for an exact arithmetic operation.
-
-        Under a concrete :class:`RealContext` (no rounding), negation, abs,
-        addition, subtraction, and multiplication preserve enough structure
-        that a containing :class:`Format` can be derived from the operand
-        formats via :class:`AbstractFormat`'s arithmetic.
-
-        Returns ``None`` to signal that the caller should fall back to
-        :meth:`_op_bound` (e.g., the operator is not exact-arithmetic, the
-        scope is not concretely REAL, or some operand is not abstractable).
-        """
-        if not self._is_real_scope(e):
-            return None
-        match e:
-            case Neg():
-                assert len(operands) == 1
-                op_fmt, = operands
-                assert isinstance(op_fmt, ScalarFormatBound), f'expected scalar format for operand of Neg, got {op_fmt!r}'
-                if isinstance(op_fmt, AbstractableFormat):
-                    return (-AbstractFormat.from_format(op_fmt)).format()
-                elif isinstance(op_fmt, SetFormat):
-                    return SetFormat(frozenset(-v for v in op_fmt.values))
-                else:
-                    return None
-            case Abs():
-                assert len(operands) == 1
-                op_fmt, = operands
-                assert isinstance(op_fmt, ScalarFormatBound), f'expected scalar format for operand of Abs, got {op_fmt!r}'
-                if isinstance(op_fmt, AbstractableFormat):
-                    return abs(AbstractFormat.from_format(op_fmt)).format()
-                elif isinstance(op_fmt, SetFormat):
-                    return SetFormat(frozenset(abs(v) for v in op_fmt.values))
-                else:
-                    return None
-            case Add():
-                assert len(operands) == 2
-                a, b = operands
-                assert isinstance(a, ScalarFormatBound), f'expected scalar format for first operand of Add, got {a!r}'
-                assert isinstance(b, ScalarFormatBound), f'expected scalar format for second operand of Add, got {b!r}'
-                # Both SetFormat: keep precision by pairwise sum.
-                if isinstance(a, SetFormat) and isinstance(b, SetFormat):
-                    return SetFormat(frozenset(va + vb for va in a.values for vb in b.values))
-                # Mixed or both AbstractableFormat: lift to AbstractFormat.
-                af_a = _to_abstract(a)
-                af_b = _to_abstract(b)
-                if af_a is None or af_b is None:
-                    return None
-                return (af_a + af_b).format()
-            case Sub():
-                assert len(operands) == 2
-                a, b = operands
-                assert isinstance(a, ScalarFormatBound), f'expected scalar format for first operand of Sub, got {a!r}'
-                assert isinstance(b, ScalarFormatBound), f'expected scalar format for second operand of Sub, got {b!r}'
-                if isinstance(a, SetFormat) and isinstance(b, SetFormat):
-                    return SetFormat(frozenset(va - vb for va in a.values for vb in b.values))
-                af_a = _to_abstract(a)
-                af_b = _to_abstract(b)
-                if af_a is None or af_b is None:
-                    return None
-                return (af_a - af_b).format()
-            case Mul():
-                assert len(operands) == 2
-                a, b = operands
-                assert isinstance(a, ScalarFormatBound), f'expected scalar format for first operand of Mul, got {a!r}'
-                assert isinstance(b, ScalarFormatBound), f'expected scalar format for second operand of Mul, got {b!r}'
-                if isinstance(a, SetFormat) and isinstance(b, SetFormat):
-                    return SetFormat(frozenset(va * vb for va in a.values for vb in b.values))
-                af_a = _to_abstract(a)
-                af_b = _to_abstract(b)
-                if af_a is None or af_b is None:
-                    return None
-                return (af_a * af_b).format()
-            case _:
-                # unsupported operation
-                return None
-
     def _visit_binding(
         self,
         site: DefSite,
@@ -672,24 +582,40 @@ class _FormatInferInstance(Visitor):
 
     def _visit_unaryop(self, e: UnaryOp, ctx: None) -> FormatBound:
         arg_fmt = self._visit_expr(e.arg, ctx)
-        # Integer-producing scalar ops: result format is INTEGER
-        # regardless of the active rounding context.
-        if isinstance(e, Len | Dim):
-            return _INTEGER_FORMAT
-        # Integer-producing list ops: result is a list of integers.
-        if isinstance(e, Range1):
-            return ListFormat(_INTEGER_FORMAT)
-        # Enumerate(xs) → list of (int, elt) tuples; the int projection
-        # is INTEGER, the original element format is preserved.
-        if isinstance(e, Enumerate):
-            assert isinstance(arg_fmt, ListFormat), \
-                f'expected ListFormat for argument of Enumerate, got {arg_fmt!r}'
-            return ListFormat(TupleFormat((_INTEGER_FORMAT, arg_fmt.elt)))
-        if isinstance(e, Sum):
-            assert isinstance(arg_fmt, ListFormat), f'expected ListFormat for argument of Sum, got {arg_fmt!r}'
-            return self._sum_bound(e, arg_fmt)
-        tight = self._exact_arith_bound(e, (arg_fmt,))
-        return tight if tight is not None else self._op_bound(e)
+        match e:
+            case Len() | Dim():
+                # len(...) / dim(...) -> result format is INTEGER regardless
+                # of the active rounding context.
+                return _INTEGER_FORMAT
+            case Range1():
+                # range(...) -> result is a list of integers.
+                return ListFormat(_INTEGER_FORMAT)
+            case Enumerate():
+                # enumerate(xs) -> list of (int, elt) tuples; the int projection
+                # is INTEGER, the original element format is preserved.
+                assert isinstance(arg_fmt, ListFormat), \
+                    f'expected ListFormat for argument of Enumerate, got {arg_fmt!r}'
+                return ListFormat(TupleFormat((_INTEGER_FORMAT, arg_fmt.elt)))
+            case Sum():
+                assert isinstance(arg_fmt, ListFormat), f'expected ListFormat for argument of Sum, got {arg_fmt!r}'
+                return self._sum_bound(e, arg_fmt)
+            case Abs():
+                # abs: preserves precision under exact arithmetic, otherwise rounds to the scope's format
+                if self._is_real_scope(e) and isinstance(arg_fmt, AbstractableFormatBound):
+                    if isinstance(arg_fmt, SetFormat):
+                        return SetFormat(frozenset(abs(v) for v in arg_fmt.values))
+                    else:
+                        return abs(AbstractFormat.from_format(arg_fmt)).format()
+            case Neg():
+                # negation: preserves precision under exact arithmetic, otherwise rounds to the scope's format
+                if self._is_real_scope(e) and isinstance(arg_fmt, AbstractableFormatBound):
+                    if isinstance(arg_fmt, SetFormat):
+                        return SetFormat(frozenset(-v for v in arg_fmt.values))
+                    else:
+                        return (-AbstractFormat.from_format(arg_fmt)).format()
+
+        return self._op_bound(e)
+
 
     def _sum_bound(self, e: Sum, arg_fmt: ListFormat) -> FormatBound:
         """
@@ -705,12 +631,11 @@ class _FormatInferInstance(Visitor):
           known via :class:`ArraySizeAnalysis`; otherwise falls back to
           ``REAL_FORMAT`` via :meth:`_op_bound`.
         """
-        if not self._is_real_scope(e):
-            return self._op_bound(e)
         n = self._known_iter_count(e.arg)
-        if n is None:
-            return self._op_bound(e)
         elt_fmt = arg_fmt.elt
+        if not self._is_real_scope(e) or n is None or not isinstance(elt_fmt, AbstractableFormatBound):
+            return self._op_bound(e)
+
         if n == 0:
             # ``sum([])`` is conventionally 0.
             return SetFormat(frozenset((Fraction(0),)))
@@ -718,7 +643,6 @@ class _FormatInferInstance(Visitor):
             # No addition occurs; the lone element passes through.
             return elt_fmt
         # Lift the element format once and accumulate ``n - 1`` times.
-        assert isinstance(elt_fmt, ScalarFormatBound), f'expected scalar format for elements of sum operand, got {elt_fmt!r}'
         af_elt = _to_abstract(elt_fmt)
         if af_elt is None:
             return self._op_bound(e)
@@ -730,13 +654,49 @@ class _FormatInferInstance(Visitor):
     def _visit_binaryop(self, e: BinaryOp, ctx: None) -> FormatBound:
         lhs = self._visit_expr(e.first, ctx)
         rhs = self._visit_expr(e.second, ctx)
-        # Integer-producing ops: result format is INTEGER.
-        if isinstance(e, Size):
-            return _INTEGER_FORMAT
-        if isinstance(e, Range2):
-            return ListFormat(_INTEGER_FORMAT)
-        tight = self._exact_arith_bound(e, (lhs, rhs))
-        return tight if tight is not None else self._op_bound(e)
+        match e:
+            case Size():
+                # size(...) -> result format is INTEGER regardless of scope.
+                return _INTEGER_FORMAT
+            case Range2():
+                # range(...) -> result is a list of integers.
+                return ListFormat(_INTEGER_FORMAT)
+            case Add():
+                # exact addition: precise under exact arithmetic with
+                # abstractable operands, otherwise rounds to the scope's format.
+                if (self._is_real_scope(e)
+                        and isinstance(lhs, AbstractableFormatBound)
+                        and isinstance(rhs, AbstractableFormatBound)):
+                    if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
+                        return SetFormat(frozenset(va + vb for va in lhs.values for vb in rhs.values))
+                    af_a = _to_abstract(lhs)
+                    af_b = _to_abstract(rhs)
+                    if af_a is not None and af_b is not None:
+                        return (af_a + af_b).format()
+            case Sub():
+                # exact subtraction: same dispatch shape as Add.
+                if (self._is_real_scope(e)
+                        and isinstance(lhs, AbstractableFormatBound)
+                        and isinstance(rhs, AbstractableFormatBound)):
+                    if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
+                        return SetFormat(frozenset(va - vb for va in lhs.values for vb in rhs.values))
+                    af_a = _to_abstract(lhs)
+                    af_b = _to_abstract(rhs)
+                    if af_a is not None and af_b is not None:
+                        return (af_a - af_b).format()
+            case Mul():
+                # exact multiplication: same dispatch shape as Add.
+                if (self._is_real_scope(e)
+                        and isinstance(lhs, AbstractableFormatBound)
+                        and isinstance(rhs, AbstractableFormatBound)):
+                    if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
+                        return SetFormat(frozenset(va * vb for va in lhs.values for vb in rhs.values))
+                    af_a = _to_abstract(lhs)
+                    af_b = _to_abstract(rhs)
+                    if af_a is not None and af_b is not None:
+                        return (af_a * af_b).format()
+
+        return self._op_bound(e)
 
     def _visit_ternaryop(self, e: TernaryOp, ctx: None) -> FormatBound:
         self._visit_expr(e.first, ctx)

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -113,7 +113,10 @@ def _ann_to_type(ty: TypeAnn | None, fresh_var: Callable[[], VarType]) -> Type:
             # boolean type
             return BoolType()
         case RealTypeAnn():
-            return RealType(None)
+            # Preserve the annotated context so that downstream analyses
+            # (notably format inference) can recover the format pinned by
+            # a monomorphizing pass via ``RealType.ctx``.
+            return RealType(ty.ctx)
         case TupleTypeAnn():
             # tuple type
             elt_tys = [_ann_to_type(elt, fresh_var) for elt in ty.elts]

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -7,7 +7,7 @@ import pytest
 
 from fractions import Fraction
 from fpy2.analysis import ContextUseAnalysis, FormatInfer, TypeAnalysis
-from fpy2.analysis.format_infer import AbstractFormat, ListFormat, SetFormat
+from fpy2.analysis.format_infer import AbstractFormat, ListFormat, SetFormat, TupleFormat
 from fpy2.analysis.format_infer.analysis import _join_bounds, _list_set_widen
 from fpy2.analysis.reaching_defs import AssignDef
 from fpy2.ast.fpyast import IndexedAssign
@@ -871,6 +871,107 @@ class TestFormatInfer:
         # Concretely: big_sum.representable_in(small_sum.maxval) holds.
         small_max = small_sum.maxval()._real
         assert big_sum.representable_in(small_max)
+
+    # ------------------------------------------------------------------
+    # Integer-producing operations report INTEGER format
+
+    def test_len_returns_integer_format_under_concrete_ctx(self):
+        """
+        ``len(xs)`` always returns an integer; the format must be
+        ``INTEGER``, *not* the active rounding context's format.
+        """
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP32:
+                n = len(xs)
+            return n
+
+        info = self._run(f)
+        # The Len expression must be the INTEGER format, not FP32.
+        len_bounds = [
+            b for e, b in info.by_expr.items() if type(e).__name__ == 'Len'
+        ]
+        integer_fmt = fp.INTEGER.format()
+        assert len_bounds and len_bounds[0] == integer_fmt, (
+            f'expected Len to report INTEGER format, got {len_bounds}'
+        )
+        # And the binding for ``n`` must inherit that.
+        n_bounds = [b for d, b in info.by_def.items() if d.name.base == 'n']
+        assert integer_fmt in n_bounds, (
+            f'expected INTEGER among n bounds, got {n_bounds}'
+        )
+
+    def test_range1_returns_listformat_of_integer(self):
+        """``range(n)`` produces a list of integers."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            ys = [0.0 for _ in range(len(xs))]
+            return ys
+
+        info = self._run(f)
+        range_bounds = [
+            b for e, b in info.by_expr.items() if type(e).__name__ == 'Range1'
+        ]
+        integer_fmt = fp.INTEGER.format()
+        assert range_bounds, 'expected a Range1 expression'
+        assert range_bounds[0] == ListFormat(integer_fmt), (
+            f'expected ListFormat(INTEGER) for Range1, got {range_bounds}'
+        )
+
+    def test_range2_returns_listformat_of_integer(self):
+        """``range(start, stop)`` produces a list of integers."""
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            return [0.0 for _ in range(0, 10)]
+
+        info = self._run(f)
+        range_bounds = [
+            b for e, b in info.by_expr.items() if type(e).__name__ == 'Range2'
+        ]
+        integer_fmt = fp.INTEGER.format()
+        assert range_bounds and range_bounds[0] == ListFormat(integer_fmt)
+
+    def test_range3_returns_listformat_of_integer(self):
+        """``range(start, stop, step)`` produces a list of integers."""
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            return [0.0 for _ in range(0, 10, 2)]
+
+        info = self._run(f)
+        range_bounds = [
+            b for e, b in info.by_expr.items() if type(e).__name__ == 'Range3'
+        ]
+        integer_fmt = fp.INTEGER.format()
+        assert range_bounds and range_bounds[0] == ListFormat(integer_fmt)
+
+    def test_enumerate_returns_listformat_of_int_value_tuple(self):
+        """
+        ``enumerate(xs)`` produces a list of (int, x) tuples — the int
+        component is INTEGER, the value component preserves ``xs``'s
+        element format.
+        """
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP32:
+                ys = [fp.round(x) for x in xs]
+            for i, y in enumerate(ys):
+                pass
+            return 0.0
+
+        info = self._run(f)
+        enum_bounds = [
+            b for e, b in info.by_expr.items() if type(e).__name__ == 'Enumerate'
+        ]
+        assert enum_bounds, 'expected an Enumerate expression'
+        bound = enum_bounds[0]
+        # Outer: ListFormat. Element: TupleFormat((INTEGER, FP32)).
+        integer_fmt = fp.INTEGER.format()
+        fp32_fmt = fp.FP32.format()
+        assert isinstance(bound, ListFormat)
+        assert isinstance(bound.elt, TupleFormat)
+        assert bound.elt.elts == (integer_fmt, fp32_fmt), (
+            f'expected TupleFormat((INTEGER, FP32)), got {bound.elt}'
+        )
 
     def test_blockwise_quantized_accumulator_end_to_end(self):
         """

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -42,6 +42,65 @@ class TestFormatInfer:
             assert fmt == REAL_FORMAT
 
     # ------------------------------------------------------------------
+    # Format pinned by monomorphized argument types
+
+    def test_monomorphized_scalar_arg_format(self):
+        """
+        After monomorphization, ``RealType.ctx`` carries the concrete
+        format.  ``_top_bound`` extracts that format so the argument's
+        bound is the precise pinned format, not ``REAL_FORMAT``.
+        """
+        from fpy2.transform import Monomorphize
+        from fpy2.types import RealType
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return x
+
+        mono_ast = Monomorphize.apply_by_arg(
+            f.ast, None, [RealType(fp.FP32)]
+        )
+        info = FormatInfer.analyze(mono_ast)
+        x_bounds = [b for d, b in info.by_def.items() if d.name.base == 'x']
+        assert fp.FP32.format() in x_bounds, (
+            f'expected FP32 among x bounds after monomorphization, got {x_bounds}'
+        )
+
+    def test_monomorphized_list_arg_format(self):
+        """
+        Monomorphization propagates through structural types: a
+        ``list[Real[FP32]]`` argument becomes ``ListFormat(IEEEFormat)``.
+        """
+        from fpy2.transform import Monomorphize
+        from fpy2.types import RealType, ListType
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return xs[0]
+
+        mono_ast = Monomorphize.apply_by_arg(
+            f.ast, None, [ListType(RealType(fp.FP32))]
+        )
+        info = FormatInfer.analyze(mono_ast)
+        xs_bounds = [b for d, b in info.by_def.items() if d.name.base == 'xs']
+        assert ListFormat(fp.FP32.format()) in xs_bounds, (
+            f'expected ListFormat(FP32) among xs bounds, got {xs_bounds}'
+        )
+
+    def test_unmonomorphized_arg_keeps_real_format(self):
+        """
+        Without a monomorphization pass, ``RealType.ctx`` is ``None`` and
+        ``_top_bound`` reports ``REAL_FORMAT`` as before — no regression.
+        """
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return x
+
+        info = self._run(f)
+        x_bounds = [b for d, b in info.by_def.items() if d.name.base == 'x']
+        assert REAL_FORMAT in x_bounds
+
+    # ------------------------------------------------------------------
     # Single context block
 
     def test_fp32_context(self):

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -896,6 +896,25 @@ class TestFormatInfer:
             f'expected REAL_FORMAT fall-back when size is unknown, got {sums}'
         )
 
+    def test_sum_empty_list_returns_zero_set_format(self):
+        """
+        Regression: ``sum([])`` under REAL must report ``SetFormat({0})``
+        regardless of the element format.  An earlier version short-
+        circuited to ``REAL_FORMAT`` via the abstractability guard
+        before checking the ``n == 0`` case.
+        """
+        @fp.fpy(ctx=fp.REAL)
+        def f() -> fp.Real:
+            xs: list[fp.Real] = []
+            return sum(xs)
+
+        info = self._run(f)
+        sums = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Sum']
+        assert sums, 'expected a Sum expression in by_expr'
+        assert sums[-1] == SetFormat(frozenset((Fraction(0),))), (
+            f'expected SetFormat({{0}}) for sum([]) under REAL, got {sums[-1]}'
+        )
+
     def test_sum_grows_with_known_size(self):
         """
         Sanity: larger N produces a wider precise format under REAL.

--- a/tests/unit/interpret/test_list_slice.py
+++ b/tests/unit/interpret/test_list_slice.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for FPy's strict list-slicing semantics.
+
+Unlike Python's clamping behaviour, FPy requires ``xs[start:stop]`` to
+extract a block of *exactly* ``stop - start`` elements — out-of-range
+bounds raise ``IndexError`` at runtime instead of silently producing a
+truncated or empty list.
+"""
+
+import fpy2 as fp
+import pytest
+
+
+class TestStrictListSlice:
+    """Runtime tests for the ``__fpy_list_slice`` helper."""
+
+    def test_valid_inner_slice(self):
+        """A fully-in-bounds slice extracts exactly ``stop - start`` items."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], a: fp.Real, b: fp.Real) -> list[fp.Real]:
+            return xs[a:b]
+
+        result = f([1.0, 2.0, 3.0, 4.0, 5.0], 1, 3)
+        assert len(result) == 2
+
+    def test_full_slice_no_bounds(self):
+        """``xs[:]`` returns the whole list."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[:]
+
+        result = f([1.0, 2.0, 3.0])
+        assert len(result) == 3
+
+    def test_omitted_start_defaults_to_zero(self):
+        """``xs[:k]`` defaults start to 0."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], k: fp.Real) -> list[fp.Real]:
+            return xs[:k]
+
+        assert len(f([1.0, 2.0, 3.0, 4.0, 5.0], 3)) == 3
+
+    def test_omitted_stop_defaults_to_length(self):
+        """``xs[k:]`` defaults stop to ``len(xs)``."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], k: fp.Real) -> list[fp.Real]:
+            return xs[k:]
+
+        assert len(f([1.0, 2.0, 3.0, 4.0, 5.0], 2)) == 3
+
+    def test_empty_slice_at_endpoint(self):
+        """``xs[k:k]`` (start == stop, in bounds) returns an empty list."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], k: fp.Real) -> list[fp.Real]:
+            return xs[k:k]
+
+        assert f([1.0, 2.0, 3.0], 2) == []
+
+    def test_full_slice_at_endpoint(self):
+        """``xs[0:len(xs)]`` is valid and returns the whole list."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[0:len(xs)]
+
+        assert len(f([1.0, 2.0, 3.0])) == 3
+
+    # ------------------------------------------------------------------
+    # Strict-bounds violations: each raises IndexError.
+
+    def test_negative_start_raises(self):
+        """``xs[-1:k]`` is invalid — strict semantics reject negatives."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], a: fp.Real, b: fp.Real) -> list[fp.Real]:
+            return xs[a:b]
+
+        with pytest.raises(IndexError, match='out of range'):
+            f([1.0, 2.0, 3.0], -1, 2)
+
+    def test_stop_past_end_raises(self):
+        """``xs[a:b]`` with ``b > len(xs)`` is invalid."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], a: fp.Real, b: fp.Real) -> list[fp.Real]:
+            return xs[a:b]
+
+        with pytest.raises(IndexError, match='out of range'):
+            f([1.0, 2.0, 3.0], 0, 5)
+
+    def test_start_greater_than_stop_raises(self):
+        """``xs[2:1]`` (start > stop) is invalid even when both are in range."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], a: fp.Real, b: fp.Real) -> list[fp.Real]:
+            return xs[a:b]
+
+        with pytest.raises(IndexError, match='start .* > stop'):
+            f([1.0, 2.0, 3.0], 2, 1)
+
+    def test_start_past_end_with_omitted_stop_raises(self):
+        """``xs[10:]`` on a size-3 list — strict semantics raise.
+
+        Python clamps this to an empty list; FPy doesn't.
+        """
+
+        @fp.fpy
+        def f(xs: list[fp.Real], a: fp.Real) -> list[fp.Real]:
+            return xs[a:]
+
+        with pytest.raises(IndexError):
+            f([1.0, 2.0, 3.0], 10)
+
+    def test_stop_past_end_with_omitted_start_raises(self):
+        """``xs[:10]`` on a size-3 list — strict semantics raise."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], b: fp.Real) -> list[fp.Real]:
+            return xs[:b]
+
+        with pytest.raises(IndexError):
+            f([1.0, 2.0, 3.0], 10)
+
+    def test_non_integer_bound_raises(self):
+        """A non-integer slice bound raises ``TypeError``."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], a: fp.Real, b: fp.Real) -> list[fp.Real]:
+            return xs[a:b]
+
+        with pytest.raises(TypeError):
+            f([1.0, 2.0, 3.0], 0.5, 2)


### PR DESCRIPTION
This PR optimizes the format inference algorithm to consider integer-valued operations and use embedded format information from monomorphizing