### PR TITLE
Fix slice semantics

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -188,6 +188,39 @@ def example_builtin():
     ...
 ```
 
+#### Slicing
+
+FPy supports list slicing `xs[start:stop]`, but its semantics **differ
+from Python's**.  Where Python silently *clamps* out-of-range bounds
+(`xs[10:]` on a length-3 list returns `[]`), FPy treats out-of-range
+bounds as an error: a slice expression must extract a block of *exactly*
+`stop - start` elements.
+
+The runtime check is `0 <= start <= stop <= len(xs)`; any violation
+raises `IndexError` (and a non-integer bound raises `TypeError`).
+Omitted bounds default to `0` and `len(xs)` respectively.
+
+```python
+@fp.fpy
+def example_slicing(xs: list[fp.Real]):
+    a = xs[1:3]   # OK iff len(xs) >= 3 — extracts exactly 2 elements
+    b = xs[:3]    # OK iff len(xs) >= 3 — equivalent to xs[0:3]
+    c = xs[2:]    # OK iff len(xs) >= 2 — equivalent to xs[2:len(xs)]
+    d = xs[:]     # always OK — full copy
+    # The next three would all raise IndexError at runtime:
+    # e = xs[10:]    # start past end of list
+    # f = xs[:100]   # stop past end of list
+    # g = xs[2:1]    # start > stop
+    ...
+```
+
+The motivation is to make static reasoning about slice sizes precise:
+under FPy's rule, `xs[a:b]` always has size `b - a` when both bounds are
+concrete (regardless of `len(xs)`), and program analyses can rely on
+this without the conditional branching that Python's clamping would
+require.  Programs that need Python-style "best-effort" truncation must
+clamp the bounds explicitly before slicing.
+
 ## Control Flow
 
 FPy supports control flow constructs like `if` statements and `for` loops.

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -365,14 +365,14 @@ class _ArraySizeInferInstance(DefaultVisitor):
             else:
                 stop = None
 
-        # Compute the slice size only when start, stop, AND the list's
-        # own size are all concrete.  Otherwise the slice size is
-        # unknown — falling back to ``ty.size`` would be unsound (the
-        # original list's size is generally larger than the slice).
-        if start is not None and stop is not None and ty.size is not None:
-            slice_size: int | None = max(
-                0, min(stop, ty.size) - min(start, ty.size)
-            )
+        # FPy slicing is *strict*: ``xs[a:b]`` is valid only when
+        # ``0 <= a <= b <= len(xs)``.  Out-of-range bounds raise at
+        # runtime rather than being clamped (Python's behavior).  So
+        # when both bounds are concrete the static size is exactly
+        # ``stop - start`` — no ``min``/``max`` clamping.  We don't
+        # need ``ty.size`` to be known to compute the difference.
+        if start is not None and stop is not None and stop >= start:
+            slice_size: int | None = stop - start
         else:
             slice_size = None
 

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -195,6 +195,60 @@ def _eval_enumerate(val: list[Value], ctx: Context):
         for i, v in enumerate(val)
     ]
 
+def _eval_list_slice(lst: list[Value], start: Value | None, stop: Value | None):
+    """
+    Strict slice ``lst[start:stop]``.
+
+    FPy slicing semantics differ from Python's: the slice must extract a
+    block of *exactly* ``stop - start`` elements.  Out-of-range bounds
+    are an error rather than being clamped silently.
+
+    Defaults follow Python: ``start=None`` means 0; ``stop=None`` means
+    ``len(lst)``.
+
+    Raises:
+        TypeError:  if *lst* isn't a list, or *start*/*stop* aren't
+                    integer-valued real numbers.
+        IndexError: if the bounds violate ``0 <= start <= stop <= len(lst)``.
+    """
+    if not isinstance(lst, list):
+        raise TypeError(f'expected a list, got {lst}')
+
+    n = len(lst)
+    if start is None:
+        start_idx = 0
+    else:
+        if not isinstance(start, RealValue):
+            raise TypeError(f'expected a real number slice bound, got {start}')
+        if not _is_integer(start):
+            raise TypeError(f'expected an integer slice bound, got {start}')
+        start_idx = int(start)
+    if stop is None:
+        stop_idx = n
+    else:
+        if not isinstance(stop, RealValue):
+            raise TypeError(f'expected a real number slice bound, got {stop}')
+        if not _is_integer(stop):
+            raise TypeError(f'expected an integer slice bound, got {stop}')
+        stop_idx = int(stop)
+
+    # Strict bounds: 0 <= start <= stop <= len(lst).
+    if start_idx < 0:
+        raise IndexError(
+            f'slice start {start_idx} out of range (must be >= 0)'
+        )
+    if stop_idx > n:
+        raise IndexError(
+            f'slice stop {stop_idx} out of range (list length {n})'
+        )
+    if start_idx > stop_idx:
+        raise IndexError(
+            f'slice bounds invalid: start {start_idx} > stop {stop_idx}'
+        )
+
+    return lst[start_idx:stop_idx]
+
+
 def _eval_list_set(lst: list[Value], idxs: list[RealValue], val: Value):
     if not isinstance(lst, list):
         raise TypeError(f'expected a list, got {lst}')
@@ -374,6 +428,7 @@ def make_namespace() -> dict[str, object]:
         '__fpy_fraction': Fraction,
         '__fpy_int': _cvt_int,
         '__fpy_list_set': _eval_list_set,
+        '__fpy_list_slice': _eval_list_slice,
         '__fpy_range': _eval_range,
     }
 
@@ -704,30 +759,25 @@ class BytecodeCompiler(Visitor):
         arr = self._visit_expr(e.value, ctx)
         attrs = self._location_to_attributes(e.loc)
 
-        # start index
+        # start index — pass through unchanged so the runtime helper
+        # can default it (None ↦ 0) and validate.
         if e.start is None:
             start: pyast.expr = pyast.Constant(value=None, kind=None, **attrs)
         else:
-            # convert index to an integer using `__fpy_int` to ensure it's a valid list index
             start = self._visit_expr(e.start, ctx)
-            cvt_name = pyast.Name(id='__fpy_int', ctx=pyast.Load(), **attrs)
-            start = pyast.Call(func=cvt_name, args=[start], keywords=[], **attrs)
 
-        # stop index
+        # stop index — same treatment (None ↦ len(arr) at runtime).
         if e.stop is None:
             stop: pyast.expr = pyast.Constant(value=None, kind=None, **attrs)
         else:
-            # convert index to an integer using `__fpy_int` to ensure it's a valid list index
             stop = self._visit_expr(e.stop, ctx)
-            cvt_name = pyast.Name(id='__fpy_int', ctx=pyast.Load(), **attrs)
-            stop = pyast.Call(func=cvt_name, args=[stop], keywords=[], **attrs)
 
-        # generate a slice of the form `arr[start:stop]`
-        return pyast.Subscript(
-            value=arr,
-            slice=pyast.Slice(lower=start, upper=stop, step=None, **attrs),
-            ctx=pyast.Load(),
-            **attrs
+        # FPy slicing semantics are strict: out-of-range bounds raise
+        # ``IndexError`` rather than clamping (Python's behavior).  The
+        # runtime helper validates ``0 <= start <= stop <= len(arr)``.
+        helper = pyast.Name(id='__fpy_list_slice', ctx=pyast.Load(), **attrs)
+        return pyast.Call(
+            func=helper, args=[arr, start, stop], keywords=[], **attrs
         )
 
     def _visit_list_set(self, e: ListSet, ctx: None):

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -394,8 +394,13 @@ class TestArraySizeInfer:
         ]
         assert len(slice_bounds) == 1 and slice_bounds[0].size is None
 
-    def test_list_slice_start_past_end(self):
-        """``xs[10:]`` on a size-5 list has size 0 (clamped to non-negative)."""
+    def test_list_slice_start_past_end_is_unknown(self):
+        """
+        ``xs[10:]`` on a size-5 list is invalid under FPy's strict
+        slicing semantics (start past end of list).  The runtime raises
+        ``IndexError``; the static size analysis reports ``None``
+        (unknown) rather than committing to Python's clamping value of 0.
+        """
 
         @fp.fpy
         def f() -> list[fp.Real]:
@@ -407,7 +412,27 @@ class TestArraySizeInfer:
             b for e, b in info.by_expr.items()
             if type(e).__name__ == 'ListSlice'
         ]
-        assert len(slice_bounds) == 1 and slice_bounds[0].size == 0
+        assert len(slice_bounds) == 1 and slice_bounds[0].size is None
+
+    def test_list_slice_concrete_bounds_resolves_without_list_size(self):
+        """
+        With strict semantics, ``xs[1:3]`` has size exactly ``3 - 1 = 2``
+        when both bounds are concrete — *regardless of whether the
+        underlying list's size is statically known*.  (At runtime, if
+        ``len(xs) < 3``, the slice raises; the static analysis trusts
+        the runtime check and reports the size the slice *would* have.)
+        """
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:3]
+
+        info = self._run(f)
+        slice_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'ListSlice'
+        ]
+        assert len(slice_bounds) == 1 and slice_bounds[0].size == 2
 
     # ------------------------------------------------------------------
     # IndexedAssign as a fresh SSA def


### PR DESCRIPTION
Slices in FPy now throw an error if a sliced index does not exist.