### PR TITLE
Add zip elimination

### DIFF
--- a/fpy2/transform/__init__.py
+++ b/fpy2/transform/__init__.py
@@ -20,3 +20,4 @@ from .split_loop import SplitLoop, SplitLoopStrategy
 from .subst_var import SubstVar
 from .while_bundling import WhileBundling
 from .while_unroll import WhileUnroll
+from .zip_elim import ZipElim

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -61,13 +61,15 @@ defeats this transform's guard.
 
 import dataclasses
 
+from typing import Any
+
 from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
 from ..ast.fpyast import (
     Assign, Expr, ForStmt, FuncDef, Len, ListComp, ListRef, NamedId,
     Range1, Stmt, StmtBlock, TupleBinding, UnderscoreId, Var, Zip,
 )
 from ..ast.visitor import DefaultTransformVisitor
-from ..utils import Gensym
+from ..utils import Gensym, Id
 
 
 @dataclasses.dataclass
@@ -84,7 +86,7 @@ class _Ctx:
         return _Ctx(stmts=[])
 
 
-def _is_zip_tuple_binding(target, iterable) -> bool:
+def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
     """Predicate for the for-loop / comp fast path.
 
     Fires iff *iterable* is a :class:`Zip`, *target* is a
@@ -123,7 +125,7 @@ class _SubstNames(DefaultTransformVisitor):
         # restores after recursing.
         self._subst = dict(subst)
 
-    def _visit_var(self, e: Var, ctx):
+    def _visit_var(self, e: Var, ctx: Any):
         # The substitution targets are ``NamedId``s; FPy's parser
         # synthesizes a ``Var`` whose ``.name`` is the same
         # ``NamedId`` object.  Equality is structural (``NamedId``
@@ -133,7 +135,7 @@ class _SubstNames(DefaultTransformVisitor):
             return replacement
         return super()._visit_var(e, ctx)
 
-    def _visit_list_comp(self, e: ListComp, ctx):
+    def _visit_list_comp(self, e: ListComp, ctx: Any):
         # A target NamedId inside this comp shadows any outer
         # substitution for the same name.  Save the shadowed entries,
         # disable them, recurse, then restore.
@@ -180,7 +182,7 @@ class _ZipElimInstance(DefaultTransformVisitor):
     # ------------------------------------------------------------------
     # Block walk with stmt → stmts expansion
 
-    def _visit_block(self, block: StmtBlock, ctx):
+    def _visit_block(self, block: StmtBlock, ctx: Any):
         # Local _Ctx so each block has its own preamble buffer; the
         # outer caller's ctx (if any) is irrelevant — preambles
         # always belong to the block introducing them.
@@ -263,33 +265,33 @@ class _ZipElimInstance(DefaultTransformVisitor):
     # ------------------------------------------------------------------
     # List comprehensions
 
-    def _visit_list_comp(self, e: ListComp, ctx):
+    def _visit_list_comp(self, e: ListComp, ctx: Any):
         # Walk the comp's (target, iterable) pairs, rewriting any
         # zip-tuple-binding stage whose zip arguments are all
         # ``Var``s.  Non-matching stages are passed through.  The
         # ``elt`` expression has substitutions applied for every
         # rewritten stage.
-        new_targets: list = []
+        new_targets: list[Id | TupleBinding] = []
         new_iterables: list[Expr] = []
         subst: dict[NamedId, Expr] = {}
 
         for target, iterable in zip(e.targets, e.iterables):
-            iterable = self._visit_expr(iterable, ctx)
+            new_iter = self._visit_expr(iterable, ctx)
             if (
-                _is_zip_tuple_binding(target, iterable)
-                and self._all_var_args(iterable)
+                _is_zip_tuple_binding(target, new_iter)
+                and isinstance(new_iter, Zip)
+                and isinstance(target, TupleBinding)
+                and all(isinstance(a, Var) for a in new_iter.args)
             ):
                 idx = self.gensym.fresh('_i')
-                assert isinstance(iterable, Zip)
-                assert isinstance(target, TupleBinding)
                 # Build a substitution for each named binding slot:
                 # ``name -> arg[idx]``.  Underscore slots contribute
                 # no substitution.
-                for elt, arg in zip(target.elts, iterable.args):
-                    match elt:
+                for binding, arg in zip(target.elts, new_iter.args):
+                    match binding:
                         case NamedId():
                             assert isinstance(arg, Var)
-                            subst[elt] = ListRef(
+                            subst[binding] = ListRef(
                                 Var(arg.name, None),
                                 Var(idx, None),
                                 None,
@@ -299,13 +301,13 @@ class _ZipElimInstance(DefaultTransformVisitor):
                         case _:
                             raise RuntimeError(
                                 f'unexpected binding element in zip '
-                                f'target: {elt!r}'
+                                f'target: {binding!r}'
                             )
                 # New target/iterable: ``_i in range(len(arg0))``.
-                assert isinstance(iterable.args[0], Var)
+                assert isinstance(new_iter.args[0], Var)
                 len_expr = Len(
                     Var(NamedId('len'), None),
-                    Var(iterable.args[0].name, None),
+                    Var(new_iter.args[0].name, None),
                     None,
                 )
                 new_targets.append(idx)
@@ -314,18 +316,14 @@ class _ZipElimInstance(DefaultTransformVisitor):
                 )
             else:
                 new_targets.append(self._visit_binding(target, ctx))
-                new_iterables.append(iterable)
+                new_iterables.append(new_iter)
 
         # Substitute names in ``elt`` after walking it normally
         # (so nested zip patterns inside the elt are also rewritten).
-        elt = self._visit_expr(e.elt, ctx)
+        new_elt = self._visit_expr(e.elt, ctx)
         if subst:
-            elt = _SubstNames(subst)._visit_expr(elt, ctx)
-        return ListComp(new_targets, new_iterables, elt, e.loc)
-
-    @staticmethod
-    def _all_var_args(zip_expr: Zip) -> bool:
-        return all(isinstance(a, Var) for a in zip_expr.args)
+            new_elt = _SubstNames(subst)._visit_expr(new_elt, ctx)
+        return ListComp(new_targets, new_iterables, new_elt, e.loc)
 
 
 class ZipElim:

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -1,0 +1,346 @@
+"""
+Rewrite ``zip(...)`` iterables into indexed loops over the source
+vectors, removing the need for any backend to materialize an
+intermediate list of tuples.
+
+Two patterns are recognized:
+
+1. **For-loop over zip.**
+
+   .. code-block:: python
+
+      for a, b in zip(xs, ys):
+          BODY
+
+   is rewritten to::
+
+      _src0 = xs
+      _src1 = ys
+      for _i in range(len(_src0)):
+          a = _src0[_i]
+          b = _src1[_i]
+          BODY
+
+   The per-source temporaries preserve "evaluate each iterable
+   exactly once" semantics, identical to a faithful ``zip``
+   implementation.  Underscore-binding targets emit no per-iteration
+   assignment but their source is still bound to a temp so its
+   side-effects fire exactly once.
+
+2. **List comp over zip** *with* ``Var`` arguments only.
+
+   .. code-block:: python
+
+      [elt for a, b in zip(xs, ys)]
+
+   is rewritten to::
+
+      [elt[a -> xs[_i], b -> ys[_i]] for _i in range(len(xs))]
+
+   The substitution is scope-aware: if ``elt`` contains a nested
+   comprehension or other construct that re-binds ``a`` or ``b``,
+   the shadowed uses are not rewritten.
+
+   Restriction: every ``zip`` argument must be a :class:`Var`.  A
+   list comprehension is an expression and has no statement-level
+   "preamble" to host the ``_srcK = ...`` bindings, so we can't
+   safely cache a non-pure ``zip`` argument across iterations.
+   The transform leaves non-``Var``-argument zip comps alone; the
+   cpp backend's emit-time fast path still optimizes them.
+
+Patterns that don't match the guards (range iterables, mismatched
+arity, nested ``TupleBinding`` elements, non-``Var`` list-comp zip
+args) are left unchanged.
+
+Ordering note: run :class:`ZipElim` *before*
+:class:`fpy2.transform.ForUnpack`.  ``ForUnpack`` rewrites
+``for (a, b) in iter:`` into ``for t in iter: a, b = t``, which
+turns the ``ForStmt``'s target into a :class:`NamedId` and thereby
+defeats this transform's guard.
+"""
+
+import dataclasses
+
+from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
+from ..ast.fpyast import (
+    Assign, Expr, ForStmt, FuncDef, Len, ListComp, ListRef, NamedId,
+    Range1, Stmt, StmtBlock, TupleBinding, UnderscoreId, Var, Zip,
+)
+from ..ast.visitor import DefaultTransformVisitor
+from ..utils import Gensym
+
+
+@dataclasses.dataclass
+class _Ctx:
+    """Block-walk accumulator.  When :meth:`_visit_for` decides to
+    rewrite a for-loop, it appends the ``_srcK = ...`` preamble
+    assignments to ``stmts`` and returns the rewritten ``ForStmt``;
+    :meth:`_visit_block` then appends that, producing one-to-many
+    statement expansion without a custom statement visitor."""
+    stmts: list[Stmt]
+
+    @staticmethod
+    def default() -> '_Ctx':
+        return _Ctx(stmts=[])
+
+
+def _is_zip_tuple_binding(target, iterable) -> bool:
+    """Predicate for the for-loop / comp fast path.
+
+    Fires iff *iterable* is a :class:`Zip`, *target* is a
+    :class:`TupleBinding` of matching arity, and every element of
+    the binding is a :class:`NamedId` or :class:`UnderscoreId`.
+    Nested tuple bindings are out of scope — they'd require
+    recursive destructuring of each per-iteration element, which
+    isn't worth the complication.
+    """
+    if not isinstance(iterable, Zip):
+        return False
+    if not isinstance(target, TupleBinding):
+        return False
+    if len(iterable.args) != len(target.elts):
+        return False
+    return all(
+        isinstance(e, (NamedId, UnderscoreId))
+        for e in target.elts
+    )
+
+
+class _SubstNames(DefaultTransformVisitor):
+    """Replace every :class:`Var` reference to a name in *subst*
+    with the corresponding expression.  Scope-aware: comprehension
+    targets that shadow a substituted name disable the substitution
+    inside that comprehension's ``elt`` (the inner uses bind to the
+    shadowing iteration variable, not to the outer one).
+    """
+
+    def __init__(self, subst: dict[NamedId, Expr]):
+        super().__init__()
+        # Active substitutions, shadowed lexically.  We mutate in
+        # place via push/pop because ``DefaultTransformVisitor`` is
+        # purely top-down and gives us no return-trip hook for
+        # popping; the surrounding ``_visit_list_comp`` override
+        # restores after recursing.
+        self._subst = dict(subst)
+
+    def _visit_var(self, e: Var, ctx):
+        # The substitution targets are ``NamedId``s; FPy's parser
+        # synthesizes a ``Var`` whose ``.name`` is the same
+        # ``NamedId`` object.  Equality is structural (``NamedId``
+        # implements ``__eq__`` over (base, count)).
+        replacement = self._subst.get(e.name)
+        if replacement is not None:
+            return replacement
+        return super()._visit_var(e, ctx)
+
+    def _visit_list_comp(self, e: ListComp, ctx):
+        # A target NamedId inside this comp shadows any outer
+        # substitution for the same name.  Save the shadowed entries,
+        # disable them, recurse, then restore.
+        shadowed: dict[NamedId, Expr] = {}
+        for target in e.targets:
+            for name in self._binding_names(target):
+                if name in self._subst:
+                    shadowed[name] = self._subst.pop(name)
+        try:
+            return super()._visit_list_comp(e, ctx)
+        finally:
+            self._subst.update(shadowed)
+
+    @staticmethod
+    def _binding_names(target) -> list[NamedId]:
+        """Flatten a comprehension target into the named identifiers
+        it binds.  Underscore slots and nested bindings contribute
+        zero or more names."""
+        match target:
+            case NamedId():
+                return [target]
+            case UnderscoreId():
+                return []
+            case TupleBinding():
+                out: list[NamedId] = []
+                for elt in target.elts:
+                    out.extend(_SubstNames._binding_names(elt))
+                return out
+            case _:
+                return []
+
+
+class _ZipElimInstance(DefaultTransformVisitor):
+    """Single-use visitor that drives the rewrite."""
+
+    def __init__(self, func: FuncDef, def_use: DefineUseAnalysis):
+        super().__init__()
+        self.func = func
+        self.gensym = Gensym(reserved=def_use.names())
+
+    def apply(self) -> FuncDef:
+        return self._visit_function(self.func, None)
+
+    # ------------------------------------------------------------------
+    # Block walk with stmt → stmts expansion
+
+    def _visit_block(self, block: StmtBlock, ctx):
+        # Local _Ctx so each block has its own preamble buffer; the
+        # outer caller's ctx (if any) is irrelevant — preambles
+        # always belong to the block introducing them.
+        block_ctx = _Ctx.default()
+        for stmt in block.stmts:
+            new_stmt, _ = self._visit_statement(stmt, block_ctx)
+            block_ctx.stmts.append(new_stmt)
+        return StmtBlock(block_ctx.stmts), ctx
+
+    # ------------------------------------------------------------------
+    # For loops
+
+    def _visit_for(self, stmt: ForStmt, ctx: _Ctx):
+        if not _is_zip_tuple_binding(stmt.target, stmt.iterable):
+            return super()._visit_for(stmt, ctx)
+        # Recursively rewrite the body first, in case it contains
+        # nested zip patterns.
+        body, _ = self._visit_block(stmt.body, ctx)
+        return self._rewrite_for(stmt, body, ctx), ctx
+
+    def _rewrite_for(
+        self, stmt: ForStmt, new_body: StmtBlock, ctx: _Ctx,
+    ) -> ForStmt:
+        assert isinstance(stmt.iterable, Zip)
+        assert isinstance(stmt.target, TupleBinding)
+
+        # Bind each zip arg to a fresh ``_srcK`` before the loop.
+        # Even ``UnderscoreId`` binding slots get a temp for the
+        # source so any side-effect in the arg fires exactly once.
+        src_names: list[NamedId] = []
+        for arg in stmt.iterable.args:
+            src = self.gensym.fresh('_src')
+            ctx.stmts.append(Assign(src, None, arg, None))
+            src_names.append(src)
+
+        idx = self.gensym.fresh('_i')
+        # Build the per-iteration assignments: one per non-underscore
+        # binding slot.  Underscore slots are skipped; their source
+        # remains bound for side-effect ordering but isn't read.
+        per_iter: list[Stmt] = []
+        for elt, src in zip(stmt.target.elts, src_names):
+            match elt:
+                case UnderscoreId():
+                    continue
+                case NamedId():
+                    per_iter.append(
+                        Assign(
+                            elt, None,
+                            ListRef(Var(src, None), Var(idx, None), None),
+                            None,
+                        )
+                    )
+                case _:
+                    # Should be ruled out by the guard, but stay
+                    # defensive.
+                    raise RuntimeError(
+                        f'unexpected binding element in zip target: {elt!r}'
+                    )
+
+        # New body: per-iteration assigns, then the original body.
+        new_body_stmts: list[Stmt] = per_iter + list(new_body.stmts)
+        # Iterable: ``range(len(_src0))``.
+        size_expr = Len(
+            Var(NamedId('len'), None),
+            Var(src_names[0], None),
+            None,
+        )
+        range_expr = Range1(
+            Var(NamedId('range'), None),
+            size_expr,
+            None,
+        )
+        return ForStmt(
+            idx,
+            range_expr,
+            StmtBlock(new_body_stmts),
+            stmt.loc,
+        )
+
+    # ------------------------------------------------------------------
+    # List comprehensions
+
+    def _visit_list_comp(self, e: ListComp, ctx):
+        # Walk the comp's (target, iterable) pairs, rewriting any
+        # zip-tuple-binding stage whose zip arguments are all
+        # ``Var``s.  Non-matching stages are passed through.  The
+        # ``elt`` expression has substitutions applied for every
+        # rewritten stage.
+        new_targets: list = []
+        new_iterables: list[Expr] = []
+        subst: dict[NamedId, Expr] = {}
+
+        for target, iterable in zip(e.targets, e.iterables):
+            iterable = self._visit_expr(iterable, ctx)
+            if (
+                _is_zip_tuple_binding(target, iterable)
+                and self._all_var_args(iterable)
+            ):
+                idx = self.gensym.fresh('_i')
+                assert isinstance(iterable, Zip)
+                assert isinstance(target, TupleBinding)
+                # Build a substitution for each named binding slot:
+                # ``name -> arg[idx]``.  Underscore slots contribute
+                # no substitution.
+                for elt, arg in zip(target.elts, iterable.args):
+                    match elt:
+                        case NamedId():
+                            assert isinstance(arg, Var)
+                            subst[elt] = ListRef(
+                                Var(arg.name, None),
+                                Var(idx, None),
+                                None,
+                            )
+                        case UnderscoreId():
+                            continue
+                        case _:
+                            raise RuntimeError(
+                                f'unexpected binding element in zip '
+                                f'target: {elt!r}'
+                            )
+                # New target/iterable: ``_i in range(len(arg0))``.
+                assert isinstance(iterable.args[0], Var)
+                len_expr = Len(
+                    Var(NamedId('len'), None),
+                    Var(iterable.args[0].name, None),
+                    None,
+                )
+                new_targets.append(idx)
+                new_iterables.append(
+                    Range1(Var(NamedId('range'), None), len_expr, None)
+                )
+            else:
+                new_targets.append(self._visit_binding(target, ctx))
+                new_iterables.append(iterable)
+
+        # Substitute names in ``elt`` after walking it normally
+        # (so nested zip patterns inside the elt are also rewritten).
+        elt = self._visit_expr(e.elt, ctx)
+        if subst:
+            elt = _SubstNames(subst)._visit_expr(elt, ctx)
+        return ListComp(new_targets, new_iterables, elt, e.loc)
+
+    @staticmethod
+    def _all_var_args(zip_expr: Zip) -> bool:
+        return all(isinstance(a, Var) for a in zip_expr.args)
+
+
+class ZipElim:
+    """Rewrite ``zip(...)`` iterables into indexed loops over the
+    source vectors.  See the module docstring for the patterns
+    recognized and the ordering constraint with
+    :class:`fpy2.transform.ForUnpack`."""
+
+    @staticmethod
+    def apply(func: FuncDef) -> FuncDef:
+        """Apply the transformation to a :class:`FuncDef`.  Returns
+        a new ``FuncDef``; the input is not mutated."""
+        if not isinstance(func, FuncDef):
+            raise TypeError(f"expected a 'FuncDef', got `{func}`")
+        def_use = DefineUse.analyze(func)
+        out = _ZipElimInstance(func, def_use).apply()
+        SyntaxCheck.check(out, ignore_unknown=True)
+        return out

--- a/tests/unit/transform/test_zip_elim.py
+++ b/tests/unit/transform/test_zip_elim.py
@@ -1,0 +1,269 @@
+"""
+Unit tests for the :class:`fpy2.transform.ZipElim` transform.
+
+The rewrite mints fresh ``_srcK`` / ``_iK`` names via ``Gensym``,
+whose suffix counts depend on the existing in-scope names — so an
+``is_equiv`` comparison against a hand-written golden AST is too
+brittle.  Instead, the tests assert two things:
+
+1. **Structural shape** of the rewritten AST (the iterable is a
+   ``range(len(...))``, the body opens with ``ListRef`` assigns,
+   etc.).  This catches "did the rewrite fire and is it
+   well-formed?"
+2. **Semantic equivalence** via the FPy interpreter on concrete
+   sample inputs.  This catches subtle errors in the rewrite that
+   pass shape checks.
+
+For the negative tests (unchanged inputs), ``is_equiv`` against
+the original AST is sufficient and stable.
+"""
+
+import fpy2 as fp
+
+from fpy2.ast.fpyast import (
+    Assign, ForStmt, Len, ListComp, ListRef, NamedId, Range1, Var, Zip,
+)
+from fpy2.transform import ZipElim
+
+
+def _find_for(ast: fp.ast.FuncDef) -> ForStmt:
+    """Return the first ``ForStmt`` reachable inside *ast.body*, descending
+    into ``ContextStmt`` blocks.  Used to inspect the rewritten loop."""
+    def walk(stmts):
+        for s in stmts:
+            if isinstance(s, ForStmt):
+                return s
+            # Descend into ContextStmt / other compound stmts via .body
+            body = getattr(s, 'body', None)
+            if body is not None and hasattr(body, 'stmts'):
+                hit = walk(body.stmts)
+                if hit is not None:
+                    return hit
+        return None
+    return walk(ast.body.stmts)
+
+
+def _find_listcomp(ast: fp.ast.FuncDef) -> ListComp:
+    """Return the first ``ListComp`` reachable in *ast*."""
+    from fpy2.ast.visitor import DefaultVisitor
+
+    found: list[ListComp] = []
+
+    class _C(DefaultVisitor):
+        def _visit_list_comp(self, e, ctx):
+            found.append(e)
+            super()._visit_list_comp(e, ctx)
+
+    _C()._visit_function(ast, None)
+    return found[0] if found else None
+
+
+def _eval(ast: fp.ast.FuncDef, fn: fp.Function, *args):
+    """Evaluate *ast* via the FPy interpreter using *fn*'s env."""
+    return fn.with_ast(ast)(*args)
+
+
+class TestForLoopRewrite:
+    """For-loops over zip get rewritten to range-indexed loops."""
+
+    def test_two_arg_zip_rewritten(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for a, b in zip(xs, ys):
+                    acc = acc + a * b
+                return acc
+
+        new_ast = ZipElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # The rewritten for-stmt's target is a NamedId (the fresh _i).
+        assert isinstance(loop.target, NamedId)
+        # The iterable is range(len(_src0)).
+        assert isinstance(loop.iterable, Range1)
+        assert isinstance(loop.iterable.arg, Len)
+        # The first two body stmts are the per-iter ListRef assigns.
+        body = loop.body.stmts
+        assert isinstance(body[0], Assign)
+        assert isinstance(body[0].expr, ListRef)
+        assert isinstance(body[1], Assign)
+        assert isinstance(body[1].expr, ListRef)
+        # Semantic equivalence on sample inputs.
+        xs = [1.0, 2.0, 3.0, 4.0]
+        ys = [10.0, 20.0, 30.0, 40.0]
+        assert _eval(new_ast, f, xs, ys) == f(xs, ys)
+
+    def test_three_arg_zip_rewritten(self):
+        @fp.fpy
+        def f(
+            xs: list[fp.Real], ys: list[fp.Real], zs: list[fp.Real]
+        ) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for a, b, c in zip(xs, ys, zs):
+                    acc = acc + a * b * c
+                return acc
+
+        new_ast = ZipElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # Three per-iter ListRef assigns, then the body.
+        body = loop.body.stmts
+        ref_count = sum(
+            1 for s in body
+            if isinstance(s, Assign) and isinstance(s.expr, ListRef)
+        )
+        assert ref_count == 3
+        # Semantic equivalence.
+        xs = [1.0, 2.0, 3.0]
+        ys = [4.0, 5.0, 6.0]
+        zs = [7.0, 8.0, 9.0]
+        assert _eval(new_ast, f, xs, ys, zs) == f(xs, ys, zs)
+
+    def test_underscore_target(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for _, b in zip(xs, ys):
+                    acc = acc + b
+                return acc
+
+        new_ast = ZipElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        body = loop.body.stmts
+        # The underscore slot emits no per-iter assign, so only one
+        # ListRef-assign appears (for ``b``).
+        ref_count = sum(
+            1 for s in body
+            if isinstance(s, Assign) and isinstance(s.expr, ListRef)
+        )
+        assert ref_count == 1
+        xs = [99.0, 99.0, 99.0]
+        ys = [1.0, 2.0, 3.0]
+        assert _eval(new_ast, f, xs, ys) == f(xs, ys)
+
+    def test_non_zip_iterable_unchanged(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for x in xs:
+                    acc = acc + x
+                return acc
+
+        new_ast = ZipElim.apply(f.ast)
+        # Untouched: AST equivalent to the original.
+        assert new_ast.is_equiv(f.ast)
+
+
+class TestListCompRewrite:
+    """List-comps over zip are rewritten when all zip args are Vars."""
+
+    def test_var_args_rewritten(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [a * b for a, b in zip(xs, ys)]
+
+        new_ast = ZipElim.apply(f.ast)
+        comp = _find_listcomp(new_ast)
+        # Single iteration stage with a NamedId target.
+        assert len(comp.targets) == 1
+        assert isinstance(comp.targets[0], NamedId)
+        # Iterable: range(len(...)).
+        assert isinstance(comp.iterables[0], Range1)
+        assert isinstance(comp.iterables[0].arg, Len)
+        # Semantic equivalence.
+        xs = [1.0, 2.0, 3.0]
+        ys = [10.0, 20.0, 30.0]
+        before = f(xs, ys)
+        after = _eval(new_ast, f, xs, ys)
+        assert list(after) == list(before)
+
+    def test_non_var_args_unchanged(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [a + b for a, b in zip(xs[1:], xs)]
+
+        new_ast = ZipElim.apply(f.ast)
+        # Non-Var zip arg (a slice) — comp is left alone.
+        assert new_ast.is_equiv(f.ast)
+        # And the comp still contains a Zip.
+        comp = _find_listcomp(new_ast)
+        assert isinstance(comp.iterables[0], Zip)
+
+    def test_shadowed_target_in_nested_comp(self):
+        """Inner comp re-binds ``a``; the inner reference should not be
+        substituted by the outer rewrite."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [sum([a for a in ys]) + b for a, b in zip(xs, ys)]
+
+        new_ast = ZipElim.apply(f.ast)
+        outer = _find_listcomp(new_ast)
+        # Outer iterable is a range now.
+        assert isinstance(outer.iterables[0], Range1)
+        # The outer ``b`` slot was substituted but inner ``a`` was not:
+        # we can verify this by checking the inner ListComp's elt is
+        # still a bare ``Var`` to ``a``, not a ListRef.
+        from fpy2.ast.fpyast import ListComp
+        # Find the inner list-comp.
+        inner_found: list[ListComp] = []
+        from fpy2.ast.visitor import DefaultVisitor
+
+        class _C(DefaultVisitor):
+            def _visit_list_comp(self, e, ctx):
+                if e is not outer:
+                    inner_found.append(e)
+                super()._visit_list_comp(e, ctx)
+
+        _C()._visit_function(new_ast, None)
+        assert len(inner_found) == 1
+        inner = inner_found[0]
+        # The inner elt is still ``Var(a)`` — not rewritten.
+        assert isinstance(inner.elt, Var)
+        assert inner.elt.name.base == 'a'
+        # And the inner iterable is still the original ``ys`` Var.
+        assert isinstance(inner.iterables[0], Var)
+        # Semantic equivalence.
+        xs = [1.0, 2.0, 3.0]
+        ys = [10.0, 20.0, 30.0]
+        before = list(f(xs, ys))
+        after = list(_eval(new_ast, f, xs, ys))
+        assert before == after
+
+
+class TestProperties:
+    """Cross-cutting properties of the transform."""
+
+    def test_idempotent(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for a, b in zip(xs, ys):
+                    acc = acc + a * b
+                return acc
+
+        once = ZipElim.apply(f.ast)
+        twice = ZipElim.apply(once)
+        assert once.is_equiv(twice)
+
+    def test_syntax_check_passes(self):
+        """``ZipElim.apply`` runs ``SyntaxCheck.check`` internally; if
+        the rewrite produced ill-formed output, ``apply`` itself would
+        raise.  This test just exercises a representative input."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for a, b in zip(xs, ys):
+                    acc = acc + a * b
+                return acc
+
+        # Should not raise.
+        ZipElim.apply(f.ast)


### PR DESCRIPTION
Add ZipElim transform

  Eliminates zip(...) iterables in for loops and list comprehensions by rewriting them to use range + indexed access on the source vectors, so backends no longer need to materialize an intermediate
  list[tuple[...]].

  Patterns rewritten

  For-loop over zip (any zip args):
```
  for a, b in zip(xs, ys):       _src0 = xs
      body                  →    _src1 = ys
                                 for _i in range(len(_src0)):
                                     a = _src0[_i]
                                     b = _src1[_i]
                                     body
```
   
  List-comp over zip (when all zip args are Vars):
```
  [elt for a, b in zip(xs, ys)]  →  [elt[a→xs[_i], b→ys[_i]] for _i in range(len(xs))]
```

  Substitution is scope-aware: a nested comprehension that re-binds a or b shadows the outer substitution.