### PR TITLE
Add rounding elimination

### DIFF
--- a/docs/todos/round-elim.md
+++ b/docs/todos/round-elim.md
@@ -7,23 +7,53 @@ rounding to the active context is provably an identity:
 
 - **Arithmetic ops** (`Add` / `Sub` / `Mul` / `Abs` / `Neg`) whose
   unrounded `F` is contained in `C.F` get hoisted into a
-  `with fp.REAL:` preamble, binding the result to a fresh `_tN`
-  that replaces the original expression site.
+  `with fp.REAL:` preamble.  Each operand is bound to a fresh
+  `_tN` under the *current* (original) context before being passed
+  into the REAL block.  Operands that are already `Var` references
+  skip the bind (a copy `_t = v` has no rounds to preserve).
 - **Explicit `Round` / `RoundExact` / `Cast` nodes** whose argument
   bound is already contained in the target context collapse to the
-  argument.
+  argument — a pure node-level rewrite that fires anywhere, even
+  inside positions where statement-level hoists are suppressed.
 
 The decision uses the public helpers `exact_binop`, `exact_unop`,
-and `round_is_identity` from `fpy2.analysis.format_infer`.  Greedy
-at the outermost fitting subtree.  Hoisting is suppressed inside
-`ListComp` element / iterable positions and inside `IfExpr`
-branches — those positions either reference loop-scoped variables
-or are conditionally evaluated, neither of which is sound for
-unconditional statement-level preambles.
+and `round_is_identity` from `fpy2.analysis.format_infer`.
 
-These follow-ups extend coverage or simplify the implementation.
+Hoisting is suppressed inside `ListComp` element / iterable
+positions and inside `IfExpr` branches — those positions either
+reference loop-scoped variables or are conditionally evaluated,
+neither of which is sound for unconditional statement-level
+preambles.
+
+The unconditional-bind scheme intentionally produces redundant
+copies (`_t = literal`, per-op REAL blocks for nested
+eliminations).  Idempotence falls out: a second RoundElim pass
+sees only `Var`-argumented ops under REAL, none of which trigger
+another hoist.  The slack in the intermediate AST is the trade
+for keeping the local rewrite small — downstream cleanup is
+expected to do the rest.
 
 ## Open items
+
+### Pair RoundElim with a const-prop + copy-prop + DCE cleanup invocation
+
+The per-op unconditional-bind scheme leaves redundant `_t = literal`
+and `_t = v` chains.  The full cleanup chain is `ConstPropagate`
+then `CopyPropagate` then `DeadCodeEliminate`: const-prop inlines
+literal-bound temps so they become dead, copy-prop collapses
+Var→Var aliases, DCE removes the unused assigns.  None of these
+are invoked from inside `RoundElim` today.  Either:
+
+- Make `RoundElim.apply` optionally chain them (e.g.,
+  `RoundElim.apply(func, cleanup=True)`), so callers get a tight
+  AST in one step.
+- Or document the recommended chain in the module docstring (done)
+  and expect pipeline callers to wire it themselves.
+
+The latter is simpler; the former is friendlier.  The cpp
+backend's `optimize=True` pipeline currently does neither —
+adding the chain after `RoundElim` in `_run_pipeline` is the
+natural integration point.
 
 ### Extend to `Sum`
 
@@ -32,42 +62,29 @@ at each step.  `_sum_bound` in `format_infer/analysis.py` already
 simulates the unrounded reduction (`af_acc = af_elt + … n-1 times`)
 and checks containment.  RoundElim can reuse that by exposing the
 unrounded simulation as a public helper (`exact_sum(elt_fmt, n)`),
-then handling `Sum` in `_unrounded_format` and `_visit_expr`.  Hoist
-shape is identical to the binary-op case.
+then handling `Sum` in `_unrounded_format` and `_visit_expr`.
+Hoist shape is identical to the binary-op case.
 
 ### Extend to `Call` to known FPy `Function`s
 
 A call's return value is implicitly rounded to the caller's active
-context.  When the callee is a known `Function` and format inference
-recorded its sub-analysis (`format_info.by_call[call_node]`), the
-return-format is available.  If the return-format fits in the
-caller's `C.F`, the round on the call is the identity — hoist the
-call into REAL.  Care needed: the callee's body may have its own
-rounding internals; the *return* round is what we're eliminating,
-not the callee's interior rounds.
-
-### Drop `_safe_to_hoist` once the collapse-first invariant is
-proven
-
-The current implementation runs the `Round` / `Cast` collapse and
-the arithmetic-op hoist in the same pass, decided per node in
-`_visit_expr`.  Because collapse happens at each Round/Cast node
-*before* any enclosing arithmetic op is hoisted, a hoisted subtree
-should never contain an eliminable round node — only non-eliminable
-ones remain to be checked.  `_safe_to_hoist` is the belt-and-
-suspenders that scans for them.
-
-If a property test or formal argument confirms the invariant always
-holds, drop the scan — saves an O(subtree) walk per hoist decision.
+context.  When the callee is a known `Function` and format
+inference recorded its sub-analysis
+(`format_info.by_call[call_node]`), the return-format is
+available.  If the return-format fits in the caller's `C.F`, the
+round on the call is the identity — hoist the call into REAL.
+Care needed: the callee's body may have its own rounding
+internals; the *return* round is what we're eliminating, not the
+callee's interior rounds.
 
 ### Relax hoist suppression inside `ListComp` iterables
 
 The first iterable of a list comp is evaluated at the enclosing
-block's scope (it doesn't reference any loop target).  It's safe to
-hoist.  Later iterables in multi-stage comps can reference earlier
-targets, so they must stay suppressed.  Implementation: in
-`_visit_list_comp`, pass the statement-level `_Ctx` to the first
-iterable and `None` to the rest.
+block's scope (it doesn't reference any loop target).  It's safe
+to hoist.  Later iterables in multi-stage comps can reference
+earlier targets, so they must stay suppressed.  Implementation:
+in `_visit_list_comp`, pass the statement-level `_Ctx` to the
+first iterable and `None` to the rest.
 
 Lower priority — multi-iterable comps are rare in FPy programs.
 
@@ -84,12 +101,13 @@ to add when a downstream consumer asks for it.
 ### Lift fully-eliminable function bodies to a `fp.REAL` decoration
 
 When *every* rounded op in a function body is eliminated, the
-function effectively executes under REAL.  Replacing the function's
-declared `ctx` with `fp.REAL` (and dropping the now-redundant per-op
-hoists) would simplify the AST further.  Pattern detection is
-straightforward — after `RoundElim`, walk the body and check for any
-remaining rounded ops outside `with fp.REAL:` blocks.  Mostly
-cosmetic; the runtime semantics are already equivalent.
+function effectively executes under REAL.  Replacing the
+function's declared `ctx` with `fp.REAL` (and dropping the
+now-redundant per-op hoists) would simplify the AST further.
+Pattern detection is straightforward — after `RoundElim`, walk
+the body and check for any remaining rounded ops outside
+`with fp.REAL:` blocks.  Mostly cosmetic; the runtime semantics
+are already equivalent.
 
 ### Phase B: per-value `SetFormat` rounding in `_bound_if_fits`
 
@@ -97,10 +115,11 @@ Not RoundElim-specific but related: format inference's SetFormat
 fast path is fits-or-bail.  A precise per-value image
 (`{C.round(v) for v in F.values}` via `Context.round`) would let
 RoundElim eliminate more rounds (constants like `fp.round(1/3)`
-become singleton `SetFormat({rounded_value})` rather than widening
-to the scope's format).  Tried once and rolled back — the per-value
-work in tight loops caused the cpp infra's `whetsone1` example to
-hang.  Re-attempt with either a size cap on the SetFormat or an
-explicit fall-back when iteration count crosses a threshold.
+become singleton `SetFormat({rounded_value})` rather than
+widening to the scope's format).  Tried once and rolled back —
+the per-value work in tight loops caused the cpp infra's
+`whetsone1` example to hang.  Re-attempt with either a size cap
+on the SetFormat or an explicit fall-back when iteration count
+crosses a threshold.
 
 Tracked as a TODO comment in `_bound_if_fits` itself.

--- a/docs/todos/round-elim.md
+++ b/docs/todos/round-elim.md
@@ -1,0 +1,106 @@
+# Round-elimination transform: follow-ups
+
+## Context
+
+`fpy2/transform/round_elim.py` rewrites expressions whose implicit
+rounding to the active context is provably an identity:
+
+- **Arithmetic ops** (`Add` / `Sub` / `Mul` / `Abs` / `Neg`) whose
+  unrounded `F` is contained in `C.F` get hoisted into a
+  `with fp.REAL:` preamble, binding the result to a fresh `_tN`
+  that replaces the original expression site.
+- **Explicit `Round` / `RoundExact` / `Cast` nodes** whose argument
+  bound is already contained in the target context collapse to the
+  argument.
+
+The decision uses the public helpers `exact_binop`, `exact_unop`,
+and `round_is_identity` from `fpy2.analysis.format_infer`.  Greedy
+at the outermost fitting subtree.  Hoisting is suppressed inside
+`ListComp` element / iterable positions and inside `IfExpr`
+branches — those positions either reference loop-scoped variables
+or are conditionally evaluated, neither of which is sound for
+unconditional statement-level preambles.
+
+These follow-ups extend coverage or simplify the implementation.
+
+## Open items
+
+### Extend to `Sum`
+
+`Sum(xs)` is a rounded op — pairwise reductions accumulate rounds
+at each step.  `_sum_bound` in `format_infer/analysis.py` already
+simulates the unrounded reduction (`af_acc = af_elt + … n-1 times`)
+and checks containment.  RoundElim can reuse that by exposing the
+unrounded simulation as a public helper (`exact_sum(elt_fmt, n)`),
+then handling `Sum` in `_unrounded_format` and `_visit_expr`.  Hoist
+shape is identical to the binary-op case.
+
+### Extend to `Call` to known FPy `Function`s
+
+A call's return value is implicitly rounded to the caller's active
+context.  When the callee is a known `Function` and format inference
+recorded its sub-analysis (`format_info.by_call[call_node]`), the
+return-format is available.  If the return-format fits in the
+caller's `C.F`, the round on the call is the identity — hoist the
+call into REAL.  Care needed: the callee's body may have its own
+rounding internals; the *return* round is what we're eliminating,
+not the callee's interior rounds.
+
+### Drop `_safe_to_hoist` once the collapse-first invariant is
+proven
+
+The current implementation runs the `Round` / `Cast` collapse and
+the arithmetic-op hoist in the same pass, decided per node in
+`_visit_expr`.  Because collapse happens at each Round/Cast node
+*before* any enclosing arithmetic op is hoisted, a hoisted subtree
+should never contain an eliminable round node — only non-eliminable
+ones remain to be checked.  `_safe_to_hoist` is the belt-and-
+suspenders that scans for them.
+
+If a property test or formal argument confirms the invariant always
+holds, drop the scan — saves an O(subtree) walk per hoist decision.
+
+### Relax hoist suppression inside `ListComp` iterables
+
+The first iterable of a list comp is evaluated at the enclosing
+block's scope (it doesn't reference any loop target).  It's safe to
+hoist.  Later iterables in multi-stage comps can reference earlier
+targets, so they must stay suppressed.  Implementation: in
+`_visit_list_comp`, pass the statement-level `_Ctx` to the first
+iterable and `None` to the rest.
+
+Lower priority — multi-iterable comps are rare in FPy programs.
+
+### Re-run `FormatInfer` on the output for downstream consumers
+
+`RoundElim.apply` runs `FormatInfer` to *decide* the rewrites but
+doesn't refresh it on the output.  Consumers calling
+`FormatInfer.analyze(round_elim_output)` get the tighter formats
+the rewrite enables (hoisted ops report unrounded `F`).  A wrapper
+that returns the rewritten `FuncDef` *and* its post-rewrite
+`FormatAnalysis` would save the duplicated analyze call.  Trivial
+to add when a downstream consumer asks for it.
+
+### Lift fully-eliminable function bodies to a `fp.REAL` decoration
+
+When *every* rounded op in a function body is eliminated, the
+function effectively executes under REAL.  Replacing the function's
+declared `ctx` with `fp.REAL` (and dropping the now-redundant per-op
+hoists) would simplify the AST further.  Pattern detection is
+straightforward — after `RoundElim`, walk the body and check for any
+remaining rounded ops outside `with fp.REAL:` blocks.  Mostly
+cosmetic; the runtime semantics are already equivalent.
+
+### Phase B: per-value `SetFormat` rounding in `_bound_if_fits`
+
+Not RoundElim-specific but related: format inference's SetFormat
+fast path is fits-or-bail.  A precise per-value image
+(`{C.round(v) for v in F.values}` via `Context.round`) would let
+RoundElim eliminate more rounds (constants like `fp.round(1/3)`
+become singleton `SetFormat({rounded_value})` rather than widening
+to the scope's format).  Tried once and rolled back — the per-value
+work in tight loops caused the cpp infra's `whetsone1` example to
+hang.  Re-attempt with either a size cap on the SetFormat or an
+explicit fall-back when iteration count crosses a threshold.
+
+Tracked as a TODO comment in `_bound_if_fits` itself.

--- a/fpy2/analysis/format_infer/__init__.py
+++ b/fpy2/analysis/format_infer/__init__.py
@@ -10,6 +10,9 @@ from .analysis import (
     PreAnalysisCache,
     SetFormat,
     TupleFormat,
+    exact_binop,
+    exact_unop,
+    round_is_identity,
 )
 from .format import AbstractFormat, AbstractableFormat
 
@@ -25,4 +28,7 @@ __all__ = [
     'PreAnalysisCache',
     'SetFormat',
     'TupleFormat',
+    'exact_binop',
+    'exact_unop',
+    'round_is_identity',
 ]

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -159,6 +159,9 @@ __all__ = [
     'SetFormat',
     'TupleFormat',
     'ListFormat',
+    'exact_binop',
+    'exact_unop',
+    'round_is_identity',
 ]
 
 
@@ -396,7 +399,7 @@ def _to_abstract(f: AbstractableFormatBound | SetFormat) -> AbstractFormat | Non
     else:
         return _setformat_to_abstract(f)
 
-def _exact_binop(
+def exact_binop(
     lhs: 'FormatBound',
     rhs: 'FormatBound',
     op: Callable[[Any, Any], Any],
@@ -412,7 +415,10 @@ def _exact_binop(
 
     Used by :meth:`_FormatInferInstance._visit_binaryop` to compute
     the candidate ``F`` that :meth:`_bound_if_fits` then checks
-    against the active scope.
+    against the active scope.  Also part of the public API
+    consumed by downstream transforms (e.g.,
+    :class:`fpy2.transform.RoundElim`) that need the unrounded
+    image of a rounded operation.
     """
     if not (
         isinstance(lhs, AbstractableFormatBound)
@@ -430,11 +436,11 @@ def _exact_binop(
     return op(af_a, af_b)
 
 
-def _exact_unop(
+def exact_unop(
     arg: 'FormatBound',
     op: Callable[[Any], Any],
 ) -> 'SetFormat | AbstractFormat | None':
-    """Unary analogue of :func:`_exact_binop` — apply *op* either
+    """Unary analogue of :func:`exact_binop` — apply *op* either
     pointwise to a :class:`SetFormat`'s values or directly to a
     lifted :class:`AbstractFormat`.  Returns ``None`` when *arg* is
     not abstractable.
@@ -447,6 +453,41 @@ def _exact_unop(
     if af is None:
         return None
     return op(af)
+
+
+def round_is_identity(
+    unrounded: 'SetFormat | AbstractFormat | None',
+    ctx: Context | None,
+) -> bool:
+    """Decide whether ``round_{ctx}(unrounded) == unrounded`` — i.e.,
+    every value representable in *unrounded* is also representable
+    in *ctx*'s format, so the round leaves the value-set unchanged.
+
+    *unrounded* is the unrounded value-set, typically the result of
+    :func:`exact_binop` / :func:`exact_unop` (or, for explicit
+    ``Round``/``RoundExact``/``Cast`` nodes, the argument's inferred
+    bound).  *ctx* is the concrete rounding context whose
+    round-identity behavior we care about.
+
+    Returns ``True`` when *ctx* is :data:`REAL` (the trivial identity
+    context) and *unrounded* is non-``None``.  Returns ``False`` when
+    *ctx* is ``None`` (symbolic / unresolved scope — we can't claim
+    identity without a concrete target) or *unrounded* is ``None``.
+
+    Used by :meth:`_FormatInferInstance._bound_if_fits` internally and
+    exposed publicly for transforms that key off the same identity
+    notion (e.g., :class:`fpy2.transform.RoundElim`).
+    """
+    if unrounded is None or ctx is None:
+        return False
+    if ctx is REAL:
+        return True
+    ctx_fmt = ctx.format()
+    if isinstance(unrounded, SetFormat):
+        return _all_representable_in(unrounded.values, ctx_fmt)
+    if not isinstance(ctx_fmt, AbstractableFormat):
+        return False
+    return unrounded <= AbstractFormat.from_format(ctx_fmt)
 
 
 def _join_bounds(
@@ -889,24 +930,25 @@ class _FormatInferInstance(Visitor):
         # intent as the widen-to-REAL branches in ``_join_bounds``.
         if self._widen:
             return None
+        # Identity-round fast path: when ``round_C(F) == F``, the
+        # rounded image equals *exact* itself.  Both the SetFormat
+        # fits-everywhere case and the AbstractFormat
+        # ``F ⊆ scope_af`` case collapse into this single check —
+        # single-sourced via :func:`round_is_identity` so external
+        # consumers (e.g. ``RoundElim``) see the same notion.
+        if round_is_identity(exact, resolved):
+            return exact if isinstance(exact, SetFormat) else exact.format()
         scope_fmt = resolved.format()
         if isinstance(exact, SetFormat):
             # TODO: we can round each value in the set individually
             # to produce a precise image even when some values exceed the scope
             # It is unclear how this affects the overal algorithm.
-            return (
-                exact
-                if _all_representable_in(exact.values, scope_fmt)
-                else None
-            )
+            return None
         if not isinstance(scope_fmt, AbstractableFormat):
             return None
-
         scope_af = AbstractFormat.from_format(scope_fmt)
         if scope_af <= exact:
             return scope_fmt
-        if exact <= scope_af:
-            return exact.format()
 
         # Mixed-overlap branch.  Tighten prec/exp unconditionally —
         # both are sound under any rounding mode.  Tighten bounds
@@ -1045,13 +1087,13 @@ class _FormatInferInstance(Visitor):
                 # abs: precision-preserving.  Use the unrounded result
                 # whenever the active scope's format contains it; see
                 # :meth:`_bound_if_fits`.
-                fitted = self._bound_if_fits(e, _exact_unop(arg_fmt, abs))
+                fitted = self._bound_if_fits(e, exact_unop(arg_fmt, abs))
                 if fitted is not None:
                     return fitted
             case Neg():
                 # negation: precision-preserving (same logic as Abs).
                 fitted = self._bound_if_fits(
-                    e, _exact_unop(arg_fmt, operator.neg),
+                    e, exact_unop(arg_fmt, operator.neg),
                 )
                 if fitted is not None:
                     return fitted
@@ -1134,19 +1176,19 @@ class _FormatInferInstance(Visitor):
                 # :meth:`_bound_if_fits`.  Subsumes the legacy REAL-only
                 # fast path (REAL_FORMAT contains everything).
                 fitted = self._bound_if_fits(
-                    e, _exact_binop(lhs, rhs, operator.add),
+                    e, exact_binop(lhs, rhs, operator.add),
                 )
                 if fitted is not None:
                     return fitted
             case Sub():
                 fitted = self._bound_if_fits(
-                    e, _exact_binop(lhs, rhs, operator.sub),
+                    e, exact_binop(lhs, rhs, operator.sub),
                 )
                 if fitted is not None:
                     return fitted
             case Mul():
                 fitted = self._bound_if_fits(
-                    e, _exact_binop(lhs, rhs, operator.mul),
+                    e, exact_binop(lhs, rhs, operator.mul),
                 )
                 if fitted is not None:
                     return fitted

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -472,6 +472,14 @@ def _join_bounds(
         case None, None:
             return None
         case SetFormat(values=a), SetFormat(values=b):
+            # Widening: SetFormat unions form a lattice of unbounded
+            # height (each loop iteration can add a fresh value), so a
+            # naive phi-join over them never converges.  When the
+            # caller signals it's running a saturated loop fixpoint,
+            # collapse to ``REAL_FORMAT`` so the next iteration falls
+            # back to the abstract path and reaches a fixed point.
+            if widen:
+                return REAL_FORMAT
             return SetFormat(a | b)
         case SetFormat(values=vals), Format() as fmt:
             return fmt if _all_representable_in(vals, fmt) else REAL_FORMAT
@@ -954,6 +962,25 @@ class _FormatInferInstance(Visitor):
             case Sum():
                 assert isinstance(arg_fmt, ListFormat), f'expected ListFormat for argument of Sum, got {arg_fmt!r}'
                 return self._sum_bound(e, arg_fmt)
+            case Round() | RoundExact() | Cast():
+                # Identity-when-fits.  ``Round`` / ``RoundExact`` round
+                # the argument to the active scope; ``Cast`` asserts
+                # the argument already fits.  When the argument's
+                # inferred format is contained in the scope's format,
+                # every one of these operations is the identity at the
+                # value level — so the result's tight format equals
+                # the argument's, not the scope's.  Falls back to
+                # :meth:`_op_bound` (the scope format) otherwise.
+                if isinstance(arg_fmt, SetFormat):
+                    fitted = self._bound_if_fits(e, arg_fmt)
+                elif isinstance(arg_fmt, AbstractableFormat):
+                    fitted = self._bound_if_fits(
+                        e, AbstractFormat.from_format(arg_fmt),
+                    )
+                else:
+                    fitted = None
+                if fitted is not None:
+                    return fitted
             case Abs():
                 # abs: precision-preserving.  Use the unrounded result
                 # whenever the active scope's format contains it; see
@@ -977,39 +1004,49 @@ class _FormatInferInstance(Visitor):
         Format of ``Sum(xs)`` — reduce-by-pairwise-addition with rounding
         under the active context at each step.
 
-        - **Non-REAL scope**: each pairwise add rounds to the scope's
-          format, so the accumulator equals the scope's format
-          throughout.  Falls back to :meth:`_op_bound`.
-        - **REAL scope**: no rounding.  Simulate ``n - 1`` exact
-          additions through :class:`AbstractFormat` to produce a precise
-          containing format.  Requires the list size to be statically
-          known via :class:`ArraySizeAnalysis`; otherwise falls back to
-          ``REAL_FORMAT`` via :meth:`_op_bound`.
+        Strategy: simulate ``n - 1`` exact pairwise additions through
+        :class:`AbstractFormat`.  The simulated accumulator's
+        representable set is a superset of every intermediate partial
+        sum's value set (this matters for signed reductions, where
+        intermediate magnitudes can exceed the final result).  If the
+        simulated accumulator fits under the active scope's format,
+        every per-step ``round_C`` is the identity, so the precise
+        format is sound to report — regardless of whether the scope
+        is :data:`REAL` or a concrete rounding context.  Otherwise
+        the result widens to the scope's format via :meth:`_op_bound`.
+
+        Requires the list size to be statically known via
+        :class:`ArraySizeAnalysis`; otherwise falls back to
+        :meth:`_op_bound`.
 
         The branches below are ordered so that the trivial cases
         (``n == 0`` and ``n == 1``) are decided before any
-        abstractability check on the element format — those cases
-        produce a precise bound independent of whether the elements
-        could be lifted to :class:`AbstractFormat`.
+        abstractability check on the element format.
         """
         n = self._known_iter_count(e.arg)
-        if not self._is_real_scope(e) or n is None:
+        if n is None:
             return self._op_bound(e)
 
-        # ``sum([])`` is conventionally 0 — independent of what the
-        # (absent) elements would have looked like.
+        # ``sum([])`` is conventionally 0 — fits trivially in any scope.
         if n == 0:
             return SetFormat(frozenset((Fraction(0),)))
 
         elt_fmt = arg_fmt.elt
-        # Single-element reduction: no addition occurs, the lone element
-        # passes through with its existing format.  Independent of
-        # abstractability.
+        # Single-element reduction: ``sum([x])`` evaluates to
+        # ``round_C(x)``.  Tighten to ``elt_fmt`` when it fits under
+        # the scope; otherwise the round may not be the identity.
         if n == 1:
-            return elt_fmt
+            if isinstance(elt_fmt, SetFormat):
+                fitted = self._bound_if_fits(e, elt_fmt)
+            elif isinstance(elt_fmt, AbstractableFormat):
+                fitted = self._bound_if_fits(e, AbstractFormat.from_format(elt_fmt))
+            else:
+                fitted = None
+            return fitted if fitted is not None else self._op_bound(e)
 
         # ``n >= 2``: simulate ``n - 1`` pairwise additions through
-        # AbstractFormat.  Requires the element to be abstractable.
+        # AbstractFormat, then check the final accumulator against the
+        # scope.  Requires the element to be abstractable.
         if not isinstance(elt_fmt, AbstractableFormatBound):
             return self._op_bound(e)
         af_elt = _to_abstract(elt_fmt)
@@ -1018,7 +1055,8 @@ class _FormatInferInstance(Visitor):
         af_acc = af_elt
         for _ in range(n - 1):
             af_acc = af_acc + af_elt
-        return af_acc.format()
+        fitted = self._bound_if_fits(e, af_acc)
+        return fitted if fitted is not None else self._op_bound(e)
 
     def _visit_binaryop(self, e: BinaryOp, ctx: None) -> FormatBound:
         lhs = self._visit_expr(e.first, ctx)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -118,10 +118,12 @@ Format inference rules
 - **Inline conditionals** (``IfExpr``): ``join(then_fmt, else_fmt)``.
 """
 
+import operator
+
 from dataclasses import dataclass
 from fractions import Fraction
 from functools import reduce
-from typing import Callable, Iterable, TypeAlias
+from typing import Any, Callable, Iterable, TypeAlias
 
 from ...ast.fpyast import *
 from ...ast.visitor import Visitor
@@ -393,6 +395,59 @@ def _to_abstract(f: AbstractableFormatBound | SetFormat) -> AbstractFormat | Non
         return AbstractFormat.from_format(f)
     else:
         return _setformat_to_abstract(f)
+
+def _exact_binop(
+    lhs: 'FormatBound',
+    rhs: 'FormatBound',
+    op: Callable[[Any, Any], Any],
+) -> 'SetFormat | AbstractFormat | None':
+    """Compute the exact unrounded result of an arithmetic binary op.
+
+    *op* is applied either pointwise to a pair of :class:`SetFormat`
+    operands (over their :class:`Fraction` values) or directly to
+    operands lifted to :class:`AbstractFormat`.  Both paths produce
+    a sound, non-rounded result.  Returns ``None`` when either
+    operand isn't abstractable (e.g. ``None``, ``TupleFormat``,
+    non-dyadic ``SetFormat``).
+
+    Used by :meth:`_FormatInferInstance._visit_binaryop` to compute
+    the candidate ``F`` that :meth:`_bound_if_fits` then checks
+    against the active scope.
+    """
+    if not (
+        isinstance(lhs, AbstractableFormatBound)
+        and isinstance(rhs, AbstractableFormatBound)
+    ):
+        return None
+    if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
+        return SetFormat(frozenset(
+            op(va, vb) for va in lhs.values for vb in rhs.values
+        ))
+    af_a = _to_abstract(lhs)
+    af_b = _to_abstract(rhs)
+    if af_a is None or af_b is None:
+        return None
+    return op(af_a, af_b)
+
+
+def _exact_unop(
+    arg: 'FormatBound',
+    op: Callable[[Any], Any],
+) -> 'SetFormat | AbstractFormat | None':
+    """Unary analogue of :func:`_exact_binop` — apply *op* either
+    pointwise to a :class:`SetFormat`'s values or directly to a
+    lifted :class:`AbstractFormat`.  Returns ``None`` when *arg* is
+    not abstractable.
+    """
+    if not isinstance(arg, AbstractableFormatBound):
+        return None
+    if isinstance(arg, SetFormat):
+        return SetFormat(frozenset(op(v) for v in arg.values))
+    af = _to_abstract(arg)
+    if af is None:
+        return None
+    return op(af)
+
 
 def _join_bounds(
     s1: FormatBound,
@@ -775,6 +830,43 @@ class _FormatInferInstance(Visitor):
         """
         return self.ctx_use.find_scope_from_use(e).ctx is REAL
 
+    def _bound_if_fits(
+        self,
+        e: ContextUseSite,
+        exact: SetFormat | AbstractFormat | None,
+    ) -> FormatBound | None:
+        """If *exact* — the statically-known unrounded result of *e* —
+        is representable under *e*'s active scope format, return it
+        as the inferred bound.  Returns ``None`` otherwise.
+
+        This generalizes the legacy REAL-only fast path: under any
+        concrete scope ``C`` whose format ``C.F`` contains *exact*'s
+        value set, ``round_C(exact) = exact``, so the rounded format
+        equals the unrounded one.  :data:`REAL` is the case where
+        ``C.F`` trivially contains every value.
+
+        Symbolic (unresolved) scopes return ``None`` — we can't safely
+        claim round-is-identity without knowing the concrete context.
+        """
+        if exact is None:
+            return None
+        resolved = self._resolve_active_ctx(e)
+        if resolved is None:
+            return None
+        if resolved is REAL:
+            return exact if isinstance(exact, SetFormat) else exact.format()
+        scope_fmt = resolved.format()
+        if isinstance(exact, SetFormat):
+            return (
+                exact
+                if _all_representable_in(exact.values, scope_fmt)
+                else None
+            )
+        if not isinstance(scope_fmt, AbstractableFormat):
+            return None
+        scope_af = AbstractFormat.from_format(scope_fmt)
+        return exact.format() if exact <= scope_af else None
+
     def _visit_binding(
         self,
         site: DefSite,
@@ -863,19 +955,19 @@ class _FormatInferInstance(Visitor):
                 assert isinstance(arg_fmt, ListFormat), f'expected ListFormat for argument of Sum, got {arg_fmt!r}'
                 return self._sum_bound(e, arg_fmt)
             case Abs():
-                # abs: preserves precision under exact arithmetic, otherwise rounds to the scope's format
-                if self._is_real_scope(e) and isinstance(arg_fmt, AbstractableFormatBound):
-                    if isinstance(arg_fmt, SetFormat):
-                        return SetFormat(frozenset(abs(v) for v in arg_fmt.values))
-                    else:
-                        return abs(AbstractFormat.from_format(arg_fmt)).format()
+                # abs: precision-preserving.  Use the unrounded result
+                # whenever the active scope's format contains it; see
+                # :meth:`_bound_if_fits`.
+                fitted = self._bound_if_fits(e, _exact_unop(arg_fmt, abs))
+                if fitted is not None:
+                    return fitted
             case Neg():
-                # negation: preserves precision under exact arithmetic, otherwise rounds to the scope's format
-                if self._is_real_scope(e) and isinstance(arg_fmt, AbstractableFormatBound):
-                    if isinstance(arg_fmt, SetFormat):
-                        return SetFormat(frozenset(-v for v in arg_fmt.values))
-                    else:
-                        return (-AbstractFormat.from_format(arg_fmt)).format()
+                # negation: precision-preserving (same logic as Abs).
+                fitted = self._bound_if_fits(
+                    e, _exact_unop(arg_fmt, operator.neg),
+                )
+                if fitted is not None:
+                    return fitted
 
         return self._op_bound(e)
 
@@ -939,39 +1031,27 @@ class _FormatInferInstance(Visitor):
                 # range(...) -> result is a list of integers.
                 return ListFormat(_INTEGER_FORMAT)
             case Add():
-                # exact addition: precise under exact arithmetic with
-                # abstractable operands, otherwise rounds to the scope's format.
-                if (self._is_real_scope(e)
-                        and isinstance(lhs, AbstractableFormatBound)
-                        and isinstance(rhs, AbstractableFormatBound)):
-                    if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
-                        return SetFormat(frozenset(va + vb for va in lhs.values for vb in rhs.values))
-                    af_a = _to_abstract(lhs)
-                    af_b = _to_abstract(rhs)
-                    if af_a is not None and af_b is not None:
-                        return (af_a + af_b).format()
+                # Exact addition.  Use the unrounded result whenever
+                # the active scope's format contains it; see
+                # :meth:`_bound_if_fits`.  Subsumes the legacy REAL-only
+                # fast path (REAL_FORMAT contains everything).
+                fitted = self._bound_if_fits(
+                    e, _exact_binop(lhs, rhs, operator.add),
+                )
+                if fitted is not None:
+                    return fitted
             case Sub():
-                # exact subtraction: same dispatch shape as Add.
-                if (self._is_real_scope(e)
-                        and isinstance(lhs, AbstractableFormatBound)
-                        and isinstance(rhs, AbstractableFormatBound)):
-                    if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
-                        return SetFormat(frozenset(va - vb for va in lhs.values for vb in rhs.values))
-                    af_a = _to_abstract(lhs)
-                    af_b = _to_abstract(rhs)
-                    if af_a is not None and af_b is not None:
-                        return (af_a - af_b).format()
+                fitted = self._bound_if_fits(
+                    e, _exact_binop(lhs, rhs, operator.sub),
+                )
+                if fitted is not None:
+                    return fitted
             case Mul():
-                # exact multiplication: same dispatch shape as Add.
-                if (self._is_real_scope(e)
-                        and isinstance(lhs, AbstractableFormatBound)
-                        and isinstance(rhs, AbstractableFormatBound)):
-                    if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
-                        return SetFormat(frozenset(va * vb for va in lhs.values for vb in rhs.values))
-                    af_a = _to_abstract(lhs)
-                    af_b = _to_abstract(rhs)
-                    if af_a is not None and af_b is not None:
-                        return (af_a * af_b).format()
+                fitted = self._bound_if_fits(
+                    e, _exact_binop(lhs, rhs, operator.mul),
+                )
+                if fitted is not None:
+                    return fitted
 
         return self._op_bound(e)
 

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -891,9 +891,9 @@ class _FormatInferInstance(Visitor):
             return None
         scope_fmt = resolved.format()
         if isinstance(exact, SetFormat):
-            # Phase B will compute ``{C.round(v) for v in exact.values}``
-            # for the general case.  For now keep the fits-only fast
-            # path; non-fitting SetFormats fall back to ``_op_bound``.
+            # TODO: we can round each value in the set individually
+            # to produce a precise image even when some values exceed the scope
+            # It is unclear how this affects the overal algorithm.
             return (
                 exact
                 if _all_representable_in(exact.values, scope_fmt)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -843,18 +843,35 @@ class _FormatInferInstance(Visitor):
         e: ContextUseSite,
         exact: SetFormat | AbstractFormat | None,
     ) -> FormatBound | None:
-        """If *exact* — the statically-known unrounded result of *e* —
-        is representable under *e*'s active scope format, return it
-        as the inferred bound.  Returns ``None`` otherwise.
+        """Return the format of ``round_C(exact)``, where ``C`` is *e*'s
+        active scope and *exact* is the statically-known unrounded
+        result.  Returns ``None`` only when the helper can't compute a
+        usable bound (no *exact*, symbolic scope, non-abstractable
+        scope format, or :class:`SetFormat` that doesn't fit — the
+        last case becomes precise in Phase B).
 
-        This generalizes the legacy REAL-only fast path: under any
-        concrete scope ``C`` whose format ``C.F`` contains *exact*'s
-        value set, ``round_C(exact) = exact``, so the rounded format
-        equals the unrounded one.  :data:`REAL` is the case where
-        ``C.F`` trivially contains every value.
+        Two regimes:
 
-        Symbolic (unresolved) scopes return ``None`` — we can't safely
-        claim round-is-identity without knowing the concrete context.
+        - ``exact ⊆ C``: every value is C-representable, so ``round_C``
+          is the identity and the inferred bound *is* ``exact`` — strict
+          improvement over the scope's format.  This is the case the
+          helper handled exclusively before; the name reflects that
+          legacy intent.
+
+        - ``exact ⊄ C`` (some dimension exceeds the scope but others
+          may be tighter): the image ``round_C(exact)`` is bounded by
+          the intersection ``exact & C`` at the
+          :class:`AbstractFormat` level (precision clipped down to
+          ``C``'s, quantum coarsened to ``max(F.exp, C.exp)``, magnitude
+          clipped to ``min(F.bound, C.bound)``).  The intersection is
+          a sound over-approximation of the image and is at most as
+          wide as ``C``.  Phase A widens to ``F & C`` here; Phase B
+          will additionally compute the precise value-image for
+          :class:`SetFormat` operands via :meth:`Context.round`.
+
+        :data:`REAL` is the case where ``C.F`` trivially contains every
+        value (intersection equals *exact*).  Symbolic scopes return
+        ``None`` — we can't apply rounding to an unknown context.
         """
         if exact is None:
             return None
@@ -863,8 +880,20 @@ class _FormatInferInstance(Visitor):
             return None
         if resolved is REAL:
             return exact if isinstance(exact, SetFormat) else exact.format()
+        # Under loop-fixpoint widening, fall back to the coarse scope
+        # format.  The intersection-image branch below can produce
+        # intermediate formats that change by one prec bit per
+        # iteration as the unrounded chain grows, which prevents the
+        # fixpoint from converging.  Skipping the intersection during
+        # widening forces the body to settle at scope_fmt — same
+        # intent as the widen-to-REAL branches in ``_join_bounds``.
+        if self._widen:
+            return None
         scope_fmt = resolved.format()
         if isinstance(exact, SetFormat):
+            # Phase B will compute ``{C.round(v) for v in exact.values}``
+            # for the general case.  For now keep the fits-only fast
+            # path; non-fitting SetFormats fall back to ``_op_bound``.
             return (
                 exact
                 if _all_representable_in(exact.values, scope_fmt)
@@ -872,8 +901,39 @@ class _FormatInferInstance(Visitor):
             )
         if not isinstance(scope_fmt, AbstractableFormat):
             return None
+
         scope_af = AbstractFormat.from_format(scope_fmt)
-        return exact.format() if exact <= scope_af else None
+        if scope_af <= exact:
+            return scope_fmt
+        if exact <= scope_af:
+            return exact.format()
+
+        # Mixed-overlap branch.  Tighten prec/exp unconditionally —
+        # both are sound under any rounding mode.  Tighten bounds
+        # only when F's precision fits in C's.
+        #
+        # Soundness pitfall on bounds: ``round_C(F.pos_bound)`` can
+        # land up to one ulp_C *above* F.pos_bound (round-up, or
+        # round-to-nearest with a tie pointing away from zero) when
+        # F.pos_bound isn't exactly C-representable.  A naive
+        # ``min(F.pos_bound, C.pos_bound)`` would then under-claim
+        # the image's bound and be unsound.
+        #
+        # The gate: when ``F.prec <= C.prec``, F.pos_bound has
+        # precision ≤ F.prec ≤ C.prec and is therefore exactly
+        # C-representable, so the intersection's bounds are sound.
+        # When ``F.prec > C.prec`` we fall back to C's bounds.
+        # ``int | float`` comparison works directly with the
+        # ``float('inf')`` sentinel used for unbounded prec.
+        prec = min(exact.prec, scope_af.prec)
+        exp = max(exact.exp, scope_af.exp)
+        if exact.prec > scope_af.prec:
+            pos_bound = scope_af.pos_bound
+            neg_bound = scope_af.neg_bound
+        else:
+            pos_bound = min(exact.pos_bound, scope_af.pos_bound)
+            neg_bound = max(exact.neg_bound, scope_af.neg_bound)
+        return AbstractFormat(prec, exp, pos_bound, neg_bound=neg_bound).format()
 
     def _visit_binding(
         self,

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -29,7 +29,7 @@ from ...number import Context
 from ...number.context.ieee754 import IEEEContext
 from ...number.context.mp_fixed import MPFixedContext
 from ...number.context.mpb_fixed import MPBFixedContext
-from ...transform import Monomorphize, ZipElim
+from ...transform import Monomorphize, RoundElim, ZipElim
 from ...types import Type
 from ..backend import Backend, CompileError
 
@@ -274,12 +274,20 @@ class CppCompiler(Backend):
             Set ``False`` to reject such programs at compile time.
         optimize:
             When ``True`` (default), apply optimizing program
-            transformations (currently :class:`fpy2.transform.ZipElim`)
-            to each :class:`FuncDef` before the rest of the pipeline
-            runs.  The pipeline is sound either way, but the
-            optimized form skips materializing intermediate
-            ``std::vector<std::tuple<...>>``s for ``zip`` iterables.
-            Set ``False`` to compile the surface AST verbatim.
+            transformations to each :class:`FuncDef` before the rest
+            of the pipeline runs:
+
+            - :class:`fpy2.transform.ZipElim` (pre-monomorphize):
+              skips materializing intermediate
+              ``std::vector<std::tuple<...>>``s for ``zip`` iterables.
+            - :class:`fpy2.transform.RoundElim` (post-monomorphize):
+              hoists eliminable rounded operations into
+              ``with fp.REAL:`` blocks so the cpp emitter's
+              lossless-widening dispatch can pick tighter storage
+              for them.
+
+            The pipeline is sound either way.  Set ``False`` to
+            compile the surface AST verbatim.
     """
 
     _unsafe_cast_int: bool
@@ -343,14 +351,21 @@ class CppCompiler(Backend):
         if ast.ctx is not None:
             ctx = None
 
-        # Optional pre-pipeline transforms.  Applied before
-        # monomorphization since they only rewrite the surface AST
-        # and don't depend on type information.
+        # Optional pre-monomorphize transforms.  These rewrite the
+        # surface AST without needing type information, so they're
+        # cheapest to run first.
         if self._optimize:
             ast = ZipElim.apply(ast)
 
         # apply monomorphization to get concrete types
         ast = Monomorphize.apply_by_arg(ast, ctx, arg_types)
+
+        # Optional post-monomorphize transforms.  ``RoundElim`` uses
+        # format inference to decide which rounded ops can be moved
+        # to ``with fp.REAL:``; the analysis needs the concrete
+        # types Monomorphize just installed.
+        if self._optimize:
+            ast = RoundElim.apply(ast)
 
         # run program analyses to get the information the emitter needs
         def_use = DefineUse.analyze(ast)

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -414,19 +414,22 @@ class CppEmitter(Visitor):
             self._visit_statement(stmt, ctx)
 
     def _visit_assign(self, stmt: Assign, ctx):
-        rhs = self._visit_expr(stmt.expr, ctx)
         match stmt.target:
             case NamedId():
                 # ``StorageInfer`` maps this Assign's SSA def to a
                 # C++ variable and tells us whether to declare (a
                 # single-writer class) or just reassign into a
                 # hoisted decl (multi-writer class).
+                target_def = self.def_use.find_def_from_site(stmt.target, stmt)
+                target_storage = self.storage.storage_of(target_def)
+                rhs = self._emit_assign_rhs(stmt.expr, target_storage, ctx)
                 self._emit_bind(stmt.target, stmt, rhs)
             case TupleBinding():
                 # ``(a, b) = expr``: bind the rhs to a tuple-valued
                 # temp once, then destructure.  Each NamedId in the
                 # binding has its own SSA def registered at the
                 # Assign statement.
+                rhs = self._visit_expr(stmt.expr, ctx)
                 tmp = self._fresh_temp()
                 self.writer.add_line(f'auto {tmp} = {rhs};')
                 self._destructure(stmt.target, tmp, stmt)
@@ -435,6 +438,58 @@ class CppEmitter(Visitor):
                     f'unsupported assignment target {stmt.target!r}',
                     at=stmt,
                 )
+
+    def _emit_assign_rhs(
+        self, expr: Expr, target_ty: CppType, ctx,
+    ) -> str:
+        """Emit an assignment's RHS, coercing a list-literal wrapper to
+        the target's storage when they disagree.
+
+        Why this matters: ``_storage_for_expr`` picks the list's wrapper
+        from format inference (the tight per-expression join), but
+        :class:`StorageInfer` may have widened the variable's storage
+        beyond that — e.g. when a subsequent ``x[i] = y`` (IndexedAssign)
+        joins the def with a wider value.  Emitting
+        ``vector<wide> x = vector<narrow>{...}`` is a hard C++ type
+        error, and per-element narrowing inside the literal also
+        triggers ``-Wnarrowing`` when the element expressions were
+        emitted at the wider type (e.g. ``Round`` lowers to a
+        ``static_cast`` into the active context's scalar).  Using the
+        target's storage for the wrapper keeps the literal consistent
+        with the variable's declared type.
+        """
+        if isinstance(expr, ListExpr) and isinstance(target_ty, CppList):
+            return self._emit_list_expr_at(expr, target_ty, ctx)
+        return self._visit_expr(expr, ctx)
+
+    def _emit_list_expr_at(
+        self, e: ListExpr, wrapper_ty: CppList, ctx,
+    ) -> str:
+        """Emit ``[a, b, c]`` as ``wrapper_ty{a, b, c}``, casting each
+        element to ``wrapper_ty.elt`` when the per-element emitted
+        storage disagrees.  Mirrors :meth:`_visit_list_expr` but with
+        an externally-supplied wrapper type."""
+        elt_target = wrapper_ty.elt
+        parts: list[str] = []
+        for elt in e.elts:
+            elt_str = self._visit_expr(elt, ctx)
+            if isinstance(elt_target, CppScalar):
+                # Cast when the element's per-expression storage
+                # differs from the wrapper's element type.  Defensive
+                # ``try`` mirrors ``_storage_for_expr``'s exception
+                # contract — non-storable formats (e.g., symbolic
+                # REAL_FORMAT) just skip the cast.
+                try:
+                    elt_storage = self._storage_for_expr(elt)
+                except CppEmitError:
+                    elt_storage = None
+                if (
+                    isinstance(elt_storage, CppScalar)
+                    and elt_storage != elt_target
+                ):
+                    elt_str = self._explicit_cast(elt_str, elt_target)
+            parts.append(elt_str)
+        return f'{wrapper_ty.format()}{{{", ".join(parts)}}}'
 
     def _visit_return(self, stmt: ReturnStmt, ctx):
         rhs = self._visit_expr(stmt.expr, ctx)

--- a/fpy2/transform/__init__.py
+++ b/fpy2/transform/__init__.py
@@ -15,6 +15,7 @@ from .if_bundling import IfBundling
 from .lift_context import LiftContext
 from .monomorphize import Monomorphize
 from .rename_target import RenameTarget
+from .round_elim import RoundElim
 from .simplify_if import SimplifyIf
 from .split_loop import SplitLoop, SplitLoopStrategy
 from .subst_var import SubstVar

--- a/fpy2/transform/round_elim.py
+++ b/fpy2/transform/round_elim.py
@@ -1,0 +1,386 @@
+"""
+Eliminate unnecessary rounding from expressions whose unrounded
+format is contained in the active rounding context.
+
+For a rounded arithmetic op ``f(x_1, ..., x_n)`` (``Add``, ``Sub``,
+``Mul``, ``Abs``, ``Neg``) under active context ``C``, the runtime
+semantics insert an implicit ``round_C`` around the result.  When
+format inference proves ``format(f(...)) ⊆ C.F``, that round is the
+identity — the value is unchanged whether or not it fires.  This
+transform makes that fact structural by hoisting the operation into
+a ``with fp.REAL:`` preamble, binding it to a fresh name, and
+threading the name back into the original expression site.
+
+For explicit ``Round`` / ``RoundExact`` / ``Cast`` nodes, the same
+notion produces a different rewrite: when the argument's bound
+already fits in the target context, the whole node collapses to
+its argument (the round was a no-op at runtime).
+
+Rewrite shape:
+
+.. code-block:: python
+
+   # Before
+   with fp.FP64:
+       a = (1.0 + 2.0) * 3.0    # whole RHS fits FP64 exactly
+
+   # After
+   with fp.FP64:
+       with fp.REAL:
+           _t0 = (1.0 + 2.0) * 3.0
+       a = _t0
+
+Greedy at the *outermost* fitting subtree: if a parent op is
+eliminable, the whole subtree hoists as one unit (children are not
+separately considered).  Only when the parent isn't eliminable do
+we recurse and consider its children individually.
+
+Soundness pitfall the implementation guards against:
+
+If the hoisted subtree contains an explicit ``Round`` / ``RoundExact``
+/ ``Cast`` node whose round is *not* itself the identity, moving the
+subtree under ``with fp.REAL:`` silently turns that round into a
+no-op — changing the value of the program.  The transform therefore
+hoists only when every explicit round node inside the subtree is
+also eliminable.  In practice, eliminable round nodes are collapsed
+to their argument *at their own site* by the same pass, so a hoisted
+subtree never contains an explicit round node — the check is the
+belt-and-suspenders that documents the invariant.
+
+Run after :class:`fpy2.transform.Monomorphize` (so format inference
+resolves to concrete contexts) and before any pass that depends on
+storage selection — those see strictly tighter formats for the
+hoisted operations.
+"""
+
+import dataclasses
+import operator
+
+from typing import Any, Callable
+
+from ..analysis import (
+    ContextUse, ContextUseAnalysis, ContextUseSite, DefineUse,
+    DefineUseAnalysis, SyntaxCheck,
+)
+from ..analysis.format_infer import (
+    FormatAnalysis, FormatInfer, exact_binop, exact_unop, round_is_identity,
+)
+from ..ast.fpyast import (
+    Abs, Add, Assign, Cast, ContextStmt, Expr, ForeignVal, FuncDef, IfExpr,
+    ListComp, Mul, Neg, Round, RoundExact, Stmt, StmtBlock, Sub, UnaryOp,
+    UnderscoreId, Var,
+)
+from ..ast.visitor import DefaultTransformVisitor, DefaultVisitor
+from ..number import REAL
+from ..number.context.context import Context
+from ..utils import Gensym
+
+
+@dataclasses.dataclass
+class _Ctx:
+    """Block-walk accumulator.  Preamble ``with fp.REAL: _tN = e``
+    statements are appended here when the visitor decides to hoist
+    a subtree out of an enclosing statement's RHS expression.  The
+    enclosing statement (with its hoisted subtree replaced by a
+    ``Var`` reference) is then appended after them by
+    :meth:`_RoundElimInstance._visit_block`."""
+    stmts: list[Stmt]
+
+    @staticmethod
+    def default() -> '_Ctx':
+        return _Ctx(stmts=[])
+
+
+# Operator dispatch for the arithmetic ops we handle.  The unrounded
+# value-set of an op is computed by `exact_binop` / `exact_unop` on
+# the children's stored (post-round) bounds.
+_BINOPS: dict[type, Callable[[Any, Any], Any]] = {
+    Add: operator.add,
+    Sub: operator.sub,
+    Mul: operator.mul,
+}
+
+_UNOPS: dict[type, Callable[[Any], Any]] = {
+    Abs: abs,
+    Neg: operator.neg,
+}
+
+
+class _RoundElimInstance(DefaultTransformVisitor):
+    """Drives the rewrite.  Single-use — one instance per
+    :meth:`RoundElim.apply` call."""
+
+    func: FuncDef
+    ctx_use: ContextUseAnalysis
+    format_info: FormatAnalysis
+    gensym: Gensym
+    outer_ctx: Context | None
+
+    def __init__(
+        self,
+        func: FuncDef,
+        def_use: DefineUseAnalysis,
+        ctx_use: ContextUseAnalysis,
+        format_info: FormatAnalysis,
+    ):
+        super().__init__()
+        self.func = func
+        self.ctx_use = ctx_use
+        self.format_info = format_info
+        self.gensym = Gensym(reserved=def_use.names())
+        # Outer ctx pinning used to resolve symbolic ``with`` scopes
+        # — identical to the resolution :class:`FormatAnalysis` does
+        # internally.  Programs analyzed standalone may not have a
+        # pin, in which case symbolic scopes are unresolvable here
+        # and treated as ineligible for elimination.
+        if format_info.fn_fmt is None:
+            self.outer_ctx = None
+        else:
+            self.outer_ctx = format_info.fn_fmt.ctx
+
+    def apply(self) -> FuncDef:
+        return self._visit_function(self.func, None)
+
+    # ------------------------------------------------------------------
+    # Scope resolution + eliminability decision
+
+    def _resolved_ctx(self, e: ContextUseSite) -> Context | None:
+        """Concrete rounding context active at *e*, with symbolic
+        scopes substituted via :attr:`outer_ctx` when the caller
+        pinned one.  Returns ``None`` for scopes that remain
+        symbolic — the eliminability decision treats those as
+        ineligible (we can't claim the round is identity without
+        a concrete target).
+
+        *e* must be a :data:`ContextUseSite` (op-typed expression);
+        only op nodes have context scopes registered."""
+        try:
+            scope = self.ctx_use.find_scope_from_use(e)
+        except KeyError:
+            return None
+        if isinstance(scope.ctx, Context):
+            return scope.ctx
+        return self.outer_ctx
+
+    def _unrounded_format(self, e: Expr):
+        """Return the unrounded value-set ``F`` for a rounded op, or
+        ``None`` for ops we don't handle.  Pulls the children's
+        stored (post-round) bounds from :attr:`format_info.by_expr`
+        and applies the corresponding ``exact_binop`` / ``exact_unop``
+        primitive.  For ``Round`` / ``RoundExact`` / ``Cast``, the
+        unrounded value *is* the argument."""
+        match e:
+            case Add() | Sub() | Mul():
+                binop = _BINOPS[type(e)]
+                lhs = self.format_info.by_expr.get(e.first)
+                rhs = self.format_info.by_expr.get(e.second)
+                return exact_binop(lhs, rhs, binop)
+            case Abs() | Neg():
+                unop = _UNOPS[type(e)]
+                arg = self.format_info.by_expr.get(e.arg)
+                return exact_unop(arg, unop)
+            case Round() | RoundExact() | Cast():
+                return self.format_info.by_expr.get(e.arg)
+            case _:
+                return None
+
+    def _is_eliminable(self, e: Expr) -> bool:
+        """True when the implicit round on *e* is the identity under
+        its active scope — meaning the round produces no value
+        change and can be skipped.
+
+        Only meaningful for rounded ops (arithmetic + explicit
+        ``Round`` / ``RoundExact`` / ``Cast``); other expressions
+        don't carry a context-driven round, so the question is
+        ill-posed and the answer is ``False``."""
+        if not isinstance(
+            e, (Add, Sub, Mul, Abs, Neg, Round, RoundExact, Cast),
+        ):
+            return False
+        ctx = self._resolved_ctx(e)
+        if ctx is None or ctx is REAL:
+            # No round to eliminate (REAL is the trivial identity)
+            # or unresolvable symbolic scope.  Either way: skip.
+            return False
+        return round_is_identity(self._unrounded_format(e), ctx)
+
+    def _safe_to_hoist(self, e: Expr) -> bool:
+        """Whether *e*'s subtree can be moved under ``with fp.REAL:``
+        without changing semantics.  All explicit
+        ``Round`` / ``RoundExact`` / ``Cast`` nodes in the subtree
+        must already be eliminable at their original scope — moving
+        them under REAL would silently drop a real rounding step
+        otherwise.  In practice this is a redundant check because
+        eliminable round nodes are collapsed *at their own site* by
+        the same pass before any enclosing arithmetic op decides to
+        hoist; non-eliminable ones remain and trip the check.
+        """
+        finder = _NonEliminableRoundFinder(self._is_eliminable)
+        finder.scan(e)
+        return not finder.found
+
+    # ------------------------------------------------------------------
+    # Block walk — the ``_Ctx``-accumulator pattern from ``ZipElim``.
+
+    def _visit_block(
+        self, block: StmtBlock, ctx: Any,
+    ) -> tuple[StmtBlock, Any]:
+        block_ctx = _Ctx.default()
+        for stmt in block.stmts:
+            new_stmt, _ = self._visit_statement(stmt, block_ctx)
+            block_ctx.stmts.append(new_stmt)
+        return StmtBlock(block_ctx.stmts), ctx
+
+    # ------------------------------------------------------------------
+    # Expression rewriting
+    #
+    # The decision logic lives in ``_visit_expr``.  At each node:
+    #
+    #  - Eliminable ``Round`` / ``RoundExact`` / ``Cast`` → replace
+    #    with the (recursively-rewritten) argument.  No statement-
+    #    level hoist needed.
+    #  - Eliminable arithmetic op AND every inner round-node is also
+    #    eliminable AND we're at a statement-level expression
+    #    position (``ctx`` is a ``_Ctx``) → hoist the whole subtree
+    #    into a ``with fp.REAL: _tN = e`` preamble, return ``Var(_tN)``.
+    #  - Anything else → recurse via the base visitor (children may
+    #    still be individually eliminable).
+
+    def _visit_expr(self, e: Expr, ctx: Any) -> Expr:
+        # Round / RoundExact / Cast collapse: works regardless of
+        # ctx since it's a pure node-level rewrite (no preamble).
+        if (
+            isinstance(e, (Round, RoundExact, Cast))
+            and self._is_eliminable(e)
+        ):
+            return self._visit_expr(e.arg, ctx)
+        # Arithmetic-op hoist: only at statement-level positions
+        # where ``ctx`` carries a preamble buffer.  Comprehension
+        # element expressions and conditional branches pass a
+        # different sentinel (``None``), suppressing hoists where
+        # statement-level preambles wouldn't be sound.
+        if (
+            isinstance(ctx, _Ctx)
+            and isinstance(e, (Add, Sub, Mul, Abs, Neg))
+            and self._is_eliminable(e)
+            and self._safe_to_hoist(e)
+        ):
+            return self._hoist(e, ctx)
+        return super()._visit_expr(e, ctx)
+
+    def _hoist(self, e: Expr, ctx: _Ctx) -> Expr:
+        """Mint ``_tN``, emit ``with fp.REAL: _tN = e`` into *ctx*'s
+        preamble buffer, return ``Var(_tN)`` for the original
+        expression site.
+
+        The hoisted subtree *e* is not separately rewritten — it
+        now lives under REAL, where no round-elim applies (REAL is
+        the trivial identity, so :meth:`_is_eliminable` returns
+        False for every op inside).  Idempotence falls out of
+        that: a re-run of the transform sees only ``Var`` references
+        at the previously-hoisted sites and nothing to hoist inside
+        the REAL blocks.
+        """
+        name = self.gensym.fresh('_t')
+        assign = Assign(name, None, e, None)
+        block = StmtBlock([assign])
+        wrapped = ContextStmt(
+            UnderscoreId(), ForeignVal(REAL, None), block, None,
+        )
+        ctx.stmts.append(wrapped)
+        return Var(name, None)
+
+    # ------------------------------------------------------------------
+    # Sentinel-ctx propagation for nested expression positions where
+    # statement-level hoisting would be unsound.
+
+    def _visit_list_comp(self, e: ListComp, ctx: Any) -> ListComp:
+        # ``[elt for t in iter]``: the elt sees the loop targets,
+        # and successive iterables in multi-stage comps reference
+        # earlier targets.  Neither can be hoisted to the enclosing
+        # block — pass ``None`` to disable hoisting inside the comp.
+        # Round-node collapse still works (it doesn't need a
+        # statement-level position).
+        targets = [self._visit_binding(t, ctx) for t in e.targets]
+        iterables = [self._visit_expr(i, None) for i in e.iterables]
+        elt = self._visit_expr(e.elt, None)
+        return ListComp(targets, iterables, elt, e.loc)
+
+    def _visit_if_expr(self, e: IfExpr, ctx: Any) -> IfExpr:
+        # ``cond ? ift : iff``: the cond is evaluated unconditionally
+        # so it can carry through ``ctx``.  The branches are
+        # conditional; hoisting either of them unconditionally would
+        # change semantics under contexts that can raise.  Disable
+        # branch hoisting via ``None``.
+        cond = self._visit_expr(e.cond, ctx)
+        ift = self._visit_expr(e.ift, None)
+        iff = self._visit_expr(e.iff, None)
+        return IfExpr(cond, ift, iff, e.loc)
+
+
+class _NonEliminableRoundFinder(DefaultVisitor):
+    """Scan a subtree for an explicit ``Round`` / ``RoundExact`` /
+    ``Cast`` node whose round is *not* the identity at its original
+    scope.  Early-exits via the :attr:`found` flag — the scan stops
+    descending once any such node is hit."""
+
+    found: bool
+
+    def __init__(self, is_eliminable: Callable[[Expr], bool]):
+        super().__init__()
+        self.is_eliminable = is_eliminable
+        self.found = False
+
+    def scan(self, e: Expr) -> None:
+        self._visit_expr(e, None)
+
+    def _visit_expr(self, e: Expr, ctx: Any) -> None:
+        if self.found:
+            return
+        super()._visit_expr(e, ctx)
+
+    def _visit_round(self, e: Round | RoundExact, ctx: Any) -> None:
+        if not self.is_eliminable(e):
+            self.found = True
+            return
+        super()._visit_round(e, ctx)
+
+    def _visit_unaryop(self, e: UnaryOp, ctx: Any) -> None:
+        if isinstance(e, Cast) and not self.is_eliminable(e):
+            self.found = True
+            return
+        super()._visit_unaryop(e, ctx)
+
+
+class RoundElim:
+    """Rewrite expressions whose implicit rounding to the active
+    context is provably an identity.  Arithmetic ops
+    (``Add``/``Sub``/``Mul``/``Abs``/``Neg``) hoist into
+    ``with fp.REAL:`` preambles; explicit ``Round`` / ``RoundExact``
+    / ``Cast`` nodes collapse to their argument.
+
+    See the module docstring for the rewrite shape, the
+    greedy-outermost policy, and the soundness invariants.
+    """
+
+    @staticmethod
+    def apply(func: FuncDef) -> FuncDef:
+        """Apply the transformation to a :class:`FuncDef`.  Returns a
+        new ``FuncDef``; the input is not mutated.
+
+        Runs :class:`DefineUse`, :class:`ContextUse`, and
+        :class:`FormatInfer` internally — these are pre-analyses the
+        rewrite needs to decide eliminability per expression.
+        """
+        if not isinstance(func, FuncDef):
+            raise TypeError(f"expected a 'FuncDef', got `{func}`")
+        def_use = DefineUse.analyze(func)
+        ctx_use = ContextUse.analyze(func, def_use=def_use)
+        format_info = FormatInfer.analyze(
+            func, def_use=def_use, ctx_use=ctx_use,
+        )
+        out = _RoundElimInstance(
+            func, def_use, ctx_use, format_info,
+        ).apply()
+        SyntaxCheck.check(out, ignore_unknown=True)
+        return out

--- a/fpy2/transform/round_elim.py
+++ b/fpy2/transform/round_elim.py
@@ -48,10 +48,14 @@ and just adds a redundant alias.  This is the only case-split;
 every other operand kind is bound unconditionally for safety.
 
 Trade-off: the unconditional bind produces redundant copies for
-literals and already-clean subtrees.  ``CopyPropagate`` and
-``DeadCodeEliminate`` (both available in :mod:`fpy2.transform`)
-clean these up downstream — the local rewrite stays simple at
-the cost of slack in the intermediate AST.
+literals and already-clean subtrees.  The recommended cleanup
+chain is :class:`fpy2.transform.ConstPropagate` then
+:class:`fpy2.transform.CopyPropagate` then
+:class:`fpy2.transform.DeadCodeEliminate` — the first inlines
+literal-bound temps (``_t = 1`` → uses of ``_t`` become ``1``),
+the second collapses any remaining Var→Var copies, and the
+third removes the now-unused assigns.  The local rewrite stays
+simple at the cost of slack in the intermediate AST.
 
 Suppressed positions: hoisting needs a statement-level preamble
 slot, so it is disabled inside ``ListComp`` element / iterable
@@ -212,13 +216,26 @@ class _RoundElimInstance(DefaultTransformVisitor):
 
     def _is_eliminable(self, e: Expr) -> bool:
         """True when the implicit round on *e* is the identity under
-        its active scope — meaning the round produces no value
-        change and can be skipped.
+        its active scope AND the unrounded format is *strictly
+        tighter* than the scope's format — meaning the round
+        produces no value change *and* moving the op to REAL gives
+        downstream consumers a more precise bound than the scope
+        provides.
 
         Only meaningful for rounded ops (arithmetic + explicit
         ``Round`` / ``RoundExact`` / ``Cast``); other expressions
         don't carry a context-driven round, so the question is
-        ill-posed and the answer is ``False``."""
+        ill-posed and the answer is ``False``.
+
+        The "strictly tighter" guard is the subtle one: under an
+        unbounded scope (e.g. ``fp.INTEGER`` / ``MPFixedContext``),
+        ``round_is_identity`` is vacuously true for any value, but
+        the unrounded format is *also* unbounded — hoisting yields
+        no narrowing and can break downstream consumers whose
+        storage selection can't pick a finite type for a saturated
+        format (e.g. the cpp emitter's lossless-widening dispatch).
+        Skipping these saves both pointless rewrites and the
+        cascading storage failures."""
         if not isinstance(
             e, (Add, Sub, Mul, Abs, Neg, Round, RoundExact, Cast),
         ):
@@ -228,7 +245,26 @@ class _RoundElimInstance(DefaultTransformVisitor):
             # No round to eliminate (REAL is the trivial identity)
             # or unresolvable symbolic scope.  Either way: skip.
             return False
-        return round_is_identity(self._unrounded_format(e), ctx)
+        unrounded = self._unrounded_format(e)
+        if not round_is_identity(unrounded, ctx):
+            return False
+        # Strictly-tighter guard.
+        if isinstance(unrounded, SetFormat):
+            # SetFormat is always a strict refinement over any Format
+            # — a finite value-set vs. a continuous range.  Always
+            # worth hoisting.
+            return True
+        # AbstractFormat case: tighter iff strictly contained in the
+        # scope's lifted AF.  Both equal → no benefit, skip.
+        scope_fmt = ctx.format()
+        if not isinstance(scope_fmt, AbstractableFormat):
+            # Scope isn't lifted-comparable; conservative skip.
+            return False
+        scope_af = AbstractFormat.from_format(scope_fmt)
+        # ``a < b`` ≡ ``a <= b and a != b`` for AbstractFormat
+        # (uses ``__le__`` for the subset check and ``__eq__`` for
+        # parameter-shape equality).
+        return unrounded <= scope_af and unrounded != scope_af
 
     # ------------------------------------------------------------------
     # Block walk — the ``_Ctx``-accumulator pattern from ``ZipElim``.
@@ -329,11 +365,12 @@ class _RoundElimInstance(DefaultTransformVisitor):
 
         Trade-off: the unconditional bind produces redundant
         ``_t = literal`` lines and per-op REAL blocks for nested
-        eliminations.  :class:`fpy2.transform.CopyPropagate` and
-        :class:`fpy2.transform.DeadCodeEliminate` (both in
-        :mod:`fpy2.transform`) clean these up downstream — the
-        local rewrite stays simple at the cost of slack in the
-        intermediate AST.
+        eliminations.  The recommended cleanup chain —
+        :class:`fpy2.transform.ConstPropagate` then
+        :class:`fpy2.transform.CopyPropagate` then
+        :class:`fpy2.transform.DeadCodeEliminate` — collapses
+        them; the local rewrite stays simple at the cost of slack
+        in the intermediate AST.
         """
         new_operands: list[Expr] = []
         for operand in self._operands(e):

--- a/fpy2/transform/round_elim.py
+++ b/fpy2/transform/round_elim.py
@@ -2,50 +2,64 @@
 Eliminate unnecessary rounding from expressions whose unrounded
 format is contained in the active rounding context.
 
-For a rounded arithmetic op ``f(x_1, ..., x_n)`` (``Add``, ``Sub``,
+For a rounded arithmetic op ``g(e_1, ..., e_n)`` (``Add``, ``Sub``,
 ``Mul``, ``Abs``, ``Neg``) under active context ``C``, the runtime
 semantics insert an implicit ``round_C`` around the result.  When
-format inference proves ``format(f(...)) ⊆ C.F``, that round is the
+format inference proves ``format(g(...)) ⊆ C.F``, that round is the
 identity — the value is unchanged whether or not it fires.  This
-transform makes that fact structural by hoisting the operation into
-a ``with fp.REAL:`` preamble, binding it to a fresh name, and
-threading the name back into the original expression site.
+transform makes that fact structural by computing ``g`` under
+``with fp.REAL:`` and binding the result to a fresh name that
+replaces the original expression site.
 
 For explicit ``Round`` / ``RoundExact`` / ``Cast`` nodes, the same
 notion produces a different rewrite: when the argument's bound
 already fits in the target context, the whole node collapses to
 its argument (the round was a no-op at runtime).
 
-Rewrite shape:
+Rewrite shape — per-op hoisting with unconditional operand binding:
 
 .. code-block:: python
 
    # Before
    with fp.FP64:
-       a = (1.0 + 2.0) * 3.0    # whole RHS fits FP64 exactly
+       a = g(e_1, ..., e_n)     # g's round is identity
 
    # After
    with fp.FP64:
+       t_1 = e_1                # original-context evaluation
+       ...
+       t_n = e_n                # of each operand
        with fp.REAL:
-           _t0 = (1.0 + 2.0) * 3.0
-       a = _t0
+           _t = g(t_1, ..., t_n)
+       a = _t
 
-Greedy at the *outermost* fitting subtree: if a parent op is
-eliminable, the whole subtree hoists as one unit (children are not
-separately considered).  Only when the parent isn't eliminable do
-we recurse and consider its children individually.
+Each operand is bound to a temp under the *current* context
+before being passed into the REAL block.  The bind preserves
+every round inside the operand at its original scope — explicit
+``Round`` / ``Cast`` nodes, implicit rounds on nested arithmetic
+ops, eliminable or non-eliminable, all fire as originally
+written.  The REAL block then consumes only ``Var`` references,
+so it can never accidentally re-evaluate a subexpression at the
+wrong context.
 
-Soundness pitfall the implementation guards against:
+Operands that are already ``Var`` references are passed through
+without binding — a copy ``_t = v`` has no rounds to preserve
+and just adds a redundant alias.  This is the only case-split;
+every other operand kind is bound unconditionally for safety.
 
-If the hoisted subtree contains an explicit ``Round`` / ``RoundExact``
-/ ``Cast`` node whose round is *not* itself the identity, moving the
-subtree under ``with fp.REAL:`` silently turns that round into a
-no-op — changing the value of the program.  The transform therefore
-hoists only when every explicit round node inside the subtree is
-also eliminable.  In practice, eliminable round nodes are collapsed
-to their argument *at their own site* by the same pass, so a hoisted
-subtree never contains an explicit round node — the check is the
-belt-and-suspenders that documents the invariant.
+Trade-off: the unconditional bind produces redundant copies for
+literals and already-clean subtrees.  ``CopyPropagate`` and
+``DeadCodeEliminate`` (both available in :mod:`fpy2.transform`)
+clean these up downstream — the local rewrite stays simple at
+the cost of slack in the intermediate AST.
+
+Suppressed positions: hoisting needs a statement-level preamble
+slot, so it is disabled inside ``ListComp`` element / iterable
+expressions and inside ``IfExpr`` branches (the latter would
+evaluate operands unconditionally, changing exception semantics
+under contexts that can raise).  ``Round`` / ``Cast`` collapse
+still applies inside these positions — it's a pure node-level
+rewrite that needs no preamble slot.
 
 Run after :class:`fpy2.transform.Monomorphize` (so format inference
 resolves to concrete contexts) and before any pass that depends on
@@ -63,14 +77,15 @@ from ..analysis import (
     DefineUseAnalysis, SyntaxCheck,
 )
 from ..analysis.format_infer import (
-    FormatAnalysis, FormatInfer, exact_binop, exact_unop, round_is_identity,
+    AbstractFormat, AbstractableFormat, FormatAnalysis, FormatInfer, SetFormat,
+    exact_binop, exact_unop, round_is_identity,
 )
 from ..ast.fpyast import (
     Abs, Add, Assign, Cast, ContextStmt, Expr, ForeignVal, FuncDef, IfExpr,
-    ListComp, Mul, Neg, Round, RoundExact, Stmt, StmtBlock, Sub, UnaryOp,
+    ListComp, Mul, Neg, Round, RoundExact, Stmt, StmtBlock, Sub,
     UnderscoreId, Var,
 )
-from ..ast.visitor import DefaultTransformVisitor, DefaultVisitor
+from ..ast.visitor import DefaultTransformVisitor
 from ..number import REAL
 from ..number.context.context import Context
 from ..utils import Gensym
@@ -180,7 +195,18 @@ class _RoundElimInstance(DefaultTransformVisitor):
                 arg = self.format_info.by_expr.get(e.arg)
                 return exact_unop(arg, unop)
             case Round() | RoundExact() | Cast():
-                return self.format_info.by_expr.get(e.arg)
+                # The unrounded "value" of an explicit round node is
+                # the argument itself.  Stored bounds may be a
+                # ``Format`` (e.g., ``IEEEFormat`` when the arg's
+                # post-round bound widened to the scope's format);
+                # lift to ``AbstractFormat`` so the result fits
+                # ``round_is_identity``'s expected input shape.
+                arg_fmt = self.format_info.by_expr.get(e.arg)
+                if isinstance(arg_fmt, SetFormat):
+                    return arg_fmt
+                if isinstance(arg_fmt, AbstractableFormat):
+                    return AbstractFormat.from_format(arg_fmt)
+                return None
             case _:
                 return None
 
@@ -204,21 +230,6 @@ class _RoundElimInstance(DefaultTransformVisitor):
             return False
         return round_is_identity(self._unrounded_format(e), ctx)
 
-    def _safe_to_hoist(self, e: Expr) -> bool:
-        """Whether *e*'s subtree can be moved under ``with fp.REAL:``
-        without changing semantics.  All explicit
-        ``Round`` / ``RoundExact`` / ``Cast`` nodes in the subtree
-        must already be eliminable at their original scope — moving
-        them under REAL would silently drop a real rounding step
-        otherwise.  In practice this is a redundant check because
-        eliminable round nodes are collapsed *at their own site* by
-        the same pass before any enclosing arithmetic op decides to
-        hoist; non-eliminable ones remain and trip the check.
-        """
-        finder = _NonEliminableRoundFinder(self._is_eliminable)
-        finder.scan(e)
-        return not finder.found
-
     # ------------------------------------------------------------------
     # Block walk — the ``_Ctx``-accumulator pattern from ``ZipElim``.
 
@@ -237,12 +248,12 @@ class _RoundElimInstance(DefaultTransformVisitor):
     # The decision logic lives in ``_visit_expr``.  At each node:
     #
     #  - Eliminable ``Round`` / ``RoundExact`` / ``Cast`` → replace
-    #    with the (recursively-rewritten) argument.  No statement-
-    #    level hoist needed.
-    #  - Eliminable arithmetic op AND every inner round-node is also
-    #    eliminable AND we're at a statement-level expression
-    #    position (``ctx`` is a ``_Ctx``) → hoist the whole subtree
-    #    into a ``with fp.REAL: _tN = e`` preamble, return ``Var(_tN)``.
+    #    with the (recursively-rewritten) argument.  Pure node-level
+    #    rewrite, no preamble required, works at any expression
+    #    position (including inside ListComp / IfExpr branches).
+    #  - Eliminable arithmetic op AND we're at a statement-level
+    #    expression position (``ctx`` is a ``_Ctx``) → per-op hoist
+    #    (see :meth:`_hoist`).
     #  - Anything else → recurse via the base visitor (children may
     #    still be individually eliminable).
 
@@ -263,32 +274,92 @@ class _RoundElimInstance(DefaultTransformVisitor):
             isinstance(ctx, _Ctx)
             and isinstance(e, (Add, Sub, Mul, Abs, Neg))
             and self._is_eliminable(e)
-            and self._safe_to_hoist(e)
         ):
             return self._hoist(e, ctx)
         return super()._visit_expr(e, ctx)
 
-    def _hoist(self, e: Expr, ctx: _Ctx) -> Expr:
-        """Mint ``_tN``, emit ``with fp.REAL: _tN = e`` into *ctx*'s
-        preamble buffer, return ``Var(_tN)`` for the original
-        expression site.
+    def _operands(self, e: Expr) -> list[Expr]:
+        """Return *e*'s direct operands (left-to-right) for the
+        rounded ops the hoist handles.  Used to enumerate the
+        positions :meth:`_hoist` may need to bind to temps."""
+        match e:
+            case Add() | Sub() | Mul():
+                return [e.first, e.second]
+            case Abs() | Neg():
+                return [e.arg]
+            case _:
+                raise RuntimeError(
+                    f'_operands called on non-rounded-arithmetic op: {e!r}'
+                )
 
-        The hoisted subtree *e* is not separately rewritten — it
-        now lives under REAL, where no round-elim applies (REAL is
-        the trivial identity, so :meth:`_is_eliminable` returns
-        False for every op inside).  Idempotence falls out of
-        that: a re-run of the transform sees only ``Var`` references
-        at the previously-hoisted sites and nothing to hoist inside
-        the REAL blocks.
+    def _rebuild(self, e: Expr, operands: list[Expr]) -> Expr:
+        """Reconstruct an arithmetic op *e* with new *operands*.
+        Mirrors the inverse of :meth:`_operands`."""
+        match e:
+            case Add() | Sub() | Mul():
+                return type(e)(operands[0], operands[1], e.loc)
+            case Abs() | Neg():
+                return type(e)(operands[0], e.loc)
+            case _:
+                raise RuntimeError(
+                    f'_rebuild called on non-rounded-arithmetic op: {e!r}'
+                )
+
+    def _hoist(self, e: Expr, ctx: _Ctx) -> Expr:
+        """Per-op hoist: compute *e* under ``with fp.REAL:`` and
+        return ``Var(_tN)`` for the original expression site.
+
+        Each operand is visited with the same *ctx* so nested
+        eliminable ops hoist at their own level — the result is a
+        ``Var`` that we can plug directly into our reconstructed
+        op.  Operands that survive the visit as non-``Var``
+        expressions (literals, non-eliminable ops, ``Round`` nodes
+        that weren't collapsed) are bound to a temp under the
+        *current* context before being passed into the REAL block.
+        The bind preserves every round inside the operand at its
+        original scope: explicit ``Round`` / ``Cast`` nodes,
+        implicit rounds on non-eliminable arithmetic, all fire as
+        originally written.
+
+        The REAL block consumes only ``Var`` references — it can
+        never accidentally re-evaluate a subexpression at the wrong
+        context.  Idempotence falls out: a second pass sees only
+        ``Var``-argumented ops under REAL (and bare assigns under
+        the original context), none of which trigger another hoist.
+
+        Trade-off: the unconditional bind produces redundant
+        ``_t = literal`` lines and per-op REAL blocks for nested
+        eliminations.  :class:`fpy2.transform.CopyPropagate` and
+        :class:`fpy2.transform.DeadCodeEliminate` (both in
+        :mod:`fpy2.transform`) clean these up downstream — the
+        local rewrite stays simple at the cost of slack in the
+        intermediate AST.
         """
-        name = self.gensym.fresh('_t')
-        assign = Assign(name, None, e, None)
-        block = StmtBlock([assign])
+        new_operands: list[Expr] = []
+        for operand in self._operands(e):
+            new_operand = self._visit_expr(operand, ctx)
+            if isinstance(new_operand, Var):
+                # Bind would be a pure copy — no rounds to preserve
+                # inside a name lookup.  Use the ``Var`` directly.
+                new_operands.append(new_operand)
+                continue
+            # Bind under the current context.  Anything not a
+            # ``Var`` is conservatively assumed to contain a round
+            # (literal, non-eliminable op, ``Round`` node, …);
+            # binding fires those rounds at their original scope
+            # before the REAL block sees the value.
+            t_op = self.gensym.fresh('_t')
+            ctx.stmts.append(Assign(t_op, None, new_operand, None))
+            new_operands.append(Var(t_op, None))
+
+        rebuilt = self._rebuild(e, new_operands)
+        result_name = self.gensym.fresh('_t')
+        block = StmtBlock([Assign(result_name, None, rebuilt, None)])
         wrapped = ContextStmt(
             UnderscoreId(), ForeignVal(REAL, None), block, None,
         )
         ctx.stmts.append(wrapped)
-        return Var(name, None)
+        return Var(result_name, None)
 
     # ------------------------------------------------------------------
     # Sentinel-ctx propagation for nested expression positions where
@@ -317,39 +388,6 @@ class _RoundElimInstance(DefaultTransformVisitor):
         iff = self._visit_expr(e.iff, None)
         return IfExpr(cond, ift, iff, e.loc)
 
-
-class _NonEliminableRoundFinder(DefaultVisitor):
-    """Scan a subtree for an explicit ``Round`` / ``RoundExact`` /
-    ``Cast`` node whose round is *not* the identity at its original
-    scope.  Early-exits via the :attr:`found` flag — the scan stops
-    descending once any such node is hit."""
-
-    found: bool
-
-    def __init__(self, is_eliminable: Callable[[Expr], bool]):
-        super().__init__()
-        self.is_eliminable = is_eliminable
-        self.found = False
-
-    def scan(self, e: Expr) -> None:
-        self._visit_expr(e, None)
-
-    def _visit_expr(self, e: Expr, ctx: Any) -> None:
-        if self.found:
-            return
-        super()._visit_expr(e, ctx)
-
-    def _visit_round(self, e: Round | RoundExact, ctx: Any) -> None:
-        if not self.is_eliminable(e):
-            self.found = True
-            return
-        super()._visit_round(e, ctx)
-
-    def _visit_unaryop(self, e: UnaryOp, ctx: Any) -> None:
-        if isinstance(e, Cast) and not self.is_eliminable(e):
-            self.found = True
-            return
-        super()._visit_unaryop(e, ctx)
 
 
 class RoundElim:

--- a/fpy2/transform/round_elim.py
+++ b/fpy2/transform/round_elim.py
@@ -74,7 +74,7 @@ hoisted operations.
 import dataclasses
 import operator
 
-from typing import Any, Callable
+from typing import Any
 
 from ..analysis import (
     ContextUse, ContextUseAnalysis, ContextUseSite, DefineUse,
@@ -109,20 +109,6 @@ class _Ctx:
     def default() -> '_Ctx':
         return _Ctx(stmts=[])
 
-
-# Operator dispatch for the arithmetic ops we handle.  The unrounded
-# value-set of an op is computed by `exact_binop` / `exact_unop` on
-# the children's stored (post-round) bounds.
-_BINOPS: dict[type, Callable[[Any, Any], Any]] = {
-    Add: operator.add,
-    Sub: operator.sub,
-    Mul: operator.mul,
-}
-
-_UNOPS: dict[type, Callable[[Any], Any]] = {
-    Abs: abs,
-    Neg: operator.neg,
-}
 
 
 class _RoundElimInstance(DefaultTransformVisitor):
@@ -171,12 +157,14 @@ class _RoundElimInstance(DefaultTransformVisitor):
         ineligible (we can't claim the round is identity without
         a concrete target).
 
-        *e* must be a :data:`ContextUseSite` (op-typed expression);
-        only op nodes have context scopes registered."""
-        try:
-            scope = self.ctx_use.find_scope_from_use(e)
-        except KeyError:
-            return None
+        *e* must be a :data:`ContextUseSite` (op-typed expression)
+        that's been seen by :class:`ContextUseAnalysis`.  We don't
+        catch ``KeyError`` here: a node that should have a scope
+        but doesn't indicates a bug elsewhere (the node was
+        constructed without going through scope analysis), and
+        failing loudly is more useful than silently treating it
+        as ineligible."""
+        scope = self.ctx_use.find_scope_from_use(e)
         if isinstance(scope.ctx, Context):
             return scope.ctx
         return self.outer_ctx
@@ -189,21 +177,44 @@ class _RoundElimInstance(DefaultTransformVisitor):
         primitive.  For ``Round`` / ``RoundExact`` / ``Cast``, the
         unrounded value *is* the argument."""
         match e:
-            case Add() | Sub() | Mul():
-                binop = _BINOPS[type(e)]
-                lhs = self.format_info.by_expr.get(e.first)
-                rhs = self.format_info.by_expr.get(e.second)
-                return exact_binop(lhs, rhs, binop)
-            case Abs() | Neg():
-                unop = _UNOPS[type(e)]
-                arg = self.format_info.by_expr.get(e.arg)
-                return exact_unop(arg, unop)
+            case Add():
+                return exact_binop(
+                    self.format_info.by_expr.get(e.first),
+                    self.format_info.by_expr.get(e.second),
+                    operator.add,
+                )
+            case Sub():
+                return exact_binop(
+                    self.format_info.by_expr.get(e.first),
+                    self.format_info.by_expr.get(e.second),
+                    operator.sub,
+                )
+            case Mul():
+                return exact_binop(
+                    self.format_info.by_expr.get(e.first),
+                    self.format_info.by_expr.get(e.second),
+                    operator.mul,
+                )
+            case Abs():
+                return exact_unop(
+                    self.format_info.by_expr.get(e.arg), abs,
+                )
+            case Neg():
+                return exact_unop(
+                    self.format_info.by_expr.get(e.arg), operator.neg,
+                )
             case Round() | RoundExact() | Cast():
                 # The unrounded "value" of an explicit round node is
-                # the argument itself.  Stored bounds may be a
-                # ``Format`` (e.g., ``IEEEFormat`` when the arg's
-                # post-round bound widened to the scope's format);
-                # lift to ``AbstractFormat`` so the result fits
+                # the argument itself — the argument's post-round
+                # bound is the right input here because the explicit
+                # Round operates on whatever the arg evaluates to.
+                # ``round_is_identity(arg's bound, this Round's
+                # target ctx)`` then answers exactly "is this Round
+                # the identity over the value the arg produces?".
+                # Stored bounds may be a ``Format`` (e.g.,
+                # ``IEEEFormat`` when the arg's post-round bound
+                # widened to the scope's format); lift to
+                # ``AbstractFormat`` so the result fits
                 # ``round_is_identity``'s expected input shape.
                 arg_fmt = self.format_info.by_expr.get(e.arg)
                 if isinstance(arg_fmt, SetFormat):
@@ -372,6 +383,10 @@ class _RoundElimInstance(DefaultTransformVisitor):
         them; the local rewrite stays simple at the cost of slack
         in the intermediate AST.
         """
+        # Inherit *e*'s location for hoist-introduced nodes so
+        # downstream errors that reference the temps point back at
+        # the original source position.
+        loc = e.loc
         new_operands: list[Expr] = []
         for operand in self._operands(e):
             new_operand = self._visit_expr(operand, ctx)
@@ -386,17 +401,17 @@ class _RoundElimInstance(DefaultTransformVisitor):
             # binding fires those rounds at their original scope
             # before the REAL block sees the value.
             t_op = self.gensym.fresh('_t')
-            ctx.stmts.append(Assign(t_op, None, new_operand, None))
-            new_operands.append(Var(t_op, None))
+            ctx.stmts.append(Assign(t_op, None, new_operand, loc))
+            new_operands.append(Var(t_op, loc))
 
         rebuilt = self._rebuild(e, new_operands)
         result_name = self.gensym.fresh('_t')
-        block = StmtBlock([Assign(result_name, None, rebuilt, None)])
+        block = StmtBlock([Assign(result_name, None, rebuilt, loc)])
         wrapped = ContextStmt(
-            UnderscoreId(), ForeignVal(REAL, None), block, None,
+            UnderscoreId(), ForeignVal(REAL, loc), block, loc,
         )
         ctx.stmts.append(wrapped)
-        return Var(result_name, None)
+        return Var(result_name, loc)
 
     # ------------------------------------------------------------------
     # Sentinel-ctx propagation for nested expression positions where

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1145,14 +1145,31 @@ class TestFormatInfer:
             f'got {block_acc_bounds}'
         )
 
-        # 2. acc must reach FP32 — every write is inside ``with fp.FP32``,
-        #    so the FP32 round dominates regardless of the outer loop's
-        #    symbolic iteration count.
+        # 2. acc must reach a bound contained in FP32 — every write is
+        #    inside ``with fp.FP32``, so the FP32 round dominates
+        #    regardless of the outer loop's symbolic iteration count.
+        #    Note: the analysis may return a *strict subset* of FP32
+        #    (e.g., narrower subnormal range) when it can prove the
+        #    accumulated magnitudes never reach FP32's full range —
+        #    this is sound (image of the rounded result is contained
+        #    in FP32) and strictly more precise than widening to FP32.
+        from fpy2.analysis.format_infer.format import (
+            AbstractFormat,
+            AbstractableFormat,
+        )
+        fp32_af = AbstractFormat.from_format(fp.FP32.format())
         acc_bounds = [
             b for d, b in info.by_def.items() if d.name.base == 'acc'
         ]
-        assert fp.FP32.format() in acc_bounds, (
-            f'expected FP32 among acc bounds, got {acc_bounds}'
+        def _contained_in_fp32(b):
+            if b == fp.FP32.format():
+                return True
+            if isinstance(b, AbstractableFormat):
+                return AbstractFormat.from_format(b) <= fp32_af
+            return False
+        assert any(_contained_in_fp32(b) for b in acc_bounds), (
+            f'expected acc to reach a Format contained in FP32, '
+            f'got {acc_bounds}'
         )
 
         # 3. ys is the rounded list — its element format is MX_E4M3.

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -522,15 +522,21 @@ class TestFormatInfer:
     def test_loop_widens_to_real_format(self):
         """
         A loop whose body applies exact arithmetic to a phi'd value would
-        produce an infinite ascending chain of AbstractFormats (each
-        iteration widens prec/bounds).  After ``loop_iter_limit`` iterations
-        the analysis switches to widen-mode joins so the fixpoint terminates
-        at ``REAL_FORMAT``.
+        produce an infinite ascending chain of bounds (each iteration
+        adds fresh values to a ``SetFormat`` or widens the
+        ``AbstractFormat`` prec/bounds).  After ``loop_iter_limit``
+        iterations the analysis switches to widen-mode joins so the
+        fixpoint terminates at ``REAL_FORMAT``.
+
+        Probe: ``x`` starts at the non-zero constant ``1`` and doubles
+        each iteration.  The natural ``SetFormat`` join over the
+        per-iteration values grows without bound — widening must kick
+        in to break the chain.
         """
         @fp.fpy
         def f(n: fp.Real) -> fp.Real:
             with fp.FP32:
-                x = fp.round(0)
+                x = fp.round(1)
             while n > 0:
                 with fp.REAL:
                     x = x + x
@@ -603,17 +609,18 @@ class TestFormatInfer:
         nested ``while``/``for``.
 
         The probe: an outer ``while`` whose body diverges (``x = x + x``
-        under REAL) and contains an inner ``while`` whose body merges two
-        Formats that would normally produce a precise containing Format.
-        With a small outer limit, the outer enters widen-mode quickly;
-        because that state propagates inward, the inner loop's phi must
-        also widen to ``REAL_FORMAT`` rather than producing the
-        AbstractFormat-mediated join.
+        under REAL starting from a non-zero constant) and contains an
+        inner ``while`` whose body merges two distinct constants that
+        would normally produce a stable ``SetFormat``.  With a small
+        outer limit, the outer enters widen-mode quickly; because that
+        state propagates inward, the inner loop's phi must also widen
+        to ``REAL_FORMAT`` rather than settling on the precise
+        ``SetFormat`` join.
         """
         @fp.fpy
         def f(n: fp.Real, m: fp.Real, c: bool) -> fp.Real:
             with fp.FP32:
-                x = fp.round(0)
+                x = fp.round(1)
                 z = fp.round(0)
             while n > 0:
                 with fp.REAL:
@@ -621,10 +628,10 @@ class TestFormatInfer:
                 while m > 0:
                     if c:
                         with fp.FP32:
-                            z = fp.round(0)
+                            z = fp.round(1)
                     else:
                         with fp.FP64:
-                            z = fp.round(0)
+                            z = fp.round(2)
             return x + z
 
         # outer limit small → outer widens, propagates to inner.
@@ -858,11 +865,17 @@ class TestFormatInfer:
         mx_e4m3 = fp.MX_E4M3.format()
         assert sums[-1].representable_in(mx_e4m3.maxval()._real)
 
-    def test_sum_under_concrete_ctx_returns_scope_format(self):
+    def test_sum_under_concrete_ctx_tightens_when_fits(self):
         """
-        Under a concrete non-REAL context, every pairwise add rounds to
-        the scope's format, so ``sum(ys)`` reports the scope's format
-        (the default ``_op_bound`` rule).
+        Under a concrete non-REAL scope, ``sum(ys)`` reports a tight
+        format whenever the simulated unrounded accumulator is
+        contained in the scope's format — every per-step ``round_C``
+        is then the identity, so the precise format is sound.
+
+        Here the four MX_E4M3 elements summed produce a format with
+        precision and range comfortably inside FP32, so the analysis
+        is free to report the tight bound rather than widening to
+        FP32 itself.
         """
         @fp.fpy
         def f() -> fp.Real:
@@ -874,8 +887,23 @@ class TestFormatInfer:
 
         info = self._run(f)
         sums = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Sum']
-        assert sums and sums[-1] == fp.FP32.format(), (
-            f'expected Sum to report FP32 (scope format), got {sums}'
+        assert sums, 'expected at least one Sum bound'
+        bound = sums[-1]
+        # Tightening fired: the bound is strictly narrower than FP32.
+        assert bound != fp.FP32.format(), (
+            f'expected tight bound narrower than FP32, got the scope format'
+        )
+        # Soundness: the tight bound is contained in FP32 — every
+        # value representable under *bound* is also representable
+        # under FP32, so the implicit round-to-FP32 is the identity.
+        from fpy2.analysis.format_infer.format import (
+            AbstractFormat, AbstractableFormat,
+        )
+        assert isinstance(bound, AbstractableFormat), (
+            f'expected an abstractable format, got {bound!r}'
+        )
+        assert AbstractFormat.from_format(bound) <= AbstractFormat.from_format(
+            fp.FP32.format()
         )
 
     def test_sum_unknown_size_falls_back(self):

--- a/tests/unit/backend/cpp/test_emit_context.py
+++ b/tests/unit/backend/cpp/test_emit_context.py
@@ -10,6 +10,14 @@ For float contexts the rounding mode must be one of the four
 ``fesetround``-supported modes (RNE / RTZ / RTP / RTN).  For integer
 contexts the rounding mode must be RTZ — C++ integer arithmetic
 already truncates toward zero, so no runtime support is needed.
+
+Tests in this module assert specific bare-emitter output and the
+rejection-mechanism behavior — both surfaces that optimizing
+transforms can legally rewrite around.  Each ``CppCompiler``
+construction passes ``optimize=False`` to keep the assertions
+stable against transforms like :class:`fpy2.transform.RoundElim`
+that would otherwise reshape the generated C++ or sidestep
+rejection paths.
 """
 
 import fpy2 as fp

--- a/tests/unit/backend/cpp/test_emit_context.py
+++ b/tests/unit/backend/cpp/test_emit_context.py
@@ -38,7 +38,7 @@ class TestStaticResolution:
         def f() -> bool:
             return True
 
-        out = CppCompiler().compile(f)
+        out = CppCompiler(optimize=False).compile(f)
         assert 'fesetround' not in out
 
     def test_concrete_with_block_resolves(self):
@@ -47,7 +47,7 @@ class TestStaticResolution:
             with fp.FP64:
                 return x + y
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, ctx=fp.FP64,
             arg_types=[RealType(fp.FP64), RealType(fp.FP64)],
         )
@@ -67,7 +67,7 @@ class TestStaticResolution:
                 return x + x               # is inside ``with fp.FP64:``.
 
         # No error: compilation succeeds.
-        out = CppCompiler().compile(f, arg_types=[RealType(fp.FP64)])
+        out = CppCompiler(optimize=False).compile(f, arg_types=[RealType(fp.FP64)])
         assert 'return (x + x);' in out
 
     def test_with_block_scope_unused_compiles(self):
@@ -83,7 +83,7 @@ class TestStaticResolution:
                 return xs[n]               # under the outer scope.
 
         from fpy2.types import ListType
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64))],
         )
@@ -100,7 +100,7 @@ class TestDefaultRmIsImplicit:
             with fp.FP64:
                 return x + y
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, ctx=fp.FP64,
             arg_types=[RealType(fp.FP64), RealType(fp.FP64)],
         )
@@ -141,7 +141,7 @@ class TestNonDefaultRmEmitsFesetround:
         def f(x: fp.Real, y: fp.Real) -> fp.Real:
             return x + y
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, arg_types=[RealType(fp.FP64), RealType(fp.FP64)],
         )
         assert 'fesetround' not in out
@@ -158,7 +158,7 @@ class TestNonDefaultRmEmitsFesetround:
                 b = a + 1
             return a + b
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, arg_types=[RealType(fp.FP64), RealType(fp.FP64)],
         )
         # Inner switches RTZ→RNE — one save / set / restore pair.
@@ -177,7 +177,7 @@ class TestNonDefaultRmEmitsFesetround:
             with _RTZ_64:
                 return x + y
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, arg_types=[RealType(fp.FP64), RealType(fp.FP64)],
         )
         # No fesetround anywhere — caller is contracted to deliver
@@ -199,7 +199,7 @@ class TestNonDefaultRmEmitsFesetround:
                 return xs[0] + xs[1]
 
         from fpy2.types import ListType
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, arg_types=[ListType(RealType(fp.FP64))],
         )
         # Inner RTZ block must emit fesetround — outer is unknown.
@@ -223,12 +223,20 @@ class TestRejection:
             CppCompileError,
             match='not supported by ``fesetround``',
         ):
-            CppCompiler().compile(
+            CppCompiler(optimize=False).compile(
                 f, arg_types=[RealType(fp.FP64), RealType(fp.FP64)],
             )
 
     def test_integer_non_rtz_rejected(self):
-        """Integer contexts must use RTZ."""
+        """Integer contexts must use RTZ.
+
+        Pinned with ``optimize=False`` — ``RoundElim`` would
+        otherwise hoist the integer-add out of the bad-RM scope
+        (the unrounded sum of two ints is an int and fits the
+        scope, so the round is identity), sidestepping the
+        rejection.  The rejection mechanism is what this test
+        exercises, so we keep it visible by opting out of
+        optimization."""
 
         bad_int = fp.MPFixedContext(-1, fp.RM.RNE)
 
@@ -240,7 +248,9 @@ class TestRejection:
             CppCompileError,
             match='must use RTZ rounding mode',
         ):
-            CppCompiler(unsafe_cast_int=True).compile(
+            CppCompiler(
+                unsafe_cast_int=True, optimize=False,
+            ).compile(
                 f, arg_types=[RealType(bad_int), RealType(bad_int)],
             )
 
@@ -250,7 +260,12 @@ class TestRejection:
         arbitrary-precision integer type, so any such rounding
         silently truncates to ``int64_t``.  The default
         (``unsafe_cast_int=True``) allows it; this test pins the
-        opt-out path."""
+        opt-out path.
+
+        Pinned with ``optimize=False`` for the same reason as
+        :meth:`test_integer_non_rtz_rejected` — ``RoundElim``
+        would otherwise eliminate the (identity) integer round
+        and sidestep the rejection."""
 
         @fp.fpy(ctx=fp.INTEGER)
         def f(x: fp.Real, y: fp.Real) -> fp.Real:
@@ -260,7 +275,9 @@ class TestRejection:
             CppCompileError,
             match=r'unbounded integer context.*unsafe_cast_int',
         ):
-            CppCompiler(unsafe_cast_int=False).compile(
+            CppCompiler(
+                unsafe_cast_int=False, optimize=False,
+            ).compile(
                 f, arg_types=[RealType(fp.INTEGER), RealType(fp.INTEGER)],
             )
 
@@ -272,7 +289,7 @@ class TestRejection:
         def f(x: fp.Real, y: fp.Real) -> fp.Real:
             return x + y
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, arg_types=[RealType(fp.INTEGER), RealType(fp.INTEGER)],
         )
         assert 'int64_t f(int64_t x, int64_t y)' in out
@@ -299,7 +316,7 @@ class TestRealScopeLosslessWidening:
             with fp.REAL:
                 return xq * yq
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, ctx=fp.FP64,
             arg_types=[RealType(fp.FP32), RealType(fp.FP32)],
         )
@@ -321,7 +338,7 @@ class TestRealScopeLosslessWidening:
             with fp.REAL:
                 return xq + yq
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, ctx=fp.FP64,
             arg_types=[RealType(fp.FP32), RealType(fp.FP32)],
         )
@@ -342,7 +359,7 @@ class TestRealScopeLosslessWidening:
             CppCompileError,
             match='no storage type on the ladder contains',
         ):
-            CppCompiler().compile(
+            CppCompiler(optimize=False).compile(
                 f, ctx=fp.FP64,
                 arg_types=[RealType(fp.FP64), RealType(fp.FP64)],
             )
@@ -363,7 +380,7 @@ class TestRealScopeLosslessWidening:
             CppCompileError,
             match='cannot store an unconstrained real value',
         ):
-            CppCompiler().compile(
+            CppCompiler(optimize=False).compile(
                 f, ctx=fp.FP64,
                 arg_types=[RealType(fp.FP32), RealType(fp.FP32)],
             )

--- a/tests/unit/backend/cpp/test_emit_if.py
+++ b/tests/unit/backend/cpp/test_emit_if.py
@@ -1,5 +1,9 @@
 """
 Phase 3c tests for the cpp emitter — ``if`` / ``if1`` statements.
+
+Each ``CppCompiler`` construction passes ``optimize=False`` to
+keep the bare-emitter output strings stable against optimizing
+transforms (notably :class:`fpy2.transform.RoundElim`).
 """
 
 import fpy2 as fp

--- a/tests/unit/backend/cpp/test_emit_if.py
+++ b/tests/unit/backend/cpp/test_emit_if.py
@@ -29,7 +29,7 @@ class TestIfStmt:
                     y = x
                 return y
 
-        out = _compile(CppCompiler(), f)
+        out = _compile(CppCompiler(optimize=False), f)
         assert out == (
             'double f(double x) {\n'
             '    double y{};\n'
@@ -55,7 +55,7 @@ class TestIfStmt:
                     y = -x
                 return y
 
-        out = _compile(CppCompiler(), f)
+        out = _compile(CppCompiler(optimize=False), f)
         assert out == (
             'double f(double x) {\n'
             '    double y = x;\n'
@@ -81,7 +81,7 @@ class TestIfStmt:
                     z = y
                 return z
 
-        out = _compile(CppCompiler(), f)
+        out = _compile(CppCompiler(optimize=False), f)
         assert out == (
             'double f(double x, double y) {\n'
             '    double z{};\n'
@@ -114,7 +114,7 @@ class TestIfStmt:
                     y = a
                 return y
 
-        out = _compile(CppCompiler(), f)
+        out = _compile(CppCompiler(optimize=False), f)
         # Hoist is anchored to the if, after the unrelated ``a`` decl.
         assert out == (
             'double f(double x) {\n'
@@ -149,7 +149,7 @@ class TestIfStmt:
                 return y + a
 
         from fpy2.types import BoolType
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             g, ctx=fp.FP64,
             arg_types=[BoolType(), BoolType(), RealType(fp.FP64)],
         )
@@ -179,7 +179,7 @@ class TestIfStmt:
                     y = x
                 return y
 
-        out = _compile(CppCompiler(), f)
+        out = _compile(CppCompiler(optimize=False), f)
         # ``y`` is hoisted because both branches write it.
         assert 'double y{};' in out
         # ``t`` declares-on-assign inside the if-branch.

--- a/tests/unit/backend/cpp/test_emit_round.py
+++ b/tests/unit/backend/cpp/test_emit_round.py
@@ -121,3 +121,68 @@ class TestCast:
         assert 'static_cast' not in out
         assert 'assert' not in out
         assert 'return x;' in out
+
+
+class TestRoundElimIntegration:
+    """End-to-end checks that the ``optimize=True`` pipeline runs
+    :class:`fpy2.transform.RoundElim` and the emitter consumes its
+    output correctly.
+
+    The cases here aren't ones that *require* RoundElim to compile —
+    they compile under ``optimize=False`` too, just less tightly.
+    What the tests pin is the measurable cpp-level *difference*
+    between the two modes, which is the contract callers care about
+    when they flip the flag."""
+
+    def test_round_exact_of_fitting_constant_collapses(self):
+        """``fp.round_exact(1.0)`` under FP32: ``1.0`` is exactly
+        FP32-representable, so the round is the identity.  Without
+        optimization the emitter still produces the full
+        assertion-protected cast (``static_cast<float>(1)`` bound
+        to a temp + NaN-aware equality check).  With RoundElim the
+        ``RoundExact`` node collapses to its argument and the
+        whole pattern disappears."""
+
+        @fp.fpy
+        def f():
+            with fp.FP32:
+                return fp.round_exact(1.0)
+
+        no_opt = CppCompiler(optimize=False).compile(
+            f, ctx=fp.FP64, arg_types=[],
+        )
+        with_opt = CppCompiler(optimize=True).compile(
+            f, ctx=fp.FP64, arg_types=[],
+        )
+
+        # Without RoundElim: the round_exact's assertion + cast
+        # machinery is present.
+        assert 'static_cast<float>' in no_opt
+        assert 'assert(' in no_opt
+
+        # With RoundElim: collapsed to a bare ``return 1;`` (no
+        # cast, no assertion).
+        assert 'static_cast' not in with_opt
+        assert 'assert(' not in with_opt
+        assert 'return 1;' in with_opt
+
+    def test_arith_fits_scope_hoisted_to_real(self):
+        """``(1.0 + 2.0) * 3.0`` under FP64: the unrounded result
+        ``SetFormat({9.0})`` fits FP64 exactly.  RoundElim should
+        hoist the chain into ``with fp.REAL:`` blocks; the emitter
+        then renders the body without ``fesetround`` boundaries
+        on the hoisted ops."""
+
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return (1.0 + 2.0) * 3.0
+
+        with_opt = CppCompiler(optimize=True).compile(
+            f, ctx=fp.FP64, arg_types=[],
+        )
+        # Hoisted: the per-op binds RoundElim emits surface as
+        # ``_t...`` temporaries.  At least one shows up.
+        assert '_t' in with_opt
+        # The final return value is the last hoisted result.
+        assert 'return _t' in with_opt

--- a/tests/unit/backend/cpp/test_emit_scalar.py
+++ b/tests/unit/backend/cpp/test_emit_scalar.py
@@ -18,7 +18,10 @@ from fpy2.types import RealType
 
 @pytest.fixture
 def cc():
-    return CppCompiler()
+    # These tests assert specific bare-emitter output; opt out of
+    # optimization so transforms like ``RoundElim`` don't reshape
+    # the strings.
+    return CppCompiler(optimize=False)
 
 
 def _compile(cc: CppCompiler, func, *, arg_ctx=None) -> str:

--- a/tests/unit/backend/cpp/test_phi_web.py
+++ b/tests/unit/backend/cpp/test_phi_web.py
@@ -15,7 +15,7 @@ from fpy2.types import RealType
 def _compile(func, *, arg_ctx=None) -> str:
     arg_ctx = arg_ctx or fp.FP64
     arg_types = [RealType(arg_ctx) for _ in func.args]
-    return CppCompiler().compile(func, ctx=arg_ctx, arg_types=arg_types)
+    return CppCompiler(optimize=False).compile(func, ctx=arg_ctx, arg_types=arg_types)
 
 
 class TestPhiWebRenaming:

--- a/tests/unit/backend/cpp/test_phi_web.py
+++ b/tests/unit/backend/cpp/test_phi_web.py
@@ -4,6 +4,11 @@ Tests for the per-SSA-def renaming via phi-web equivalence classes.
 The cpp emitter is free to map distinct SSA defs of the same source
 name to distinct C++ variables.  Only defs joined by a phi node share
 storage.  These tests pin that behavior.
+
+The helper compiler uses ``optimize=False`` so the assertions track
+the bare emitter's per-def renaming policy rather than whatever
+shape optimizing transforms like :class:`fpy2.transform.RoundElim`
+might leave behind.
 """
 
 import fpy2 as fp

--- a/tests/unit/transform/test_round_elim.py
+++ b/tests/unit/transform/test_round_elim.py
@@ -1,0 +1,463 @@
+"""
+Unit tests for the :class:`fpy2.transform.RoundElim` transform.
+
+The rewrite mints fresh ``_tN`` names via ``Gensym``, whose suffix
+counts depend on the existing in-scope names — so an ``is_equiv``
+comparison against a hand-written golden AST is too brittle.  The
+tests assert three kinds of properties:
+
+1. **Structural shape** of the rewritten AST.  Counts of
+   ``with fp.REAL:`` blocks, presence/absence of ``Round`` /
+   ``RoundExact`` / ``Cast`` nodes, presence/absence of arithmetic
+   ops under the original (non-REAL) context.
+2. **Negative checks**: unchanged inputs (REAL scope, ops that
+   don't fit) compare via ``is_equiv`` against the original AST.
+3. **Semantic equivalence** via the FPy interpreter on concrete
+   sample inputs.  Catches subtle errors in the rewrite that pass
+   shape checks.
+"""
+
+import fpy2 as fp
+
+from fpy2.ast.fpyast import (
+    Abs, Add, Assign, BinaryOp, Cast, ContextStmt, ForeignVal, Mul, Neg, Round,
+    RoundExact, Sub, UnaryOp,
+)
+from fpy2.ast.visitor import DefaultVisitor
+from fpy2.number import REAL
+from fpy2.transform import RoundElim
+
+
+# ----------------------------------------------------------------------
+# Helpers
+
+
+_ROUNDED_ARITH = (Add, Sub, Mul, Abs, Neg)
+_ROUND_NODES = (Round, RoundExact, Cast)
+
+
+def _count_real_blocks(ast: fp.ast.FuncDef) -> int:
+    """Return the number of ``with fp.REAL:`` blocks reachable in *ast*."""
+    count = 0
+
+    class _C(DefaultVisitor):
+        def _visit_context(self, stmt: ContextStmt, ctx):
+            nonlocal count
+            if isinstance(stmt.ctx, ForeignVal) and stmt.ctx.val is REAL:
+                count += 1
+            super()._visit_context(stmt, ctx)
+
+    _C()._visit_function(ast, None)
+    return count
+
+
+def _arith_op_types_under_real(ast: fp.ast.FuncDef) -> set[type]:
+    """Return the set of arithmetic-op classes that appear under
+    a ``with fp.REAL:`` block in *ast*.  Used to confirm the
+    rewrite moved a given op kind into REAL — without forbidding
+    the same op kind from also appearing *outside* REAL via an
+    operand bind (which preserves a non-identity round at its
+    original scope)."""
+    seen: set[type] = set()
+
+    class _C(DefaultVisitor):
+        def __init__(self):
+            super().__init__()
+            self.under_real = 0
+
+        def _visit_context(self, stmt: ContextStmt, ctx):
+            if isinstance(stmt.ctx, ForeignVal) and stmt.ctx.val is REAL:
+                self.under_real += 1
+                super()._visit_context(stmt, ctx)
+                self.under_real -= 1
+            else:
+                super()._visit_context(stmt, ctx)
+
+        def _visit_unaryop(self, e: UnaryOp, ctx):
+            if self.under_real > 0 and isinstance(e, (Abs, Neg)):
+                seen.add(type(e))
+            super()._visit_unaryop(e, ctx)
+
+        def _visit_binaryop(self, e: BinaryOp, ctx):
+            if self.under_real > 0 and isinstance(e, (Add, Sub, Mul)):
+                seen.add(type(e))
+            super()._visit_binaryop(e, ctx)
+
+    _C()._visit_function(ast, None)
+    return seen
+
+
+def _count_fresh_temp_assigns(ast: fp.ast.FuncDef) -> int:
+    """Count ``Assign`` statements in *ast* whose target name starts
+    with ``_t`` (the convention this transform uses for hoisted
+    temporaries).  Used by the Var-skip test to detect a stray
+    copy assignment."""
+    count = 0
+
+    class _C(DefaultVisitor):
+        def _visit_assign(self, stmt, ctx):
+            t = stmt.target
+            name = getattr(t, 'base', None) or str(t)
+            if isinstance(name, str) and name.startswith('_t'):
+                nonlocal count
+                count += 1
+            super()._visit_assign(stmt, ctx)
+
+    _C()._visit_function(ast, None)
+    return count
+
+
+def _has_node(ast: fp.ast.FuncDef, node_type) -> bool:
+    """True iff any reachable expression in *ast* is an instance of
+    *node_type*."""
+    found = [False]
+
+    class _C(DefaultVisitor):
+        def _visit_expr(self, e, ctx):
+            if isinstance(e, node_type):
+                found[0] = True
+                return
+            super()._visit_expr(e, ctx)
+
+    _C()._visit_function(ast, None)
+    return found[0]
+
+
+def _eval(ast: fp.ast.FuncDef, fn: fp.Function, *args):
+    """Run *ast* through the FPy interpreter using *fn*'s env."""
+    return fn.with_ast(ast)(*args)
+
+
+# ----------------------------------------------------------------------
+# Arithmetic-op hoisting
+
+
+class TestArithmeticHoist:
+    """Eliminable arithmetic ops should hoist their unrounded computation
+    into a ``with fp.REAL:`` block, leaving operand evaluation at the
+    original scope."""
+
+    def test_add_fits_hoisted(self):
+        """``1.0 + 2.0`` under FP64 — sum is the SetFormat ``{3}``,
+        fits FP64.  Add should hoist; an Add appears under REAL."""
+
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return 1.0 + 2.0
+
+        out = RoundElim.apply(f.ast)
+        assert _count_real_blocks(out) >= 1
+        assert Add in _arith_op_types_under_real(out)
+        assert _eval(out, f) == f()
+
+    def test_chained_mul_fits_hoisted(self):
+        """``(1.0 + 2.0) * 3.0`` under FP64 — both ops are eliminable.
+        Per-op hoist produces nested temps; both Add and Mul end up
+        under REAL."""
+
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return (1.0 + 2.0) * 3.0
+
+        out = RoundElim.apply(f.ast)
+        types_under_real = _arith_op_types_under_real(out)
+        assert Add in types_under_real
+        assert Mul in types_under_real
+        assert _eval(out, f) == f()
+
+    def test_real_operand_arith_inside_eliminable_op(self):
+        """``abs(x + y)`` under FP64 where ``x, y: fp.Real``.
+
+        The outer ``Abs``'s unrounded result fits FP64 (abs of any
+        FP64 value is FP64-representable).  The inner ``Add``'s
+        round, however, is *not* the identity — it rounds REAL
+        operands to FP64.  The rewrite must bind ``x + y`` under
+        FP64 *before* the REAL block so the Add's round fires at
+        its original scope.
+
+        Post-rewrite shape: Abs appears under REAL; Add survives
+        outside REAL (the operand bind preserves the round)."""
+
+        @fp.fpy
+        def f(x: fp.Real, y: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return abs(x + y)
+
+        out = RoundElim.apply(f.ast)
+        types_under_real = _arith_op_types_under_real(out)
+        # Abs hoisted under REAL.
+        assert Abs in types_under_real
+        # Add NOT moved to REAL — the operand bind keeps it at FP64.
+        assert Add not in types_under_real
+        # Semantic equivalence — rewrite preserves the original
+        # (FP64-rounded) value.  Picking small operands so the sum
+        # doesn't overflow either side.
+        assert _eval(out, f, 1.5, 2.5) == f(1.5, 2.5)
+
+    def test_arith_doesnt_fit_unchanged(self):
+        """``x + y`` under FP32 where ``x, y: fp.Real``.  The Add's
+        unrounded format is REAL — doesn't fit FP32.  No rewrite
+        should fire."""
+
+        @fp.fpy
+        def f(x: fp.Real, y: fp.Real) -> fp.Real:
+            with fp.FP32:
+                return x + y
+
+        out = RoundElim.apply(f.ast)
+        assert out.is_equiv(f.ast)
+
+
+# ----------------------------------------------------------------------
+# Round / RoundExact / Cast collapse
+
+
+class TestRoundNodeCollapse:
+    """Eliminable explicit round nodes should disappear, replaced by
+    their argument."""
+
+    def test_round_collapses_when_arg_fits(self):
+        """``fp.round(1.0)`` under FP64 — ``1.0`` is exactly
+        FP64-representable, the Round is the identity."""
+
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return fp.round(1.0)
+
+        out = RoundElim.apply(f.ast)
+        assert not _has_node(out, Round)
+        assert _eval(out, f) == f()
+
+    def test_round_stays_when_arg_doesnt_fit(self):
+        """``fp.round(x)`` under FP64 where ``x: fp.Real`` — Real
+        doesn't fit FP64 (saturated abstract format), Round must
+        stay."""
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return fp.round(x)
+
+        out = RoundElim.apply(f.ast)
+        assert _has_node(out, Round)
+        assert out.is_equiv(f.ast)
+
+    def test_cast_collapses_when_arg_fits(self):
+        """``fp.cast(1.0)`` under FP64 — same identity check as Round."""
+
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return fp.cast(1.0)
+
+        out = RoundElim.apply(f.ast)
+        assert not _has_node(out, Cast)
+        assert _eval(out, f) == f()
+
+    def test_round_exact_collapses_when_arg_fits(self):
+        """``fp.round_exact`` is identity-when-fits just like Round."""
+
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return fp.round_exact(1.0)
+
+        out = RoundElim.apply(f.ast)
+        assert not _has_node(out, RoundExact)
+        assert _eval(out, f) == f()
+
+
+# ----------------------------------------------------------------------
+# Scope guards (REAL / symbolic)
+
+
+class TestScopeGuards:
+    """REAL scope is the trivial identity — no rounds to eliminate.
+    Symbolic / unresolved scopes can't safely claim identity."""
+
+    def test_real_scope_noop(self):
+        """``@fpy(ctx=fp.REAL): def f(x): return x + x`` — no ``with``
+        block, scope is REAL.  Nothing to hoist."""
+
+        @fp.fpy(ctx=fp.REAL)
+        def f(x: fp.Real) -> fp.Real:
+            return x + x
+
+        out = RoundElim.apply(f.ast)
+        assert out.is_equiv(f.ast)
+        assert _count_real_blocks(out) == 0
+
+    def test_symbolic_scope_noop(self):
+        """Function with no declared ctx and no pinned outer ctx —
+        the scope is symbolic.  RoundElim refuses to claim identity
+        without a concrete target."""
+
+        @fp.fpy
+        def f(x: fp.Real, y: fp.Real) -> fp.Real:
+            return x + y
+
+        out = RoundElim.apply(f.ast)
+        assert out.is_equiv(f.ast)
+
+
+# ----------------------------------------------------------------------
+# Suppression positions
+
+
+class TestSuppressionPositions:
+    """Hoisting needs a statement-level preamble slot — disabled
+    inside ListComp elt/iterables and IfExpr branches.  Round /
+    Cast collapse still fires (pure node rewrite)."""
+
+    def test_no_hoist_inside_list_comp(self):
+        """``[a + b for a, b in zip(xs, ys)]`` under FP64 — the Add
+        inside the elt would benefit from REAL evaluation, but
+        there's no statement slot inside the comp to host the
+        preamble.  Add must stay un-hoisted."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [a + b for a, b in zip(xs, ys)]
+
+        out = RoundElim.apply(f.ast)
+        # No REAL block was added.  The original AST may already
+        # contain REAL contexts elsewhere; we only assert no *new*
+        # REAL block introduced.
+        assert _count_real_blocks(out) == _count_real_blocks(f.ast)
+
+    def test_round_collapse_inside_list_comp(self):
+        """Round collapse still fires inside a list comp — it's a
+        pure node rewrite that needs no preamble slot."""
+
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            with fp.FP64:
+                return [fp.round(1.0), fp.round(2.0)]
+
+        out = RoundElim.apply(f.ast)
+        assert not _has_node(out, Round)
+        assert list(_eval(out, f)) == list(f())
+
+    def test_no_hoist_inside_if_expr_branches(self):
+        """``(x + y) if cond else 0.0`` — the Add inside the ift
+        branch would evaluate conditionally; hoisting it
+        unconditionally would change exception semantics under
+        contexts that can raise.  Stay suppressed."""
+
+        @fp.fpy
+        def f(x: fp.Real, y: fp.Real, cond: bool) -> fp.Real:
+            with fp.FP64:
+                return (1.0 + 2.0) if cond else (3.0 + 4.0)
+
+        out = RoundElim.apply(f.ast)
+        # No NEW REAL block introduced for the branch Adds.  (Whole-
+        # IfExpr might still hoist if it itself is eliminable, but
+        # the inner branch ops shouldn't hoist out.)
+        # Soundness check via interpreter — works under both branches.
+        assert _eval(out, f, 1.0, 2.0, True) == f(1.0, 2.0, True)
+        assert _eval(out, f, 1.0, 2.0, False) == f(1.0, 2.0, False)
+
+
+# ----------------------------------------------------------------------
+# Var-skip
+
+
+class TestVarSkip:
+    """Operands that are already ``Var`` references skip the bind
+    step — a copy ``_t = v`` has no rounds to preserve and just
+    adds a redundant alias."""
+
+    def test_var_operand_not_bound(self):
+        """``abs(a)`` where ``a`` is a local Var.  The hoist should
+        plug ``a`` directly into the REAL block without minting a
+        temp for it.  Expected fresh temps: just one (the Abs
+        result) — *not* two (which would mean `_t = a` was also
+        emitted)."""
+
+        @fp.fpy
+        def f(x: fp.Real, y: fp.Real) -> fp.Real:
+            with fp.FP64:
+                a = x + y
+            with fp.FP64:
+                return abs(a)
+
+        out = RoundElim.apply(f.ast)
+        # Abs hoisted.
+        assert Abs in _arith_op_types_under_real(out)
+        # Only one fresh temp — the Abs result.  An extra `_t = a`
+        # copy would push this to 2.
+        assert _count_fresh_temp_assigns(out) == 1
+        assert _eval(out, f, 1.5, 2.5) == f(1.5, 2.5)
+
+
+# ----------------------------------------------------------------------
+# Idempotence + post-transform SyntaxCheck
+
+
+class TestProperties:
+    """Cross-cutting properties of the transform."""
+
+    def test_idempotent_clean_case(self):
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return (1.0 + 2.0) * 3.0
+        once = RoundElim.apply(f.ast)
+        twice = RoundElim.apply(once)
+        assert once.is_equiv(twice)
+
+    def test_idempotent_operand_bind_case(self):
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return abs(fp.round(x))
+        once = RoundElim.apply(f.ast)
+        twice = RoundElim.apply(once)
+        assert once.is_equiv(twice)
+
+    def test_idempotent_real_operand_case(self):
+        """The bug case — earlier `_safe_to_hoist` couldn't detect
+        the non-identity inner Add, so hoisting was unsound and
+        also non-idempotent across rewrites."""
+
+        @fp.fpy
+        def f(x: fp.Real, y: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return abs(x + y)
+        once = RoundElim.apply(f.ast)
+        twice = RoundElim.apply(once)
+        assert once.is_equiv(twice)
+
+    def test_idempotent_real_scope_noop(self):
+        @fp.fpy(ctx=fp.REAL)
+        def f(x: fp.Real) -> fp.Real:
+            return x + x
+        once = RoundElim.apply(f.ast)
+        twice = RoundElim.apply(once)
+        assert once.is_equiv(twice)
+
+    def test_syntax_check_passes(self):
+        """``RoundElim.apply`` runs ``SyntaxCheck.check`` internally;
+        if the rewrite produced ill-formed output, ``apply`` itself
+        would raise.  This test just exercises a representative
+        input."""
+
+        @fp.fpy
+        def f(x: fp.Real, y: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return abs(x + y)
+
+        # Should not raise.
+        RoundElim.apply(f.ast)
+
+    def test_type_error_on_non_funcdef(self):
+        try:
+            RoundElim.apply("not a funcdef")
+        except TypeError:
+            pass
+        else:
+            assert False, "expected TypeError"

--- a/tests/unit/transform/test_round_elim.py
+++ b/tests/unit/transform/test_round_elim.py
@@ -461,3 +461,111 @@ class TestProperties:
             pass
         else:
             assert False, "expected TypeError"
+
+
+# ----------------------------------------------------------------------
+# Regression: paths the property tests don't exercise hard
+
+
+class TestRegression:
+    """Coverage for paths the per-feature tests don't reach: the
+    cleanup-chain advertised in the module docstring, hoists under
+    nested ``with`` blocks, and the strict-tighter guard against
+    unbounded contexts (``fp.INTEGER``).
+    """
+
+    def test_cleanup_chain_collapses_redundant_binds(self):
+        """RoundElim intentionally leaves redundant operand binds
+        (``_t = literal`` lines) that the documented downstream
+        cleanup chain — :class:`ConstPropagate` then
+        :class:`CopyPropagate` then :class:`DeadCodeEliminate` — is
+        expected to collapse.
+
+        ``ConstPropagate`` is the load-bearing piece: it inlines
+        literal-bound temps (``_t = 1`` → uses of ``_t`` become
+        ``1``) so they become dead.  ``CopyPropagate`` handles
+        Var→Var copies (also created by the per-op bind scheme).
+        ``DeadCodeEliminate`` removes the resulting unused
+        assigns.  Without ``ConstPropagate`` the literal binds
+        stay live and DCE can't remove them.
+
+        This test pins that contract: the post-cleanup AST has
+        fewer fresh temps than the post-RoundElim AST."""
+
+        from fpy2.transform import (
+            ConstPropagate, CopyPropagate, DeadCodeEliminate,
+        )
+
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return (1.0 + 2.0) * 3.0
+
+        after_elim = RoundElim.apply(f.ast)
+        # The verbose intermediate form has several `_t` temps (per
+        # operand + per op result).
+        elim_temps = _count_fresh_temp_assigns(after_elim)
+        assert elim_temps > 1, (
+            f'expected RoundElim to produce multiple temps for the '
+            f'verbose form, got {elim_temps}'
+        )
+
+        # Run the documented cleanup chain.
+        after = ConstPropagate.apply(after_elim)
+        after = CopyPropagate.apply(after)
+        after = DeadCodeEliminate.apply(after)
+        cleaned_temps = _count_fresh_temp_assigns(after)
+        # Cleanup should reduce the count.  We don't pin the exact
+        # number — that depends on the cleanup passes' specifics
+        # and would couple this test to their implementations.
+        assert cleaned_temps < elim_temps, (
+            f'expected cleanup chain to reduce temp count from '
+            f'{elim_temps}; got {cleaned_temps}'
+        )
+        # Semantic equivalence preserved through the full chain.
+        assert _eval(after, f) == f()
+
+    def test_hoist_inside_nested_with_blocks(self):
+        """Hoist should fire correctly inside an inner ``with`` block.
+        The active scope at the eliminable op is the innermost
+        ``with``; ``_resolved_ctx`` and ``_unrounded_format`` must
+        consult that scope, not the outer one."""
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP32:                 # outer scope
+                with fp.FP64:             # inner scope — Add is here
+                    a = 1.0 + 2.0         # eliminable: SetFormat({3}) ⊆ FP64
+                return a + a              # outer Add under FP32 — Real-typed
+                                          # operands → NOT eliminable, stays
+
+        out = RoundElim.apply(f.ast)
+        # Inner Add hoisted under REAL.
+        assert Add in _arith_op_types_under_real(out)
+        # Outer Add NOT hoisted — semantic preservation under FP32 round.
+        # (Tested via interpreter; we don't assert structural shape on
+        # the outer since the inner hoist may have introduced new
+        # statements that the structural predicates pick up.)
+        # The function's value with `x` unused: ``a + a == 6`` rounded
+        # through FP32 == 6.  Interpreter agrees.
+        assert _eval(out, f, 0.0) == f(0.0)
+
+    def test_unbounded_context_no_hoist(self):
+        """Strictly-tighter guard: under ``fp.INTEGER`` (an unbounded
+        ``MPFixedContext``), the unrounded format of ``x + 1`` equals
+        the scope's format — both are saturated except for ``exp=0``.
+        ``round_is_identity`` is vacuously true, but hoisting yields
+        no narrowing and breaks downstream storage selection (the cpp
+        emitter's lossless-widening dispatch can't pick a finite type
+        for a saturated ``AbstractFormat``).  The guard should reject
+        this hoist."""
+
+        @fp.fpy(ctx=fp.INTEGER)
+        def f(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        out = RoundElim.apply(f.ast)
+        # No REAL block introduced.
+        assert _count_real_blocks(out) == _count_real_blocks(f.ast)
+        # Add stays in its original (INTEGER) position.
+        assert out.is_equiv(f.ast)


### PR DESCRIPTION
Adds a rounding elimination transformation pass.

Given an expression `f<C>(e_1, ..., e_n)` where `f` is a rounded operation under a rounding context `C`, let `F` be the format that contains all possible values of the unrounded `f(e_1, ..., e_n)`. If `F` is a subset of `C.F`, then the rounding operation can be eliminated.