### PR TITLE
Remove `RoundExact` AST node

### DIFF
--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -465,7 +465,7 @@ def round_is_identity(
 
     *unrounded* is the unrounded value-set, typically the result of
     :func:`exact_binop` / :func:`exact_unop` (or, for explicit
-    ``Round``/``RoundExact``/``Cast`` nodes, the argument's inferred
+    ``Round``/``Cast`` nodes, the argument's inferred
     bound).  *ctx* is the concrete rounding context whose
     round-identity behavior we care about.
 
@@ -1064,10 +1064,10 @@ class _FormatInferInstance(Visitor):
             case Sum():
                 assert isinstance(arg_fmt, ListFormat), f'expected ListFormat for argument of Sum, got {arg_fmt!r}'
                 return self._sum_bound(e, arg_fmt)
-            case Round() | RoundExact() | Cast():
-                # Identity-when-fits.  ``Round`` / ``RoundExact`` round
-                # the argument to the active scope; ``Cast`` asserts
-                # the argument already fits.  When the argument's
+            case Round() | Cast():
+                # Identity-when-fits.  ``Round`` rounds the argument to
+                # the active scope; ``Cast`` rounds and asserts the
+                # result is exact.  When the argument's
                 # inferred format is contained in the scope's format,
                 # every one of these operations is the identity at the
                 # value level — so the result's tight format equals

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -79,7 +79,6 @@ _unary_table: dict[type[UnaryOp], FunctionType] = {
     Signbit: _Predicate,
     Not: _Bool1ary,
     Round: _Real1ary,
-    RoundExact: _Real1ary,
     Cast: _Real1ary,
     Logb: _Real1ary
 }

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -168,7 +168,6 @@ __all__ = [
 
     # Rounding operator
     'Round',
-    'RoundExact',
     'RoundAt',
     'Cast',
 
@@ -1090,16 +1089,12 @@ class And(NaryOp):
 class Round(NamedUnaryOp):
     """FPy node: inter-format rounding"""
 
-class RoundExact(NamedUnaryOp):
-    """FPy node: inter-format rounding"""
-    __slots__ = ()
-
 class RoundAt(NamedBinaryOp):
     """FPy node: inter-format rounding with absolute position"""
     __slots__ = ()
 
 class Cast(NamedUnaryOp):
-    """FPy node: identity operation that checks if argument is contained in current rounding context"""
+    """FPy node: round to the current context, asserting the result is exact"""
     __slots__ = ()
 
 # Tensor operators

--- a/fpy2/ast/visitor.py
+++ b/fpy2/ast/visitor.py
@@ -30,7 +30,6 @@ _expr_dispatch: dict[type[Expr], str] = {
     Attribute: "_visit_attribute",
 
     Round: "_visit_round",
-    RoundExact: "_visit_round",
     RoundAt: "_visit_round_at",
     Cast: "_visit_unaryop",
 }
@@ -109,7 +108,7 @@ class Visitor(ABC):
     def _visit_naryop(self, e: NaryOp, ctx: Any) -> Any:
         ...
 
-    def _visit_round(self, e: Round | RoundExact, ctx: Any) -> Any:
+    def _visit_round(self, e: Round, ctx: Any) -> Any:
         return self._visit_unaryop(e, ctx)
 
     def _visit_round_at(self, e: RoundAt, ctx: Any) -> Any:

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -25,8 +25,8 @@ Currently supported:
   inserts explicit ``static_cast`` conversions.
 - Rounding-context boundaries: ``with`` blocks emit save / set /
   restore around ``fesetround`` when the active mode changes;
-  ``Round`` / ``RoundExact`` / ``Cast`` lower as
-  ``static_cast`` (with a NaN-aware assertion for ``RoundExact``).
+  ``Round`` / ``Cast`` lower as
+  ``static_cast`` (with a NaN-aware assertion for ``Cast``).
 
 Anything else raises :class:`CppEmitError`, which the public
 ``CppCompiler`` re-wraps as :class:`CppCompileError`.
@@ -45,7 +45,7 @@ from ...ast.fpyast import (
     ForStmt, FuncDef, Hexnum, If1Stmt, IfStmt, IndexedAssign, Integer,
     IsFinite, IsInf, IsNan, IsNormal, Len, ListComp, ListExpr, ListRef,
     ListSlice, Max, Min, NamedId, NaryOp, Not, Or, Range1, Range2, Range3,
-    Rational, ReturnStmt, Round, RoundExact, Signbit, Size, StmtBlock, Sum,
+    Rational, ReturnStmt, Round, Signbit, Size, StmtBlock, Sum,
     TernaryOp, TupleBinding, TupleExpr, UnaryOp, UnderscoreId, Var,
     WhileStmt, Zip,
 )
@@ -747,7 +747,7 @@ class CppEmitter(Visitor):
         should either narrow the active context or wrap the operand
         in ``fp.round(...)`` to acknowledge the precision change.
 
-        For user-explicit casts (``Round`` / ``RoundExact``, vector
+        For user-explicit casts (``Round`` / ``Cast``, vector
         subscript), use :meth:`_explicit_cast` instead — that path
         never refuses."""
         if arg_ty == target_ty:
@@ -767,7 +767,7 @@ class CppEmitter(Visitor):
         """Emit ``static_cast<target>(arg)`` unconditionally.
 
         Used at sites where the cast is part of the FPy semantics
-        the user wrote — ``Round`` / ``RoundExact`` lower to a cast,
+        the user wrote — ``Round`` / ``Cast`` lower to a cast,
         ``xs[i]`` needs ``static_cast<size_t>(i)``.  These callers
         accept that the conversion may be lossy."""
         return f'static_cast<{target_ty.format()}>({arg})'
@@ -1003,13 +1003,12 @@ class CppEmitter(Visitor):
         arg = self._visit_expr(e.arg, ctx)
         match e:
             case Cast():
-                # ``Cast`` is an analysis-only annotation: it asserts
-                # the argument's value is contained in the active
-                # context's format.  At the C++ level it's the
-                # identity — no generated code, no ``static_cast``
-                # (the explicit-cast policy is enforced by the
-                # op-table dispatch, not by ``Cast`` itself).
-                return arg
+                # ``Cast(arg)`` rounds ``arg`` into the active context
+                # and asserts the round was lossless (it's an error to
+                # cast a value the target format can't hold exactly).
+                # Lowered as ``static_cast`` → bind to a temp →
+                # ``assert(arg == tmp || (NaN-aware equality))``.
+                return self._emit_exact_cast(e, arg)
             case Not():
                 # Logical negation — operand is bool, result is bool.
                 # No rounding context involved.
@@ -1529,63 +1528,63 @@ class CppEmitter(Visitor):
         self.writer.dedent()
         self.writer.add_line('}')
         return result
-    def _visit_round(self, e, ctx) -> str:
-        # ``Round(arg)`` rounds ``arg`` to the active rounding
-        # context — emitted as a plain ``static_cast`` (the cast's
-        # rounding mode is the active ``fesetround`` mode set by
-        # Phase 5b at the surrounding ``with`` boundary).
-        #
-        # ``RoundExact(arg)`` is the same cast plus a runtime
-        # assertion that the cast was lossless: cast → bind to a
-        # temp → ``assert(arg == tmp || (NaN-aware equality))``.
-        arg = self._visit_expr(e.arg, ctx)
-        # The argument's storage is only used to short-circuit
-        # same-type casts.  Non-dyadic numeric literals
-        # (e.g., ``fp.round(3.14159265359)``) have a SetFormat with
-        # no representable storage — that's fine, we always cast.
+    def _scalar_cast_types(self, e):
+        """Source/target scalar storage for a round-like node ``e``.
+
+        The argument's storage is only used to short-circuit
+        same-type casts.  Non-dyadic numeric literals
+        (e.g., ``fp.round(3.14159265359)``) have a SetFormat with
+        no representable storage — that's fine, we always cast."""
         try:
             arg_ty = self._scalar_storage_for_expr(e.arg)
         except CppEmitError:
             arg_ty = None
         active = self._active_ctx_for(e)
         target_ty = self._scalar_for_ctx(active, at=e)
+        return arg_ty, target_ty
 
-        match e:
-            case Round():
-                # The user explicitly asked to round into the active
-                # context — emit the cast even when lossy.  Same-type
-                # short-circuits to a no-op.
-                if arg_ty == target_ty:
-                    return arg
-                return self._explicit_cast(arg, target_ty)
-            case RoundExact():
-                # Same-type is a guaranteed no-op, no assert.
-                if arg_ty == target_ty:
-                    return arg
-                # Bind the rounded value to a temp so the assertion
-                # can name it without re-evaluating the source.
-                tmp = self._fresh_temp()
-                self.writer.add_line(
-                    f'{target_ty.format()} {tmp} = '
-                    f'{self._explicit_cast(arg, target_ty)};'
-                )
-                # NaN-aware comparison: ``NaN == NaN`` is false in
-                # C++, so FP operands need an extra ``isnan`` guard
-                # to avoid false asserts when both sides round to
-                # NaN.  Skipped for purely integer operand pairs.
-                if target_ty.is_float() or (arg_ty is not None and arg_ty.is_float()):
-                    check = (
-                        f'{arg} == {tmp} || '
-                        f'(std::isnan({arg}) && std::isnan({tmp}))'
-                    )
-                else:
-                    check = f'{arg} == {tmp}'
-                self.writer.add_line(f'assert({check});')
-                return tmp
-            case _:
-                raise CppEmitError(
-                    f'unsupported round op: {type(e).__name__}', at=e,
-                )
+    def _emit_exact_cast(self, e, arg: str) -> str:
+        # ``Cast(arg)`` is a ``static_cast`` plus a runtime assertion
+        # that the cast was lossless: cast → bind to a temp →
+        # ``assert(arg == tmp || (NaN-aware equality))``.
+        arg_ty, target_ty = self._scalar_cast_types(e)
+        # Same-type is a guaranteed no-op, no assert.
+        if arg_ty == target_ty:
+            return arg
+        # Bind the rounded value to a temp so the assertion
+        # can name it without re-evaluating the source.
+        tmp = self._fresh_temp()
+        self.writer.add_line(
+            f'{target_ty.format()} {tmp} = '
+            f'{self._explicit_cast(arg, target_ty)};'
+        )
+        # NaN-aware comparison: ``NaN == NaN`` is false in
+        # C++, so FP operands need an extra ``isnan`` guard
+        # to avoid false asserts when both sides round to
+        # NaN.  Skipped for purely integer operand pairs.
+        if target_ty.is_float() or (arg_ty is not None and arg_ty.is_float()):
+            check = (
+                f'{arg} == {tmp} || '
+                f'(std::isnan({arg}) && std::isnan({tmp}))'
+            )
+        else:
+            check = f'{arg} == {tmp}'
+        self.writer.add_line(f'assert({check});')
+        return tmp
+
+    def _visit_round(self, e, ctx) -> str:
+        # ``Round(arg)`` rounds ``arg`` to the active rounding
+        # context — emitted as a plain ``static_cast`` (the cast's
+        # rounding mode is the active ``fesetround`` mode set by
+        # Phase 5b at the surrounding ``with`` boundary).  The user
+        # explicitly asked to round into the active context, so the
+        # cast is emitted even when lossy.  Same-type short-circuits
+        # to a no-op.
+        arg = self._visit_expr(e.arg, ctx)
+        arg_ty, target_ty = self._scalar_cast_types(e)
+        if arg_ty == target_ty:
+            return arg
+        return self._explicit_cast(arg, target_ty)
 
     def _visit_round_at(self, e, ctx):
         self._unsupported('RoundAt', at=e)

--- a/fpy2/backend/cpp/utils.py
+++ b/fpy2/backend/cpp/utils.py
@@ -10,7 +10,7 @@ explicitly and concatenate them — same shape as the legacy
 
 Header coverage tracks what the emitter actually uses:
 
-- ``<cassert>``: ``assert(...)`` from ``RoundExact``.
+- ``<cassert>``: ``assert(...)`` from ``Cast``.
 - ``<cfenv>``: ``std::fegetround`` / ``std::fesetround`` and the
   ``FE_*`` rounding-mode macros.
 - ``<cmath>``: every ``std::fabs`` / ``std::sqrt`` / ``std::sin`` /

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -272,7 +272,7 @@ class _FPCoreCompileInstance(Visitor):
         args = [self._visit_expr(c, ctx) for c in e.args]
         return fpc.UnknownOperator(*args, name=name)
 
-    def _visit_round(self, e: Round | RoundExact, ctx: None) -> fpc.Expr:
+    def _visit_round(self, e: Round, ctx: None) -> fpc.Expr:
         # round expression
         match e.arg:
             case Decnum():

--- a/fpy2/backend/mpfx/compiler.py
+++ b/fpy2/backend/mpfx/compiler.py
@@ -449,7 +449,7 @@ class _MPFXBackendInstance(Visitor):
             case _:
                 raise MPFXCompileError(self.func, f'Unsupported nary operation to compile: {e}')
 
-    def _visit_round(self, e: Round | RoundExact, ctx: CompileCtx):
+    def _visit_round(self, e: Round, ctx: CompileCtx):
         if isinstance(e.arg, RealVal):
             # special case: rounded literal
             ty = self._expr_type(e)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -69,7 +69,7 @@ _unary_table: dict[Callable, type[UnaryOp] | type[NamedUnaryOp]] = {
     isnormal: IsNormal,
     signbit: Signbit,
     round: Round,
-    round_exact: RoundExact,
+    round_exact: Cast,
     cast: Cast,
     len: Len,
     dim: Dim,

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -380,7 +380,6 @@ _UNARY_TABLE: dict[type[UnaryOp], object] = {
     IsNormal: ops.isnormal,
     Signbit: ops.signbit,
     Round: ops.round,
-    RoundExact: ops.round_exact,
     Cast: ops.cast,
     Logb: ops.logb,
     # rounding context

--- a/fpy2/transform/const_fold.py
+++ b/fpy2/transform/const_fold.py
@@ -109,7 +109,7 @@ class _ConstFoldInstance(DefaultTransformVisitor):
 
     def _visit_unaryop(self, e: UnaryOp, ctx: Context | None):
         e = super()._visit_unaryop(e, ctx)
-        if self.enable_op and not isinstance(e, Round | RoundExact) and ctx is not None and self._is_value(e.arg):
+        if self.enable_op and not isinstance(e, Round | Cast) and ctx is not None and self._is_value(e.arg):
             # constant folding is possible
             val = self.rt.eval_expr(e, self._eval_env(), ctx)
             if isinstance(val, Float | Fraction):

--- a/fpy2/transform/round_elim.py
+++ b/fpy2/transform/round_elim.py
@@ -11,7 +11,7 @@ transform makes that fact structural by computing ``g`` under
 ``with fp.REAL:`` and binding the result to a fresh name that
 replaces the original expression site.
 
-For explicit ``Round`` / ``RoundExact`` / ``Cast`` nodes, the same
+For explicit ``Round`` / ``Cast`` nodes, the same
 notion produces a different rewrite: when the argument's bound
 already fits in the target context, the whole node collapses to
 its argument (the round was a no-op at runtime).
@@ -86,7 +86,7 @@ from ..analysis.format_infer import (
 )
 from ..ast.fpyast import (
     Abs, Add, Assign, Cast, ContextStmt, Expr, ForeignVal, FuncDef, IfExpr,
-    ListComp, Mul, Neg, Round, RoundExact, Stmt, StmtBlock, Sub,
+    ListComp, Mul, Neg, Round, Stmt, StmtBlock, Sub,
     UnderscoreId, Var,
 )
 from ..ast.visitor import DefaultTransformVisitor
@@ -174,7 +174,7 @@ class _RoundElimInstance(DefaultTransformVisitor):
         ``None`` for ops we don't handle.  Pulls the children's
         stored (post-round) bounds from :attr:`format_info.by_expr`
         and applies the corresponding ``exact_binop`` / ``exact_unop``
-        primitive.  For ``Round`` / ``RoundExact`` / ``Cast``, the
+        primitive.  For ``Round`` / ``Cast``, the
         unrounded value *is* the argument."""
         match e:
             case Add():
@@ -203,7 +203,7 @@ class _RoundElimInstance(DefaultTransformVisitor):
                 return exact_unop(
                     self.format_info.by_expr.get(e.arg), operator.neg,
                 )
-            case Round() | RoundExact() | Cast():
+            case Round() | Cast():
                 # The unrounded "value" of an explicit round node is
                 # the argument itself — the argument's post-round
                 # bound is the right input here because the explicit
@@ -234,7 +234,7 @@ class _RoundElimInstance(DefaultTransformVisitor):
         provides.
 
         Only meaningful for rounded ops (arithmetic + explicit
-        ``Round`` / ``RoundExact`` / ``Cast``); other expressions
+        ``Round`` / ``Cast``); other expressions
         don't carry a context-driven round, so the question is
         ill-posed and the answer is ``False``.
 
@@ -248,7 +248,7 @@ class _RoundElimInstance(DefaultTransformVisitor):
         Skipping these saves both pointless rewrites and the
         cascading storage failures."""
         if not isinstance(
-            e, (Add, Sub, Mul, Abs, Neg, Round, RoundExact, Cast),
+            e, (Add, Sub, Mul, Abs, Neg, Round, Cast),
         ):
             return False
         ctx = self._resolved_ctx(e)
@@ -294,7 +294,7 @@ class _RoundElimInstance(DefaultTransformVisitor):
     #
     # The decision logic lives in ``_visit_expr``.  At each node:
     #
-    #  - Eliminable ``Round`` / ``RoundExact`` / ``Cast`` → replace
+    #  - Eliminable ``Round`` / ``Cast`` → replace
     #    with the (recursively-rewritten) argument.  Pure node-level
     #    rewrite, no preamble required, works at any expression
     #    position (including inside ListComp / IfExpr branches).
@@ -305,10 +305,10 @@ class _RoundElimInstance(DefaultTransformVisitor):
     #    still be individually eliminable).
 
     def _visit_expr(self, e: Expr, ctx: Any) -> Expr:
-        # Round / RoundExact / Cast collapse: works regardless of
+        # Round / Cast collapse: works regardless of
         # ctx since it's a pure node-level rewrite (no preamble).
         if (
-            isinstance(e, (Round, RoundExact, Cast))
+            isinstance(e, (Round, Cast))
             and self._is_eliminable(e)
         ):
             return self._visit_expr(e.arg, ctx)
@@ -446,8 +446,8 @@ class RoundElim:
     """Rewrite expressions whose implicit rounding to the active
     context is provably an identity.  Arithmetic ops
     (``Add``/``Sub``/``Mul``/``Abs``/``Neg``) hoist into
-    ``with fp.REAL:`` preambles; explicit ``Round`` / ``RoundExact``
-    / ``Cast`` nodes collapse to their argument.
+    ``with fp.REAL:`` preambles; explicit ``Round`` / ``Cast``
+    nodes collapse to their argument.
 
     See the module docstring for the rewrite shape, the
     greedy-outermost policy, and the soundness invariants.

--- a/tests/unit/backend/cpp/test_emit_round.py
+++ b/tests/unit/backend/cpp/test_emit_round.py
@@ -1,12 +1,13 @@
 """
-Phase 5c tests for the cpp emitter — ``Round``, ``RoundExact``, ``Cast``.
+Phase 5c tests for the cpp emitter — ``Round`` and ``Cast``.
 
 - ``Round(arg)`` is a plain ``static_cast<target>(arg)``; the cast's
   rounding mode comes from Phase 5b's ``fesetround`` boundary.
-- ``RoundExact(arg)`` adds a runtime assertion that the round-trip
-  preserves the value; FP operands get a NaN-aware equality check.
-- ``Cast(arg)`` is a pure analysis annotation — emitted as the
-  identity (no ``static_cast``).
+- ``Cast(arg)`` (the node ``fp.cast`` and ``fp.round_exact`` both
+  parse to) is the same cast plus a runtime assertion that the
+  round-trip preserves the value; FP operands get a NaN-aware
+  equality check.  Casting to the same type is a guaranteed no-op,
+  so no cast and no assertion are emitted.
 """
 
 import fpy2 as fp
@@ -48,7 +49,8 @@ class TestRound:
 
 
 class TestRoundExact:
-    """Round + assert that the cast was lossless."""
+    """``fp.round_exact`` (which parses to a ``Cast`` node):
+    round + assert that the cast was lossless."""
 
     def test_fp_round_exact_uses_nan_aware_compare(self):
         @fp.fpy
@@ -106,9 +108,10 @@ class TestRoundExact:
 
 
 class TestCast:
-    """``Cast`` is the identity — no generated code."""
+    """``Cast`` rounds and asserts the result is exact — same
+    emission as ``round_exact`` (they parse to the same node)."""
 
-    def test_cast_emits_identity(self):
+    def test_cast_same_type_emits_identity(self):
         @fp.fpy
         def f(x: fp.Real) -> fp.Real:
             with fp.FP64:
@@ -118,9 +121,28 @@ class TestCast:
             f, ctx=fp.FP64,
             arg_types=[RealType(fp.FP64)],
         )
+        # Same-type cast is a guaranteed no-op.
         assert 'static_cast' not in out
         assert 'assert' not in out
         assert 'return x;' in out
+
+    def test_cast_cross_type_emits_assert(self):
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP32:
+                return fp.cast(x)
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP32,
+            arg_types=[RealType(fp.FP64)],
+        )
+        # Lossy-capable cast → cast bound to a temp + NaN-aware assert.
+        assert 'float __cpp_tmp1 = static_cast<float>(x);' in out
+        assert (
+            'assert(x == __cpp_tmp1 || '
+            '(std::isnan(x) && std::isnan(__cpp_tmp1)));'
+        ) in out
+        assert 'return __cpp_tmp1;' in out
 
 
 class TestRoundElimIntegration:
@@ -140,7 +162,7 @@ class TestRoundElimIntegration:
         optimization the emitter still produces the full
         assertion-protected cast (``static_cast<float>(1)`` bound
         to a temp + NaN-aware equality check).  With RoundElim the
-        ``RoundExact`` node collapses to its argument and the
+        ``Cast`` node collapses to its argument and the
         whole pattern disappears."""
 
         @fp.fpy

--- a/tests/unit/transform/test_round_elim.py
+++ b/tests/unit/transform/test_round_elim.py
@@ -8,7 +8,7 @@ tests assert three kinds of properties:
 
 1. **Structural shape** of the rewritten AST.  Counts of
    ``with fp.REAL:`` blocks, presence/absence of ``Round`` /
-   ``RoundExact`` / ``Cast`` nodes, presence/absence of arithmetic
+   ``Cast`` nodes, presence/absence of arithmetic
    ops under the original (non-REAL) context.
 2. **Negative checks**: unchanged inputs (REAL scope, ops that
    don't fit) compare via ``is_equiv`` against the original AST.
@@ -21,7 +21,7 @@ import fpy2 as fp
 
 from fpy2.ast.fpyast import (
     Abs, Add, Assign, BinaryOp, Cast, ContextStmt, ForeignVal, Mul, Neg, Round,
-    RoundExact, Sub, UnaryOp,
+    Sub, UnaryOp,
 )
 from fpy2.ast.visitor import DefaultVisitor
 from fpy2.number import REAL
@@ -33,7 +33,7 @@ from fpy2.transform import RoundElim
 
 
 _ROUNDED_ARITH = (Add, Sub, Mul, Abs, Neg)
-_ROUND_NODES = (Round, RoundExact, Cast)
+_ROUND_NODES = (Round, Cast)
 
 
 def _count_real_blocks(ast: fp.ast.FuncDef) -> int:
@@ -211,7 +211,7 @@ class TestArithmeticHoist:
 
 
 # ----------------------------------------------------------------------
-# Round / RoundExact / Cast collapse
+# Round / Cast collapse
 
 
 class TestRoundNodeCollapse:
@@ -258,7 +258,8 @@ class TestRoundNodeCollapse:
         assert _eval(out, f) == f()
 
     def test_round_exact_collapses_when_arg_fits(self):
-        """``fp.round_exact`` is identity-when-fits just like Round."""
+        """``fp.round_exact`` parses to a ``Cast`` node and is
+        identity-when-fits just like Round."""
 
         @fp.fpy
         def f():
@@ -266,7 +267,7 @@ class TestRoundNodeCollapse:
                 return fp.round_exact(1.0)
 
         out = RoundElim.apply(f.ast)
-        assert not _has_node(out, RoundExact)
+        assert not _has_node(out, Cast)
         assert _eval(out, f) == f()
 
 


### PR DESCRIPTION
Removes the `RoundExact` AST node, updates passes and tests