### PR TITLE
Add call graph builder

### DIFF
--- a/docs/source/ast.rst
+++ b/docs/source/ast.rst
@@ -47,6 +47,10 @@ Analyses
    :members:
    :show-inheritance:
 
+.. autoclass:: fpy2.analysis.CallGraph
+   :members:
+   :show-inheritance:
+
 .. autoclass:: fpy2.analysis.ContextInfer
    :members:
    :show-inheritance:

--- a/fpy2/analysis/__init__.py
+++ b/fpy2/analysis/__init__.py
@@ -8,6 +8,7 @@ from .array_size import (
     ListSize,
     TupleSize,
 )
+from .call_graph import CallGraph, CallGraphAnalysis, CallGraphError
 from .context_infer import ContextInfer, ContextAnalysis, ContextInferError
 from .context_use import (
     ContextUse, ContextUseAnalysis,

--- a/fpy2/analysis/call_graph.py
+++ b/fpy2/analysis/call_graph.py
@@ -97,6 +97,86 @@ _GRAY = 1   # on the current DFS stack (in progress)
 _BLACK = 2  # fully visited
 
 
+class _CallGraphInstance:
+    """Builds the call graph via a three-color DFS, accumulating the
+    edge maps and a leaves-first (post-order) traversal order."""
+
+    func: FuncDef
+    nodes: set[FuncDef]
+    callees: dict[FuncDef, list[FuncDef]]
+    callers: dict[FuncDef, list[FuncDef]]
+    call_sites: dict[FuncDef, list[Call]]
+    order: list[FuncDef]
+
+    def __init__(self, func: FuncDef):
+        self.func = func
+        self.nodes = set()
+        self.callees = {}
+        self.callers = {}
+        self.call_sites = {}
+        self.order = []
+        # DFS bookkeeping.
+        self._color: dict[FuncDef, int] = {}
+        self._stack: list[FuncDef] = []
+        # Memoized per-body call collection (a callee reached from
+        # multiple sites is only scanned once).
+        self._body_calls: dict[FuncDef, list[Call]] = {}
+
+    def _calls_in(self, fdef: FuncDef) -> list[Call]:
+        if fdef not in self._body_calls:
+            self._body_calls[fdef] = _CallCollector().collect(fdef)
+        return self._body_calls[fdef]
+
+    def _visit(self, fdef: FuncDef):
+        self._color[fdef] = _GRAY
+        self._stack.append(fdef)
+        self.nodes.add(fdef)
+        self.callees.setdefault(fdef, [])
+        self.callers.setdefault(fdef, [])
+        self.call_sites.setdefault(fdef, [])
+
+        seen: set[FuncDef] = set()
+        for call in self._calls_in(fdef):
+            fn = call.fn
+            if not isinstance(fn, Function):
+                # primitive / builtin / context constructor /
+                # unresolved — an external leaf, not a graph node.
+                continue
+            callee = fn.ast
+            self.call_sites[fdef].append(call)
+            if callee in seen:
+                continue
+            seen.add(callee)
+            self.callees[fdef].append(callee)
+            self.callers.setdefault(callee, []).append(fdef)
+
+            c = self._color.get(callee)
+            if c == _GRAY:
+                cycle = self._stack[self._stack.index(callee):] + [callee]
+                path = ' -> '.join(f.name for f in cycle)
+                raise CallGraphError(
+                    f'recursion is not supported in FPy, but the call '
+                    f'graph contains a cycle: {path}'
+                )
+            elif c is None:
+                self._visit(callee)
+
+        self._stack.pop()
+        self._color[fdef] = _BLACK
+        self.order.append(fdef)
+
+    def analyze(self) -> CallGraphAnalysis:
+        self._visit(self.func)
+        return CallGraphAnalysis(
+            root=self.func,
+            nodes=self.nodes,
+            callees=self.callees,
+            callers=self.callers,
+            call_sites=self.call_sites,
+            order=self.order,
+        )
+
+
 class CallGraph:
     """Call graph analysis.
 
@@ -109,69 +189,4 @@ class CallGraph:
         """Build the call graph rooted at *func*."""
         if not isinstance(func, FuncDef):
             raise TypeError(f'Expected `FuncDef`, got {type(func)} for {func}')
-
-        nodes: set[FuncDef] = set()
-        callees: dict[FuncDef, list[FuncDef]] = {}
-        callers: dict[FuncDef, list[FuncDef]] = {}
-        call_sites: dict[FuncDef, list[Call]] = {}
-        order: list[FuncDef] = []
-
-        color: dict[FuncDef, int] = {}
-        stack: list[FuncDef] = []
-        # Memoized per-body call collection (a callee reached from
-        # multiple sites is only scanned once).
-        body_calls: dict[FuncDef, list[Call]] = {}
-
-        def calls_in(fdef: FuncDef) -> list[Call]:
-            if fdef not in body_calls:
-                body_calls[fdef] = _CallCollector().collect(fdef)
-            return body_calls[fdef]
-
-        def visit(fdef: FuncDef):
-            color[fdef] = _GRAY
-            stack.append(fdef)
-            nodes.add(fdef)
-            callees.setdefault(fdef, [])
-            callers.setdefault(fdef, [])
-            call_sites.setdefault(fdef, [])
-
-            seen: set[FuncDef] = set()
-            for call in calls_in(fdef):
-                fn = call.fn
-                if not isinstance(fn, Function):
-                    # primitive / builtin / context constructor /
-                    # unresolved — an external leaf, not a graph node.
-                    continue
-                callee = fn.ast
-                call_sites[fdef].append(call)
-                if callee in seen:
-                    continue
-                seen.add(callee)
-                callees[fdef].append(callee)
-                callers.setdefault(callee, []).append(fdef)
-
-                c = color.get(callee)
-                if c == _GRAY:
-                    cycle = stack[stack.index(callee):] + [callee]
-                    path = ' -> '.join(f.name for f in cycle)
-                    raise CallGraphError(
-                        f'recursion is not supported in FPy, but the call '
-                        f'graph contains a cycle: {path}'
-                    )
-                elif c is None:
-                    visit(callee)
-
-            stack.pop()
-            color[fdef] = _BLACK
-            order.append(fdef)
-
-        visit(func)
-
-        return CallGraphAnalysis(
-            root=func,
-            nodes=nodes,
-            callees=callees,
-            callers=callers,
-            call_sites=call_sites,
-            order=order,
-        )
+        return _CallGraphInstance(func).analyze()

--- a/fpy2/analysis/call_graph.py
+++ b/fpy2/analysis/call_graph.py
@@ -1,0 +1,177 @@
+"""
+Call graph analysis.
+
+Builds the call graph of a :class:`~fpy2.ast.FuncDef` and everything it
+transitively calls.  The graph is keyed on ``FuncDef`` objects (by
+identity); each edge ``caller -> callee`` corresponds to a :class:`Call`
+whose ``fn`` resolves to a user-defined :class:`~fpy2.function.Function`.
+Calls to primitives, context constructors, or builtins have no FPy body
+to recurse into, so they are treated as external leaves and excluded
+from the graph.
+
+FPy does not support recursion, so the call graph is a DAG.  This
+invariant is *enforced*: a direct (``f -> f``) or mutual
+(``a -> b -> a``) cycle raises :class:`CallGraphError`.  Downstream
+analyses may therefore assume acyclicity and a valid topological order.
+(The parser already rejects forward references, so a cycle cannot arise
+through ``@fpy`` decoration; the cycle check is a guard for
+programmatically-built ASTs, e.g. FPCore import or AST transforms.)
+
+The analysis exposes a *leaves-first* iteration order (callees before
+callers, the root last), which is the natural order for bottom-up
+analyses that need a callee's result before processing its callers.
+"""
+
+import dataclasses
+
+from ..ast import *
+from ..function import Function
+
+
+class CallGraphError(Exception):
+    """Raised when the call graph is not a DAG (FPy forbids recursion)."""
+    pass
+
+
+class _CallCollector(DefaultVisitor):
+    """Collects every :class:`Call` in a single function body, in source
+    order (outer calls before the calls nested in their arguments).  Does
+    not cross into callees — it walks one ``FuncDef`` only."""
+
+    calls: list[Call]
+
+    def __init__(self):
+        self.calls = []
+
+    def _visit_call(self, e: Call, ctx: None):
+        self.calls.append(e)
+        super()._visit_call(e, ctx)
+
+    def collect(self, func: FuncDef) -> list[Call]:
+        self.calls = []
+        self._visit_function(func, None)
+        return self.calls
+
+
+@dataclasses.dataclass
+class CallGraphAnalysis:
+    """Result of a :class:`CallGraph` analysis.
+
+    All maps are keyed by ``FuncDef`` identity and have an entry for
+    every node in :attr:`nodes` (including the root and leaves)."""
+
+    root: FuncDef
+    """the function the graph was built from"""
+    nodes: set[FuncDef]
+    """every function reachable from the root, including the root"""
+    callees: dict[FuncDef, list[FuncDef]]
+    """direct callees of each function, deduplicated, in source order"""
+    callers: dict[FuncDef, list[FuncDef]]
+    """direct callers of each function, deduplicated, in discovery order"""
+    call_sites: dict[FuncDef, list[Call]]
+    """every ``Call`` to a user-defined function in each body (not deduped)"""
+    order: list[FuncDef]
+    """leaves-first order: a function appears after all of its callees"""
+
+    def callees_of(self, func: FuncDef) -> list[FuncDef]:
+        """Direct callees of *func*."""
+        return self.callees[func]
+
+    def callers_of(self, func: FuncDef) -> list[FuncDef]:
+        """Direct callers of *func*."""
+        return self.callers[func]
+
+    def __iter__(self):
+        """Iterate functions leaves-first (callees before callers)."""
+        return iter(self.order)
+
+    def __len__(self):
+        return len(self.nodes)
+
+    def __contains__(self, func: object) -> bool:
+        return func in self.nodes
+
+
+# DFS colors for cycle detection.
+_GRAY = 1   # on the current DFS stack (in progress)
+_BLACK = 2  # fully visited
+
+
+class CallGraph:
+    """Call graph analysis.
+
+    Builds the DAG of functions transitively called from a root
+    ``FuncDef``.  Raises :class:`CallGraphError` on recursion.
+    """
+
+    @staticmethod
+    def analyze(func: FuncDef) -> CallGraphAnalysis:
+        """Build the call graph rooted at *func*."""
+        if not isinstance(func, FuncDef):
+            raise TypeError(f'Expected `FuncDef`, got {type(func)} for {func}')
+
+        nodes: set[FuncDef] = set()
+        callees: dict[FuncDef, list[FuncDef]] = {}
+        callers: dict[FuncDef, list[FuncDef]] = {}
+        call_sites: dict[FuncDef, list[Call]] = {}
+        order: list[FuncDef] = []
+
+        color: dict[FuncDef, int] = {}
+        stack: list[FuncDef] = []
+        # Memoized per-body call collection (a callee reached from
+        # multiple sites is only scanned once).
+        body_calls: dict[FuncDef, list[Call]] = {}
+
+        def calls_in(fdef: FuncDef) -> list[Call]:
+            if fdef not in body_calls:
+                body_calls[fdef] = _CallCollector().collect(fdef)
+            return body_calls[fdef]
+
+        def visit(fdef: FuncDef):
+            color[fdef] = _GRAY
+            stack.append(fdef)
+            nodes.add(fdef)
+            callees.setdefault(fdef, [])
+            callers.setdefault(fdef, [])
+            call_sites.setdefault(fdef, [])
+
+            seen: set[FuncDef] = set()
+            for call in calls_in(fdef):
+                fn = call.fn
+                if not isinstance(fn, Function):
+                    # primitive / builtin / context constructor /
+                    # unresolved — an external leaf, not a graph node.
+                    continue
+                callee = fn.ast
+                call_sites[fdef].append(call)
+                if callee in seen:
+                    continue
+                seen.add(callee)
+                callees[fdef].append(callee)
+                callers.setdefault(callee, []).append(fdef)
+
+                c = color.get(callee)
+                if c == _GRAY:
+                    cycle = stack[stack.index(callee):] + [callee]
+                    path = ' -> '.join(f.name for f in cycle)
+                    raise CallGraphError(
+                        f'recursion is not supported in FPy, but the call '
+                        f'graph contains a cycle: {path}'
+                    )
+                elif c is None:
+                    visit(callee)
+
+            stack.pop()
+            color[fdef] = _BLACK
+            order.append(fdef)
+
+        visit(func)
+
+        return CallGraphAnalysis(
+            root=func,
+            nodes=nodes,
+            callees=callees,
+            callers=callers,
+            call_sites=call_sites,
+            order=order,
+        )

--- a/fpy2/analysis/call_graph.py
+++ b/fpy2/analysis/call_graph.py
@@ -45,7 +45,13 @@ class _CallCollector(DefaultVisitor):
 
     def _visit_call(self, e: Call, ctx: None):
         self.calls.append(e)
+        # ``DefaultVisitor._visit_call`` only walks positional args, so
+        # visit keyword-argument values explicitly — a call nested in a
+        # kwarg value (and any cycle through it) would otherwise be
+        # missed from the graph and the acyclicity guard.
         super()._visit_call(e, ctx)
+        for _, kwarg in e.kwargs:
+            self._visit_expr(kwarg, ctx)
 
     def collect(self, func: FuncDef) -> list[Call]:
         self.calls = []

--- a/fpy2/analysis/call_graph.py
+++ b/fpy2/analysis/call_graph.py
@@ -81,6 +81,71 @@ class CallGraphAnalysis:
         """Direct callers of *func*."""
         return self.callers[func]
 
+    def format(self) -> str:
+        """An indented-tree rendering rooted at :attr:`root`, callees
+        nested under their callers.  A function reached from more than
+        one caller is expanded once; later occurrences are marked
+        ``(*)`` and not re-expanded (keeping shared subtrees compact —
+        and the output finite even if a cycle ever slipped through)."""
+        lines: list[str] = []
+        revisited = self._format_node(self.root, '', '', True, lines, set())
+        if revisited:
+            lines.append('')
+            lines.append('(*) = callees shown above')
+        return '\n'.join(lines)
+
+    def _format_node(
+        self,
+        func: FuncDef,
+        prefix: str,
+        connector: str,
+        is_root: bool,
+        lines: list[str],
+        seen: set[FuncDef],
+    ) -> bool:
+        """Append the subtree rooted at *func* to *lines*.  Returns
+        whether any node in the subtree was a revisit, so
+        :meth:`format` knows whether to print the ``(*)`` legend."""
+        revisit = func in seen
+        marker = ' (*)' if revisit else ''
+        lines.append(f'{prefix}{connector}{func.name}{marker}')
+        if revisit:
+            return True
+        seen.add(func)
+
+        # Children continue the vertical line unless this node was the
+        # last of its siblings (``└─``), in which case the column is
+        # blank below it.  The root's children start at column zero.
+        child_prefix = '' if is_root else prefix + (
+            '   ' if connector == '└─ ' else '│  '
+        )
+        any_revisit = False
+        callees = self.callees[func]
+        for i, callee in enumerate(callees):
+            last = i == len(callees) - 1
+            child_connector = '└─ ' if last else '├─ '
+            if self._format_node(
+                callee, child_prefix, child_connector, False, lines, seen,
+            ):
+                any_revisit = True
+        return any_revisit
+
+    def dot(self) -> str:
+        """A Graphviz ``digraph`` rendering, pipe-able to ``dot``.
+
+        Nodes are given stable ids (``n0``, ``n1``, … in leaves-first
+        order) with the function name as the label, so two distinct
+        functions that happen to share a name stay distinct."""
+        ids = {func: f'n{i}' for i, func in enumerate(self.order)}
+        lines = ['digraph call_graph {']
+        for func in self.order:
+            lines.append(f'  {ids[func]} [label="{func.name}"];')
+        for func in self.order:
+            for callee in self.callees[func]:
+                lines.append(f'  {ids[func]} -> {ids[callee]};')
+        lines.append('}')
+        return '\n'.join(lines)
+
     def __iter__(self):
         """Iterate functions leaves-first (callees before callers)."""
         return iter(self.order)

--- a/fpy2/analysis/context_infer.py
+++ b/fpy2/analysis/context_infer.py
@@ -14,6 +14,7 @@ from ..primitive import Primitive
 from ..utils import Gensym, NamedId, Unionfind
 
 from ..types import *
+from .call_graph import CallGraph, CallGraphError
 from .define_use import DefineUse, DefineUseAnalysis, Definition, DefSite
 from .type_infer import TypeInfer, TypeAnalysis
 from .partial_eval import PartialEval, PartialEvalInfo
@@ -495,8 +496,9 @@ class ContextTypeInferInstance(Visitor):
 
                 return fn_ty.return_type
             case Function():
-                # calling a function
-                # TODO: guard against recursion
+                # calling a function.  Recursion can't loop here:
+                # `ContextInfer.infer` runs a `CallGraph` acyclicity
+                # guard at its entry.
                 from ..transform import ConstFold, Monomorphize
 
                 # get argument types
@@ -964,6 +966,15 @@ class ContextInfer:
             raise TypeError(f'expected a \'FuncDef\', got {func}')
         if not isinstance(unsafe_cast_int, bool):
             raise TypeError(f'expected a \'bool\' for unsafe_cast_int, got {unsafe_cast_int}')
+
+        # Guard against recursion: FPy forbids it, and the lazy callee
+        # analysis in `_visit_call` would otherwise recurse forever on a
+        # cyclic call graph.  `CallGraph` raises on any cycle reachable
+        # from `func`, so this fires before the body is walked.
+        try:
+            CallGraph.analyze(func)
+        except CallGraphError as e:
+            raise ContextInferError(str(e)) from e
 
         if def_use is None:
             def_use = DefineUse.analyze(func)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -146,6 +146,7 @@ from ...types import (
 )
 
 from ..array_size import ArraySizeAnalysis, ArraySizeInfer, ListSize
+from ..call_graph import CallGraph, CallGraphError
 from ..context_use import ContextUse, ContextUseAnalysis, ContextScope, ContextUseSite
 from ..define_use import DefineUse, DefineUseAnalysis
 from ..reaching_defs import PhiDef, Definition, DefSite
@@ -1252,10 +1253,11 @@ class _FormatInferInstance(Visitor):
         scopes inside the callee resolve correctly and parameter
         formats get pinned.
 
-        Recursion assumes no cycles in the call graph (a separate
-        analysis is expected to enforce that pre-condition).  Returns
-        ``None`` when the callee isn't a concrete :class:`Function`
-        — the caller falls back to a static type bound.
+        Recursion assumes no cycles in the call graph — enforced by
+        the :class:`CallGraph` acyclicity check at the public
+        :meth:`FormatInfer.analyze` entry.  Returns ``None`` when the
+        callee isn't a concrete :class:`Function` — the caller falls
+        back to a static type bound.
         """
         fn = e.fn
         if not isinstance(fn, Function):
@@ -1702,9 +1704,10 @@ class FormatInfer:
         :class:`FormatInfer` itself re-runs per instantiation so each
         callee sees the caller's active rounding context.
 
-        The call graph is assumed to be acyclic; recursion (direct
-        or mutual) is not handled here and is expected to be ruled
-        out by a separate analysis.
+        The call graph must be acyclic; recursion (direct or mutual)
+        is not handled by the per-call-site sub-analysis.  A
+        :class:`CallGraph` acyclicity check runs at this entry and
+        raises :class:`CallGraphError` if a cycle is reachable.
 
         Args:
             func:        The :class:`FuncDef` AST node to analyse.
@@ -1752,9 +1755,19 @@ class FormatInfer:
 
         Raises:
             TypeError: If *func* is not a :class:`FuncDef`.
+            CallGraphError: If the call graph reachable from *func*
+                contains a cycle (FPy forbids recursion).
         """
         if not isinstance(func, FuncDef):
             raise TypeError(f"expected a 'FuncDef', got {type(func)}")
+
+        # Guard against recursion: the per-call-site sub-analysis in
+        # `_analyze_callee` would otherwise diverge on a cyclic call
+        # graph.  `CallGraph` raises on any cycle reachable from `func`.
+        # The recursive descents go through `_FormatInferInstance`
+        # directly, not this public entry, so the check runs exactly
+        # once per top-level analysis — before any instance is built.
+        CallGraph.analyze(func)
 
         if pre_cache is None:
             pre_cache = PreAnalysisCache()

--- a/fpy2/analysis/purity.py
+++ b/fpy2/analysis/purity.py
@@ -7,6 +7,7 @@ from ..function import Function
 from ..number import Context
 from ..primitive import Primitive
 
+from .call_graph import CallGraph
 from .define_use import AssignDef, DefineUse, DefineUseAnalysis
 
 class _ImpureError(Exception):
@@ -87,6 +88,10 @@ class Purity:
         """
         if not isinstance(func, FuncDef):
             raise TypeError(f'Expected `FuncDef`, got {type(func)} for {func}')
+        # Guard against recursion: `_visit_call` recurses into callees,
+        # which would loop forever on a cyclic call graph.  `CallGraph`
+        # raises `CallGraphError` on any cycle reachable from `func`.
+        CallGraph.analyze(func)
         if def_use is None:
             def_use = DefineUse.analyze(func)
         return _Purity(func, def_use).apply()

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -10,6 +10,7 @@ from ..primitive import Primitive
 from ..utils import Gensym, NamedId, Unionfind
 
 from ..types import *
+from .call_graph import CallGraph, CallGraphError
 from .define_use import DefineUse, DefineUseAnalysis, Definition, DefSite
 
 #####################################################################
@@ -447,8 +448,9 @@ class _TypeInferInstance(Visitor):
 
                 # type check the function and instantiate
                 if e.fn.sig is None:
-                    # type checking not run
-                    # TODO: guard against recursion
+                    # type checking not run.  Recursion can't loop here:
+                    # `TypeInfer.check` runs a `CallGraph` acyclicity
+                    # guard at its entry.
                     fn_info = TypeInfer.check(e.fn.ast)
                     fn_ty = fn_info.fn_type
                 else:
@@ -808,6 +810,15 @@ class TypeInfer:
         """
         if not isinstance(func, FuncDef):
             raise TypeError(f'expected a \'FuncDef\', got {func}')
+
+        # Guard against recursion: FPy forbids it, and the lazy callee
+        # analysis in `_visit_call` would otherwise recurse forever on a
+        # cyclic call graph.  `CallGraph` raises on any cycle reachable
+        # from `func`, so this fires before the body is walked.
+        try:
+            CallGraph.analyze(func)
+        except CallGraphError as e:
+            raise TypeInferError(str(e)) from e
 
         if def_use is None:
             def_use = DefineUse.analyze(func)

--- a/fpy2/transform/func_inline.py
+++ b/fpy2/transform/func_inline.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from ..analysis import (
-    AssignDef, DefineUse, DefineUseAnalysis, Reachability, ReachingDefs,
-    SyntaxCheck,
+    AssignDef, CallGraph, DefineUse, DefineUseAnalysis, Reachability,
+    ReachingDefs, SyntaxCheck,
 )
 from ..ast.fpyast import *
 from ..ast.visitor import DefaultTransformVisitor
@@ -46,6 +46,7 @@ class _FuncInline(DefaultTransformVisitor):
     func: FuncDef
     def_use: DefineUseAnalysis
     funcs: set[FuncDef] | None
+    inlined: dict[FuncDef, FuncDef]
     recursive: bool
 
     gensym: Gensym
@@ -57,12 +58,21 @@ class _FuncInline(DefaultTransformVisitor):
         func: FuncDef,
         def_use: DefineUseAnalysis,
         funcs: set[FuncDef] | None,
+        inlined: dict[FuncDef, FuncDef] | None = None,
         recursive: bool = True
     ):
         self.func = func
         self.def_use = def_use
         self.funcs = funcs
+        # Cache of fully-inlined callee bodies, keyed by callee
+        # ``FuncDef``.  ``_visit_call`` reuses a cached body across call
+        # sites instead of re-inlining the whole callee subtree each
+        # time.  ``FuncInline.apply`` may pre-populate it in leaves-first
+        # order (so every lookup is a hit); otherwise it fills lazily on
+        # first use.  Either way it is never re-built per call site.
+        self.inlined = {} if inlined is None else inlined
         self.recursive = recursive
+
         self.gensym = Gensym(self.def_use.names())
         self.free_vars = set(func.free_vars)
         self.env = func.env.copy()
@@ -75,10 +85,17 @@ class _FuncInline(DefaultTransformVisitor):
             # not a candidate for inlining
             return super()._visit_call(e, ctx)
 
-        # recursively inline the callee function body
-        # ASSUME: no recursive calls, i.e. the callee function does not call itself directly or indirectly
+        # Inline the callee body.  Acyclicity is guaranteed by the
+        # `CallGraph` guard in `FuncInline.apply`, so this terminates.
         if self.recursive:
-            ast = FuncInline.apply(e.fn.ast, recursive=True)
+            if e.fn.ast in self.inlined:
+                # cached
+                ast = self.inlined[e.fn.ast]
+            else:
+                # first time we see this callee, inline it and cache the result
+                ast = FuncInline.apply(e.fn.ast, recursive=True)
+                self.inlined[e.fn.ast] = ast
+
             def_use = DefineUse.analyze(ast)
             self.gensym.reserve(*def_use.names())
         else:
@@ -184,17 +201,38 @@ class FuncInline:
     ) -> FuncDef:
         """
         Applies function inlining to `func` returning the transformed function.
+
+        Raises `CallGraphError` if the call graph reachable from `func`
+        contains a cycle (FPy forbids recursion; inlining a recursive
+        call would not terminate).
         """
         if not isinstance(func, FuncDef):
             raise TypeError(f'expected a \'FuncDef\', got `{func}`')
-        if def_use is None:
-            def_use = DefineUse.analyze(func)
+
+        # Recursion guard — see the method docstring.  Also gives us
+        # the leaves-first order for the bottom-up path below.
+        cg = CallGraph.analyze(func)
 
         if funcs is not None:
             funcs = set(funcs)
 
-        inst = _FuncInline(func, def_use, funcs, recursive=recursive)
-        func = inst.apply()
+        if recursive and funcs is None:
+            # Bottom-up: inline each reachable function exactly once in
+            # leaves-first order, reusing cached results, instead of
+            # re-inlining the whole callee subtree at every call site.
+            inlined: dict[FuncDef, FuncDef] = {}
+            for fdef in cg.order:
+                fdef_du = DefineUse.analyze(fdef)
+                inlined[fdef] = _FuncInline(
+                    fdef, fdef_du, None, recursive=True, inlined=inlined,
+                ).apply()
+            result = inlined[func]
+        else:
+            # One-level inlining, or selective inlining via `funcs`:
+            # keep the per-call-site strategy.
+            if def_use is None:
+                def_use = DefineUse.analyze(func)
+            result = _FuncInline(func, def_use, funcs, recursive=recursive).apply()
 
-        SyntaxCheck.check(func, ignore_unknown=True)
-        return func
+        SyntaxCheck.check(result, ignore_unknown=True)
+        return result

--- a/tests/unit/analysis/test_call_graph.py
+++ b/tests/unit/analysis/test_call_graph.py
@@ -1,0 +1,230 @@
+"""
+Tests for the :class:`fpy2.analysis.CallGraph` analysis.
+"""
+
+import pytest
+
+import fpy2 as fp
+
+from fpy2.analysis import CallGraph, CallGraphError
+from fpy2.ast import DefaultVisitor
+
+
+def _cg(func):
+    """Build the call graph from a decorated ``Function``."""
+    return CallGraph.analyze(func.ast)
+
+
+def _first_call(func):
+    """The first ``Call`` node in a decorated function's body."""
+    calls = []
+
+    class _C(DefaultVisitor):
+        def _visit_call(self, e, ctx):
+            calls.append(e)
+            super()._visit_call(e, ctx)
+
+    _C()._visit_function(func.ast, None)
+    return calls[0]
+
+
+class TestStructure:
+    """Nodes, edges, and reverse edges."""
+
+    def test_single_function_no_calls(self):
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        cg = _cg(f)
+        assert cg.nodes == {f.ast}
+        assert cg.callees_of(f.ast) == []
+        assert cg.callers_of(f.ast) == []
+        assert cg.order == [f.ast]
+        assert len(cg) == 1
+        assert f.ast in cg
+
+    def test_linear_chain(self):
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return c(x) * 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) - 1
+
+        cg = _cg(a)
+        assert cg.nodes == {a.ast, b.ast, c.ast}
+        assert cg.callees_of(a.ast) == [b.ast]
+        assert cg.callees_of(b.ast) == [c.ast]
+        assert cg.callees_of(c.ast) == []
+        assert cg.callers_of(c.ast) == [b.ast]
+        assert cg.callers_of(b.ast) == [a.ast]
+        assert cg.callers_of(a.ast) == []
+
+    def test_diamond(self):
+        @fp.fpy
+        def d(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return d(x) * 2
+
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return d(x) - 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) + c(x)
+
+        cg = _cg(a)
+        assert cg.nodes == {a.ast, b.ast, c.ast, d.ast}
+        # callees in source order
+        assert cg.callees_of(a.ast) == [b.ast, c.ast]
+        # d reached from both b and c, deduplicated; both recorded as callers
+        assert set(cg.callers_of(d.ast)) == {b.ast, c.ast}
+
+    def test_duplicate_calls_dedup_in_callees_but_not_sites(self):
+        @fp.fpy
+        def g(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return g(x) * g(x + 1)
+
+        cg = _cg(f)
+        # one edge, two call sites
+        assert cg.callees_of(f.ast) == [g.ast]
+        assert len(cg.call_sites[f.ast]) == 2
+
+    def test_nested_call_in_argument_discovered(self):
+        @fp.fpy
+        def inner(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def outer(x: fp.Real) -> fp.Real:
+            return inner(inner(x))
+
+        cg = _cg(outer)
+        assert cg.nodes == {outer.ast, inner.ast}
+        assert cg.callees_of(outer.ast) == [inner.ast]
+        assert len(cg.call_sites[outer.ast]) == 2
+
+
+class TestLeavesFirst:
+    """The ``order`` field / iteration is callee-before-caller."""
+
+    def test_order_chain(self):
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return c(x) * 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) - 1
+
+        cg = _cg(a)
+        assert cg.order == [c.ast, b.ast, a.ast]
+        # iteration matches order
+        assert list(cg) == [c.ast, b.ast, a.ast]
+
+    def test_order_respects_dependencies_in_diamond(self):
+        @fp.fpy
+        def d(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return d(x) * 2
+
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return d(x) - 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) + c(x)
+
+        order = _cg(a).order
+        # every callee precedes its caller
+        assert order.index(d.ast) < order.index(b.ast)
+        assert order.index(d.ast) < order.index(c.ast)
+        assert order.index(b.ast) < order.index(a.ast)
+        assert order.index(c.ast) < order.index(a.ast)
+        assert order[-1] is a.ast
+
+
+class TestExternalLeaves:
+    """Primitives / builtins / context constructors are not nodes."""
+
+    def test_primitive_call_excluded(self):
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return fp.sqrt(x)
+
+        cg = _cg(f)
+        assert cg.nodes == {f.ast}
+        assert cg.callees_of(f.ast) == []
+        assert cg.call_sites[f.ast] == []
+
+
+class TestRecursion:
+    """FPy forbids recursion — cycles raise ``CallGraphError``.
+
+    The parser already rejects forward references, so a cycle can't be
+    built through ``@fp.fpy`` decoration; we construct one by patching a
+    ``Call.fn`` to exercise the defensive guard (the case that matters
+    for programmatically-built ASTs, e.g. FPCore import or transforms).
+    """
+
+    def test_direct_recursion(self):
+        @fp.fpy
+        def leaf(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def m(x: fp.Real) -> fp.Real:
+            return leaf(x)
+
+        # Make `m` call itself: m -> m.
+        _first_call(m).fn = m
+
+        with pytest.raises(CallGraphError):
+            _cg(m)
+
+    def test_mutual_recursion(self):
+        @fp.fpy
+        def leaf(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return leaf(x)
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x)
+
+        # Redirect b's call from `leaf` to `a`, closing a -> b -> a.
+        _first_call(b).fn = a
+
+        with pytest.raises(CallGraphError):
+            _cg(a)
+
+
+class TestInputValidation:
+    def test_rejects_non_funcdef(self):
+        with pytest.raises(TypeError):
+            CallGraph.analyze('not a FuncDef')  # type: ignore[arg-type]

--- a/tests/unit/analysis/test_call_graph.py
+++ b/tests/unit/analysis/test_call_graph.py
@@ -118,6 +118,28 @@ class TestStructure:
         assert cg.callees_of(outer.ast) == [inner.ast]
         assert len(cg.call_sites[outer.ast]) == 2
 
+    def test_nested_call_in_kwarg_value_discovered(self):
+        # ``DefaultVisitor._visit_call`` only walks positional args; the
+        # collector must also descend into keyword-argument values, or a
+        # callee reached only through a kwarg is missed entirely.
+        @fp.fpy
+        def leaf(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def mid(x: fp.Real) -> fp.Real:
+            return x * 2
+
+        @fp.fpy
+        def top(x: fp.Real) -> fp.Real:
+            # `leaf` is reachable ONLY through the kwarg value.
+            return mid(x=leaf(x))
+
+        cg = _cg(top)
+        assert cg.nodes == {top.ast, mid.ast, leaf.ast}
+        assert cg.callees_of(top.ast) == [mid.ast, leaf.ast]
+        assert len(cg.call_sites[top.ast]) == 2
+
 
 class TestLeavesFirst:
     """The ``order`` field / iteration is callee-before-caller."""

--- a/tests/unit/analysis/test_call_graph.py
+++ b/tests/unit/analysis/test_call_graph.py
@@ -166,6 +166,91 @@ class TestLeavesFirst:
         assert order[-1] is a.ast
 
 
+class TestFormat:
+    """``format()`` renders an indented tree rooted at the entry."""
+
+    def test_single_node(self):
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        assert _cg(f).format() == 'f'
+
+    def test_chain(self):
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return c(x) * 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) - 1
+
+        assert _cg(a).format() == 'a\n└─ b\n   └─ c'
+
+    def test_diamond_marks_revisit_and_legend(self):
+        @fp.fpy
+        def d(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return d(x) * 2
+
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return d(x) - 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) + c(x)
+
+        assert _cg(a).format() == (
+            'a\n'
+            '├─ b\n'
+            '│  └─ d\n'
+            '└─ c\n'
+            '   └─ d (*)\n'
+            '\n'
+            '(*) = callees shown above'
+        )
+
+
+class TestDot:
+    """``dot()`` renders a Graphviz digraph with collision-safe ids."""
+
+    def test_diamond(self):
+        @fp.fpy
+        def d(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return d(x) * 2
+
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return d(x) - 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) + c(x)
+
+        out = _cg(a).dot()
+        assert out.startswith('digraph call_graph {')
+        assert out.rstrip().endswith('}')
+        # one node declaration per function
+        assert out.count('[label=') == 4
+        # one edge per (deduplicated) call-graph edge: a->b, a->c, b->d, c->d
+        assert out.count(' -> ') == 4
+        # labels are the function names
+        for name in ('a', 'b', 'c', 'd'):
+            assert f'[label="{name}"]' in out
+
+
 class TestExternalLeaves:
     """Primitives / builtins / context constructors are not nodes."""
 

--- a/tests/unit/analysis/test_recursion_guard.py
+++ b/tests/unit/analysis/test_recursion_guard.py
@@ -13,10 +13,11 @@ import pytest
 import fpy2 as fp
 
 from fpy2.analysis import (
-    CallGraphError, ContextInfer, ContextInferError, FormatInfer,
+    CallGraphError, ContextInfer, ContextInferError, FormatInfer, Purity,
     TypeInfer, TypeInferError,
 )
 from fpy2.ast import DefaultVisitor
+from fpy2.transform import FuncInline
 
 
 def _first_call(func):
@@ -103,3 +104,30 @@ class TestFormatInferGuard:
 
         # no exception
         FormatInfer.analyze(f.ast)
+
+
+class TestPurityGuard:
+    def test_recursion_raises_call_graph_error(self):
+        m = _make_self_cycle()
+        # Purity returns a bool; a structural cycle is an error, not a
+        # purity verdict — CallGraphError propagates.
+        with pytest.raises(CallGraphError):
+            Purity.analyze(m.ast)
+
+    def test_acyclic_multi_function_still_analyzes(self):
+        @fp.fpy
+        def g(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return g(x) * 2
+
+        assert Purity.analyze(f.ast) is True
+
+
+class TestFuncInlineGuard:
+    def test_recursion_raises_call_graph_error(self):
+        m = _make_self_cycle()
+        with pytest.raises(CallGraphError):
+            FuncInline.apply(m.ast)

--- a/tests/unit/analysis/test_recursion_guard.py
+++ b/tests/unit/analysis/test_recursion_guard.py
@@ -1,0 +1,105 @@
+"""
+The recursion guard shared by ``TypeInfer`` and ``ContextInfer``.
+
+FPy forbids recursion, so both analyses run a :class:`CallGraph`
+acyclicity check at their entry point before lazily descending into
+callees.  The parser rejects forward references, so a cycle can't be
+built through ``@fp.fpy`` decoration; we patch a ``Call.fn`` to close
+one (the case that matters for programmatically-built ASTs).
+"""
+
+import pytest
+
+import fpy2 as fp
+
+from fpy2.analysis import (
+    CallGraphError, ContextInfer, ContextInferError, FormatInfer,
+    TypeInfer, TypeInferError,
+)
+from fpy2.ast import DefaultVisitor
+
+
+def _first_call(func):
+    """The first ``Call`` node in a decorated function's body."""
+    calls = []
+
+    class _C(DefaultVisitor):
+        def _visit_call(self, e, ctx):
+            calls.append(e)
+            super()._visit_call(e, ctx)
+
+    _C()._visit_function(func.ast, None)
+    return calls[0]
+
+
+def _make_self_cycle():
+    @fp.fpy
+    def leaf(x: fp.Real) -> fp.Real:
+        return x + 1
+
+    @fp.fpy
+    def m(x: fp.Real) -> fp.Real:
+        return leaf(x)
+
+    # Redirect m's only call from `leaf` to `m`: m -> m.
+    _first_call(m).fn = m
+    return m
+
+
+class TestTypeInferGuard:
+    def test_recursion_raises_type_infer_error(self):
+        m = _make_self_cycle()
+        with pytest.raises(TypeInferError):
+            TypeInfer.check(m.ast)
+
+    def test_acyclic_multi_function_still_checks(self):
+        @fp.fpy
+        def g(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return g(x) * 2
+
+        # no exception
+        TypeInfer.check(f.ast)
+
+
+class TestContextInferGuard:
+    def test_recursion_raises_context_infer_error(self):
+        m = _make_self_cycle()
+        with pytest.raises(ContextInferError):
+            ContextInfer.infer(m.ast)
+
+    def test_acyclic_multi_function_still_infers(self):
+        @fp.fpy
+        def g(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return g(x) * 2
+
+        # no exception
+        ContextInfer.infer(f.ast)
+
+
+class TestFormatInferGuard:
+    def test_recursion_raises_call_graph_error(self):
+        m = _make_self_cycle()
+        # FormatInfer has no dedicated error type; the descriptive
+        # CallGraphError propagates directly.
+        with pytest.raises(CallGraphError):
+            FormatInfer.analyze(m.ast)
+
+    def test_acyclic_multi_function_still_infers(self):
+        @fp.fpy
+        def g(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return g(x) * 2
+
+        # no exception
+        FormatInfer.analyze(f.ast)

--- a/tests/unit/transform/test_inline.py
+++ b/tests/unit/transform/test_inline.py
@@ -4,6 +4,26 @@ Unit tests for function inlining
 
 import fpy2 as fp
 
+from fpy2.ast import Call
+from fpy2.ast.visitor import DefaultVisitor
+from fpy2.function import Function
+
+
+def _count_fpy_calls(ast) -> int:
+    """Number of remaining calls to user-defined FPy functions."""
+    n = 0
+
+    class _C(DefaultVisitor):
+        def _visit_call(self, e, ctx):
+            nonlocal n
+            if isinstance(e.fn, Function):
+                n += 1
+            super()._visit_call(e, ctx)
+
+    _C()._visit_function(ast, None)
+    return n
+
+
 class TestFuncInline():
 
     def assertASTEquiv(self, f: fp.ast.FuncDef, g: fp.ast.FuncDef, msg: str = ''):
@@ -78,3 +98,29 @@ class TestFuncInline():
         h = fp.transform.ConstFold.apply(h, enable_op=False)
         e = fp.transform.ConstFold.apply(expect.ast, enable_op=False)
         self.assertASTEquiv(h, e, 'inlining failed')
+
+    def test_recursive_bottom_up(self):
+        """`recursive=True` flattens a multi-level call graph with a
+        shared callee, leaving no user-function calls and preserving
+        the computed value."""
+
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return c(x) * 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            # `c` is shared: reached via `b` and directly.
+            return b(x) + c(x)
+
+        inlined = fp.transform.FuncInline.apply(a.ast, recursive=True)
+        # everything user-defined is inlined away
+        assert _count_fpy_calls(inlined) == 0
+        # value is preserved
+        inlined_fn = Function(inlined, None)
+        for xv in (0.0, 1.5, -3.25, 10.0):
+            assert a(xv) == inlined_fn(xv)


### PR DESCRIPTION
This PR adds a program analysis that builds a call graph of FPy functions. The call graph assumes there is no recursion, that is, no cycles in the call graph. This PR integrates call graph where we want to block recursive analysis.