### PR TITLE
Fix type inference

### DIFF
--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -163,15 +163,27 @@ class _TypeInferInstance(Visitor):
 
     func: FuncDef
     def_use: DefineUseAnalysis
+    sigs: dict[FuncDef, 'FunctionType']
     by_def: dict[Definition, Type]
     by_expr: dict[Expr, Type]
     ret_type: Type | None
     tvars: Unionfind[Type]
     gensym: Gensym
 
-    def __init__(self, func: FuncDef, def_use: DefineUseAnalysis):
+    def __init__(
+        self,
+        func: FuncDef,
+        def_use: DefineUseAnalysis,
+        sigs: dict[FuncDef, 'FunctionType'] | None = None,
+    ):
         self.func = func
         self.def_use = def_use
+        # Generalized signatures of already-checked callees, keyed by
+        # ``FuncDef``.  `TypeInfer.check` pre-fills this in leaves-first
+        # call-graph order, so a call's `_visit_call` is a lookup rather
+        # than a recursive re-check.  Empty/partial caches fall back to
+        # lazy checking (see `_visit_call`).
+        self.sigs = {} if sigs is None else sigs
         self.by_def = {}
         self.by_expr = {}
         self.ret_type = None
@@ -444,11 +456,16 @@ class _TypeInferInstance(Visitor):
 
                 return fn_ty.return_type
             case Function():
-                # calling a function: type check it and instantiate.
-                # Recursion can't loop here: `TypeInfer.check` runs a
-                # `CallGraph` acyclicity guard at its entry.
-                fn_info = TypeInfer.check(e.fn.ast)
-                fn_ty = cast(FunctionType, self._instantiate(fn_info.fn_type))
+                # calling a function: look up the callee's generalized
+                # signature and instantiate it at this site.  `check`
+                # pre-fills `sigs` in leaves-first call-graph order, so
+                # this is normally a hit; the miss branch lazily checks
+                # a callee that wasn't walked (and can't loop — `check`
+                # runs a `CallGraph` acyclicity guard at its entry).
+                callee = e.fn.ast
+                if callee not in self.sigs:
+                    self.sigs[callee] = TypeInfer.check(callee).fn_type
+                fn_ty = cast(FunctionType, self._instantiate(self.sigs[callee]))
 
                 # check arity
                 if len(fn_ty.arg_types) != len(e.args):
@@ -804,19 +821,29 @@ class TypeInfer:
         if not isinstance(func, FuncDef):
             raise TypeError(f'expected a \'FuncDef\', got {func}')
 
-        # Guard against recursion: FPy forbids it, and the lazy callee
-        # analysis in `_visit_call` would otherwise recurse forever on a
-        # cyclic call graph.  `CallGraph` raises on any cycle reachable
-        # from `func`, so this fires before the body is walked.
+        # Build the call graph: this guards against recursion (FPy
+        # forbids it; `CallGraph` raises on any reachable cycle) and
+        # gives the leaves-first order to check callees before callers.
         try:
-            CallGraph.analyze(func)
+            cg = CallGraph.analyze(func)
         except CallGraphError as e:
             raise TypeInferError(str(e)) from e
 
-        if def_use is None:
-            def_use = DefineUse.analyze(func)
-        inst = _TypeInferInstance(func, def_use)
-        return inst.analyze()
+        # Walk callees-before-callers, caching each generalized
+        # signature so `_visit_call` reuses it instead of re-checking
+        # the callee at every call site.  The root is last in the
+        # order, so its full analysis is what we return.
+        sigs: dict[FuncDef, FunctionType] = {}
+        result: TypeAnalysis | None = None
+        for fdef in cg.order:
+            fdef_du = def_use if fdef is func and def_use is not None \
+                else DefineUse.analyze(fdef)
+            analysis = _TypeInferInstance(fdef, fdef_du, sigs).analyze()
+            sigs[fdef] = analysis.fn_type
+            if fdef is func:
+                result = analysis
+        assert result is not None  # func is always in cg.order
+        return result
 
     @staticmethod
     def infer_primitive(prim: Primitive) -> FunctionType:

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -444,18 +444,11 @@ class _TypeInferInstance(Visitor):
 
                 return fn_ty.return_type
             case Function():
-                # calling a function
-
-                # type check the function and instantiate
-                if e.fn.sig is None:
-                    # type checking not run.  Recursion can't loop here:
-                    # `TypeInfer.check` runs a `CallGraph` acyclicity
-                    # guard at its entry.
-                    fn_info = TypeInfer.check(e.fn.ast)
-                    fn_ty = fn_info.fn_type
-                else:
-                    fn_ty = e.fn.sig
-                fn_ty = cast(FunctionType, self._instantiate(fn_ty))
+                # calling a function: type check it and instantiate.
+                # Recursion can't loop here: `TypeInfer.check` runs a
+                # `CallGraph` acyclicity guard at its entry.
+                fn_info = TypeInfer.check(e.fn.ast)
+                fn_ty = cast(FunctionType, self._instantiate(fn_info.fn_type))
 
                 # check arity
                 if len(fn_ty.arg_types) != len(e.args):

--- a/fpy2/decorator.py
+++ b/fpy2/decorator.py
@@ -221,7 +221,7 @@ def _apply_fpy_decorator(
         )
 
     # wrap the AST in a Function
-    return Function(ast, None)
+    return Function(ast)
 
 def _is_valid_context(ctx: Context | str | tuple):
     match ctx:

--- a/fpy2/function.py
+++ b/fpy2/function.py
@@ -10,7 +10,6 @@ from .number import Context
 
 # avoids circular dependency issues (useful for type checking)
 if TYPE_CHECKING:
-    from .types import FunctionType
     from .interpret import Interpreter
 
 P = ParamSpec('P')
@@ -33,18 +32,15 @@ class Function(Generic[P, R]):
     """
 
     ast: fpyast.FuncDef
-    sig: Optional['FunctionType']
     runtime: Optional['Interpreter']
 
     def __init__(
         self,
         ast: fpyast.FuncDef,
-        sig: Optional['FunctionType'],
         *,
         runtime: Optional['Interpreter'] = None,
     ):
         self.ast = ast
-        self.sig = sig
         self.runtime = runtime
 
     def __repr__(self):
@@ -93,17 +89,17 @@ class Function(Generic[P, R]):
         if not isinstance(core, FPCore):
             raise TypeError(f'expected FPCore, got {core}')
         ir = fpcore_to_fpy(core, env=env, default_name=default_name, ignore_unknown=ignore_unknown)
-        return Function(ir, None)
+        return Function(ir)
 
     def with_rt(self, rt: 'Interpreter'):
         if not isinstance(rt, Interpreter):
             raise TypeError(f'expected \'BaseInterpreter\', got {rt}')
-        return Function(self.ast, self.sig, runtime=rt)
+        return Function(self.ast, runtime=rt)
 
     def with_ast(self, ast: fpyast.FuncDef):
         if not isinstance(ast, fpyast.FuncDef):
             raise TypeError(f'expected \'FuncDef\', got {ast}')
-        return Function(ast, self.sig, runtime=self.runtime)
+        return Function(ast, runtime=self.runtime)
 
 ###########################################################
 # Default function call

--- a/tests/unit/analysis/test_type_infer.py
+++ b/tests/unit/analysis/test_type_infer.py
@@ -1,0 +1,97 @@
+"""
+Unit tests for `TypeInfer`, focused on the call-graph-driven checking:
+callees are checked once in leaves-first order and their signatures are
+reused at call sites, rather than re-checked per site.
+"""
+
+import fpy2 as fp
+
+from fpy2.analysis import TypeInfer
+from fpy2.analysis.type_infer import TypeInfer as _TI
+
+
+class TestCrossFunction:
+    def test_callee_return_type_flows_to_caller(self):
+        @fp.fpy
+        def g(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return g(x) * 2
+
+        info = TypeInfer.check(f.ast)
+        # f: real -> real, derived from g's inferred real return type
+        assert len(info.fn_type.arg_types) == 1
+        assert isinstance(info.fn_type.return_type, fp.types.RealType)
+
+    def test_returned_analysis_is_the_root_not_a_callee(self):
+        # root has 2 args, callee has 1 — if `check` returned the
+        # callee's analysis (a bug in the leaves-first walk) the arity
+        # would be wrong.
+        @fp.fpy
+        def g(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def f(x: fp.Real, y: fp.Real) -> fp.Real:
+            return g(x) + g(y)
+
+        info = TypeInfer.check(f.ast)
+        assert len(info.fn_type.arg_types) == 2
+
+    def test_diamond_checks(self):
+        @fp.fpy
+        def d(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return d(x) * 2
+
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return d(x) - 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) + c(x)
+
+        info = TypeInfer.check(a.ast)
+        assert isinstance(info.fn_type.return_type, fp.types.RealType)
+
+
+class TestCheckedOnce:
+    def test_each_function_checked_once(self, monkeypatch):
+        """A shared callee in a diamond is checked once, not once per
+        call site: the call-graph walk pre-fills the signature cache, so
+        `_visit_call` never recurses back into `TypeInfer.check`."""
+        calls: list[str] = []
+        orig = _TI.check  # staticmethod resolves to the plain function
+
+        def counting(func, def_use=None):
+            calls.append(func.name)
+            return orig(func, def_use)
+
+        monkeypatch.setattr(_TI, 'check', staticmethod(counting))
+
+        @fp.fpy
+        def d(x: fp.Real) -> fp.Real:
+            return x + 1
+
+        @fp.fpy
+        def b(x: fp.Real) -> fp.Real:
+            return d(x) * 2
+
+        @fp.fpy
+        def c(x: fp.Real) -> fp.Real:
+            return d(x) - 2
+
+        @fp.fpy
+        def a(x: fp.Real) -> fp.Real:
+            return b(x) + c(x)
+
+        TypeInfer.check(a.ast)
+        # exactly one top-level `check`; the per-function analysis runs
+        # inside it via the leaves-first walk, with no recursive checks.
+        assert calls == ['a']

--- a/tests/unit/transform/test_inline.py
+++ b/tests/unit/transform/test_inline.py
@@ -121,6 +121,6 @@ class TestFuncInline():
         # everything user-defined is inlined away
         assert _count_fpy_calls(inlined) == 0
         # value is preserved
-        inlined_fn = Function(inlined, None)
+        inlined_fn = Function(inlined)
         for xv in (0.0, 1.5, -3.25, 10.0):
             assert a(xv) == inlined_fn(xv)


### PR DESCRIPTION
Removes the `sig` attribute of the `Function` class and updates type inference to walk the call graph and analyze each function only once