### PR TITLE
Various fixes

### DIFF
--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -920,16 +920,12 @@ class _FormatInferInstance(Visitor):
         resolved = self._resolve_active_ctx(e)
         if resolved is None:
             return None
-        # Under loop-fixpoint widening, fall back to the coarse scope
-        # format.  Both the REAL identity shortcut and the
-        # intersection-image branch below can produce intermediate
-        # formats that change every iteration as the unrounded chain
-        # grows (under REAL the exact format itself widens; under a
-        # bounded scope the intersection's prec/exp tightens by one
-        # bit), preventing the fixpoint from converging.  Returning
-        # ``None`` here forces the caller to settle at the scope
-        # format via :meth:`_op_bound` — same intent as the
-        # widen-to-REAL branches in :func:`_join_bounds`.
+        # Under loop-fixpoint widening, bail to the scope format via
+        # :meth:`_op_bound`.  Both the REAL identity shortcut and the
+        # intersection branch below grow the inferred format every
+        # iteration as the unrounded chain grows, which prevents
+        # convergence — same intent as the widen-to-REAL branches in
+        # :func:`_join_bounds`.
         if self._widen:
             return None
         if resolved is REAL:

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -524,8 +524,12 @@ def _join_bounds(
                 return REAL_FORMAT
             return SetFormat(a | b)
         case SetFormat(values=vals), Format() as fmt:
+            if widen:
+                return REAL_FORMAT
             return fmt if _all_representable_in(vals, fmt) else REAL_FORMAT
         case Format() as fmt, SetFormat(values=vals):
+            if widen:
+                return REAL_FORMAT
             return fmt if _all_representable_in(vals, fmt) else REAL_FORMAT
         case Format(), Format():
             if s1 == s2:

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -524,12 +524,8 @@ def _join_bounds(
                 return REAL_FORMAT
             return SetFormat(a | b)
         case SetFormat(values=vals), Format() as fmt:
-            if widen:
-                return REAL_FORMAT
             return fmt if _all_representable_in(vals, fmt) else REAL_FORMAT
         case Format() as fmt, SetFormat(values=vals):
-            if widen:
-                return REAL_FORMAT
             return fmt if _all_representable_in(vals, fmt) else REAL_FORMAT
         case Format(), Format():
             if s1 == s2:
@@ -924,17 +920,20 @@ class _FormatInferInstance(Visitor):
         resolved = self._resolve_active_ctx(e)
         if resolved is None:
             return None
-        if resolved is REAL:
-            return exact if isinstance(exact, SetFormat) else exact.format()
         # Under loop-fixpoint widening, fall back to the coarse scope
-        # format.  The intersection-image branch below can produce
-        # intermediate formats that change by one prec bit per
-        # iteration as the unrounded chain grows, which prevents the
-        # fixpoint from converging.  Skipping the intersection during
-        # widening forces the body to settle at scope_fmt — same
-        # intent as the widen-to-REAL branches in ``_join_bounds``.
+        # format.  Both the REAL identity shortcut and the
+        # intersection-image branch below can produce intermediate
+        # formats that change every iteration as the unrounded chain
+        # grows (under REAL the exact format itself widens; under a
+        # bounded scope the intersection's prec/exp tightens by one
+        # bit), preventing the fixpoint from converging.  Returning
+        # ``None`` here forces the caller to settle at the scope
+        # format via :meth:`_op_bound` — same intent as the
+        # widen-to-REAL branches in :func:`_join_bounds`.
         if self._widen:
             return None
+        if resolved is REAL:
+            return exact if isinstance(exact, SetFormat) else exact.format()
         # Identity-round fast path: when ``round_C(F) == F``, the
         # rounded image equals *exact* itself.  Both the SetFormat
         # fits-everywhere case and the AbstractFormat

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -502,10 +502,8 @@ class _TypeInferInstance(Visitor):
 
     def _visit_binding(self, site: DefSite, binding: Id | TupleBinding, ty: Type):
         # ``ty`` may be a ``VarType`` whose union-find representative is a
-        # concrete shape (e.g. produced by ``_visit_list_ref`` returning a
-        # fresh tvar that ``_unify`` later linked to a ``TupleType``).
-        # Resolve before pattern-matching so tuple unpacking sees the
-        # concrete shape rather than the placeholder.
+        # concrete shape; resolve so tuple unpacking sees the shape rather
+        # than the placeholder.
         ty = self._resolve_type(ty)
         match binding:
             case NamedId():

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -501,6 +501,12 @@ class _TypeInferInstance(Visitor):
             return ty
 
     def _visit_binding(self, site: DefSite, binding: Id | TupleBinding, ty: Type):
+        # ``ty`` may be a ``VarType`` whose union-find representative is a
+        # concrete shape (e.g. produced by ``_visit_list_ref`` returning a
+        # fresh tvar that ``_unify`` later linked to a ``TupleType``).
+        # Resolve before pattern-matching so tuple unpacking sees the
+        # concrete shape rather than the placeholder.
+        ty = self._resolve_type(ty)
         match binding:
             case NamedId():
                 d = self.def_use.find_def_from_site(binding, site)

--- a/fpy2/number/number/reals.py
+++ b/fpy2/number/number/reals.py
@@ -245,11 +245,10 @@ class RealFloat(numbers.Rational):
                 other = RealFloat.from_int(other)
             case float():
                 if math.isnan(other) or math.isinf(other):
-                    # ``self`` is always finite; nan / +/-inf absorb a finite
-                    # addend.  Returning ``other`` directly avoids converting
-                    # ``self`` to a Python float, which raises for RealFloats
-                    # too large to fit (e.g. those produced by abstract REAL
-                    # arithmetic in :mod:`fpy2.analysis.format_infer`).
+                    # ``self`` is always finite; nan / +/-inf absorb the
+                    # addend.  Return ``other`` directly — converting
+                    # ``self`` to a Python float would raise for any
+                    # ``RealFloat`` outside ``float``'s representable range.
                     return other
                 else:
                     other = RealFloat.from_float(other)

--- a/fpy2/number/number/reals.py
+++ b/fpy2/number/number/reals.py
@@ -245,8 +245,12 @@ class RealFloat(numbers.Rational):
                 other = RealFloat.from_int(other)
             case float():
                 if math.isnan(other) or math.isinf(other):
-                    # Convert self to float and perform float arithmetic
-                    return float(self) + other
+                    # ``self`` is always finite; nan / +/-inf absorb a finite
+                    # addend.  Returning ``other`` directly avoids converting
+                    # ``self`` to a Python float, which raises for RealFloats
+                    # too large to fit (e.g. those produced by abstract REAL
+                    # arithmetic in :mod:`fpy2.analysis.format_infer`).
+                    return other
                 else:
                     other = RealFloat.from_float(other)
             case Fraction():

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1225,25 +1225,9 @@ class TestFormatInfer:
         assert _join_bounds(s, REAL_FORMAT) == REAL_FORMAT
         assert _join_bounds(REAL_FORMAT, s) == REAL_FORMAT
 
-    def test_join_set_with_format_widens(self):
-        """Under ``widen=True``, ``SetFormat ⊔ Format`` collapses to
-        ``REAL_FORMAT`` regardless of representability.
-
-        Regression: the widening flag must propagate through every join
-        case used inside the loop fixpoint, not just ``Format ⊔ Format``.
-        A loop phi joining a ``SetFormat`` (e.g. an integer-literal init
-        like ``s = 0``) with the body's growing ``MPBFloatFormat`` used to
-        ignore ``widen`` and silently re-pick the (still-growing) Format,
-        preventing convergence.
-        """
-        fmt = fp.FP32.format()
-        s = SetFormat(frozenset((Fraction(0),)))
-        assert _join_bounds(s, fmt, widen=True) == REAL_FORMAT
-        assert _join_bounds(fmt, s, widen=True) == REAL_FORMAT
-
-    def test_loop_with_set_init_and_real_body_terminates(self):
-        """A loop whose phi joins a ``SetFormat`` (the pre-loop literal
-        ``0``) with a ``Format`` that grows under ``with fp.REAL:`` must
+    def test_loop_under_real_with_set_init_terminates(self):
+        """A loop whose body performs exact arithmetic ``with fp.REAL:``
+        starting from a ``SetFormat`` literal init (``s = 0``) must
         terminate via widening — not loop forever in the fixpoint.
 
         Regression for the hang on::
@@ -1253,11 +1237,13 @@ class TestFormatInfer:
                 for ai, bi in zip(a, b):
                     sum += ai * bi
 
-        Before the fix, the phi join hit the ``SetFormat × Format``
-        branch (since ``sum = 0`` produces a SetFormat init), which
-        ignored the widen flag and silently returned the body's
-        unbounded MPBFloatFormat, causing ``_fixpoint`` to never
-        converge.
+        Before the fix, :meth:`_bound_if_fits` short-circuited under
+        ``REAL`` scope (returning the exact format) before honoring
+        ``self._widen``.  The exact format grew by one precision bit
+        per iteration, so the phi never stabilized and the fixpoint
+        ran forever.  The fix moves the widen check ahead of the REAL
+        shortcut so widening forces the body to settle at the scope's
+        ``REAL_FORMAT``.
         """
         @fp.fpy
         def foo(a: list[fp.Real], b: list[fp.Real]) -> fp.Real:
@@ -1271,6 +1257,40 @@ class TestFormatInfer:
         s_bounds = [b for d, b in info.by_def.items() if d.name.base == 's']
         assert REAL_FORMAT in s_bounds, (
             f"expected REAL_FORMAT among s bounds with widening, got {s_bounds}"
+        )
+
+    def test_loop_under_integer_with_set_init_keeps_scope_format(self):
+        """A loop accumulating integers under ``with fp.INTEGER:`` from
+        a ``SetFormat`` literal init must converge to ``INTEGER``'s
+        ``MPFixedFormat`` at widen time — *not* widen to ``REAL_FORMAT``.
+
+        Companion to :meth:`test_loop_under_real_with_set_init_terminates`:
+        an earlier attempt to make the REAL case converge widened the
+        ``SetFormat × Format`` join branch indiscriminately, breaking
+        bounded-scope loops (``test_while*_rounded`` and
+        ``test_for*_rounded`` in the cpp infra suite).  This test pins
+        the correct behavior: at widen-mode the body settles at the
+        scope's bounded format, and the phi join recovers that format
+        rather than collapsing to ``REAL``.
+        """
+        @fp.fpy
+        def f():
+            with fp.INTEGER:
+                x = fp.round(0)
+            while x < 5:
+                with fp.INTEGER:
+                    x += 1
+            return x
+
+        info = FormatInfer.analyze(f.ast, loop_iter_limit=2)
+        x_bounds = {b for d, b in info.by_def.items() if d.name.base == 'x'}
+        int_fmt = fp.INTEGER.format()
+        assert int_fmt in x_bounds, (
+            f'expected INTEGER MPFixedFormat among x bounds, got {x_bounds}'
+        )
+        assert REAL_FORMAT not in x_bounds, (
+            f'integer-bounded loop should not widen to REAL_FORMAT, '
+            f'got {x_bounds}'
         )
 
     def test_literal_produces_set_shape(self):

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1226,24 +1226,11 @@ class TestFormatInfer:
         assert _join_bounds(REAL_FORMAT, s) == REAL_FORMAT
 
     def test_loop_under_real_with_set_init_terminates(self):
-        """A loop whose body performs exact arithmetic ``with fp.REAL:``
-        starting from a ``SetFormat`` literal init (``s = 0``) must
-        terminate via widening — not loop forever in the fixpoint.
-
-        Regression for the hang on::
-
-            sum = 0
-            with fp.REAL:
-                for ai, bi in zip(a, b):
-                    sum += ai * bi
-
-        Before the fix, :meth:`_bound_if_fits` short-circuited under
-        ``REAL`` scope (returning the exact format) before honoring
-        ``self._widen``.  The exact format grew by one precision bit
-        per iteration, so the phi never stabilized and the fixpoint
-        ran forever.  The fix moves the widen check ahead of the REAL
-        shortcut so widening forces the body to settle at the scope's
-        ``REAL_FORMAT``.
+        """A loop body that performs exact arithmetic ``with fp.REAL:``
+        starting from a ``SetFormat`` literal init must terminate via
+        widening rather than loop forever.  The exact format grows one
+        precision bit per iteration, so without the widen short-circuit
+        in :meth:`_bound_if_fits` the phi never stabilizes.
         """
         @fp.fpy
         def foo(a: list[fp.Real], b: list[fp.Real]) -> fp.Real:
@@ -1256,22 +1243,13 @@ class TestFormatInfer:
         info = FormatInfer.analyze(foo.ast, loop_iter_limit=2)
         s_bounds = [b for d, b in info.by_def.items() if d.name.base == 's']
         assert REAL_FORMAT in s_bounds, (
-            f"expected REAL_FORMAT among s bounds with widening, got {s_bounds}"
+            f'expected REAL_FORMAT among s bounds with widening, got {s_bounds}'
         )
 
     def test_loop_under_integer_with_set_init_keeps_scope_format(self):
         """A loop accumulating integers under ``with fp.INTEGER:`` from
         a ``SetFormat`` literal init must converge to ``INTEGER``'s
-        ``MPFixedFormat`` at widen time — *not* widen to ``REAL_FORMAT``.
-
-        Companion to :meth:`test_loop_under_real_with_set_init_terminates`:
-        an earlier attempt to make the REAL case converge widened the
-        ``SetFormat × Format`` join branch indiscriminately, breaking
-        bounded-scope loops (``test_while*_rounded`` and
-        ``test_for*_rounded`` in the cpp infra suite).  This test pins
-        the correct behavior: at widen-mode the body settles at the
-        scope's bounded format, and the phi join recovers that format
-        rather than collapsing to ``REAL``.
+        ``MPFixedFormat`` at widen time, not collapse to ``REAL_FORMAT``.
         """
         @fp.fpy
         def f():

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1225,6 +1225,54 @@ class TestFormatInfer:
         assert _join_bounds(s, REAL_FORMAT) == REAL_FORMAT
         assert _join_bounds(REAL_FORMAT, s) == REAL_FORMAT
 
+    def test_join_set_with_format_widens(self):
+        """Under ``widen=True``, ``SetFormat ⊔ Format`` collapses to
+        ``REAL_FORMAT`` regardless of representability.
+
+        Regression: the widening flag must propagate through every join
+        case used inside the loop fixpoint, not just ``Format ⊔ Format``.
+        A loop phi joining a ``SetFormat`` (e.g. an integer-literal init
+        like ``s = 0``) with the body's growing ``MPBFloatFormat`` used to
+        ignore ``widen`` and silently re-pick the (still-growing) Format,
+        preventing convergence.
+        """
+        fmt = fp.FP32.format()
+        s = SetFormat(frozenset((Fraction(0),)))
+        assert _join_bounds(s, fmt, widen=True) == REAL_FORMAT
+        assert _join_bounds(fmt, s, widen=True) == REAL_FORMAT
+
+    def test_loop_with_set_init_and_real_body_terminates(self):
+        """A loop whose phi joins a ``SetFormat`` (the pre-loop literal
+        ``0``) with a ``Format`` that grows under ``with fp.REAL:`` must
+        terminate via widening — not loop forever in the fixpoint.
+
+        Regression for the hang on::
+
+            sum = 0
+            with fp.REAL:
+                for ai, bi in zip(a, b):
+                    sum += ai * bi
+
+        Before the fix, the phi join hit the ``SetFormat × Format``
+        branch (since ``sum = 0`` produces a SetFormat init), which
+        ignored the widen flag and silently returned the body's
+        unbounded MPBFloatFormat, causing ``_fixpoint`` to never
+        converge.
+        """
+        @fp.fpy
+        def foo(a: list[fp.Real], b: list[fp.Real]) -> fp.Real:
+            s = 0
+            with fp.REAL:
+                for ai, bi in zip(a, b):
+                    s += ai * bi
+            return fp.round(s)
+
+        info = FormatInfer.analyze(foo.ast, loop_iter_limit=2)
+        s_bounds = [b for d, b in info.by_def.items() if d.name.base == 's']
+        assert REAL_FORMAT in s_bounds, (
+            f"expected REAL_FORMAT among s bounds with widening, got {s_bounds}"
+        )
+
     def test_literal_produces_set_shape(self):
         """A numeric literal expression has a singleton ``SetFormat``."""
         @fp.fpy

--- a/tests/unit/analysis/test_type_infer.py
+++ b/tests/unit/analysis/test_type_infer.py
@@ -61,6 +61,32 @@ class TestCrossFunction:
         assert isinstance(info.fn_type.return_type, fp.types.RealType)
 
 
+class TestBinding:
+    def test_unpack_through_list_ref(self):
+        """Unpacking a list element directly — ``a = xs[i]; a1, a2 = a``
+        — must resolve ``a``'s type through the union-find before
+        checking the tuple shape.
+
+        Regression: ``_visit_list_ref`` returns a fresh ``VarType``
+        that ``_unify`` links to the list's element type.  Without
+        resolving in ``_visit_binding``, the tuple-binding case saw a
+        ``VarType`` (not a ``TupleType``) and raised ``cannot unpack``.
+        Triggered through the cpp ``optimize=True`` path: ``ZipElim``
+        rewrites ``for a, b in zip(xs, xs): ...`` into ``a = _src[_i]``,
+        then ``a1, a2 = a`` failed to type-check.
+        """
+        @fp.fpy
+        def bar(x: list[tuple[fp.Real, fp.Real]]) -> fp.Real:
+            for a, b in zip(x, x):
+                a1, a2 = a
+            return 0
+
+        from fpy2.transform.zip_elim import ZipElim
+        rewritten = ZipElim.apply(bar.ast)
+        info = TypeInfer.check(rewritten)  # raised before the fix
+        assert isinstance(info.fn_type.return_type, fp.types.RealType)
+
+
 class TestCheckedOnce:
     def test_each_function_checked_once(self, monkeypatch):
         """A shared callee in a diamond is checked once, not once per

--- a/tests/unit/analysis/test_type_infer.py
+++ b/tests/unit/analysis/test_type_infer.py
@@ -63,17 +63,10 @@ class TestCrossFunction:
 
 class TestBinding:
     def test_unpack_through_list_ref(self):
-        """Unpacking a list element directly — ``a = xs[i]; a1, a2 = a``
-        — must resolve ``a``'s type through the union-find before
-        checking the tuple shape.
-
-        Regression: ``_visit_list_ref`` returns a fresh ``VarType``
-        that ``_unify`` links to the list's element type.  Without
-        resolving in ``_visit_binding``, the tuple-binding case saw a
-        ``VarType`` (not a ``TupleType``) and raised ``cannot unpack``.
-        Triggered through the cpp ``optimize=True`` path: ``ZipElim``
-        rewrites ``for a, b in zip(xs, xs): ...`` into ``a = _src[_i]``,
-        then ``a1, a2 = a`` failed to type-check.
+        """Unpacking a list element via ``a = xs[i]; a1, a2 = a`` must
+        resolve ``a``'s type through the union-find before checking the
+        tuple shape, since ``_visit_list_ref`` returns a fresh ``VarType``
+        that only later unifies with the list's element type.
         """
         @fp.fpy
         def bar(x: list[tuple[fp.Real, fp.Real]]) -> fp.Real:
@@ -83,7 +76,7 @@ class TestBinding:
 
         from fpy2.transform.zip_elim import ZipElim
         rewritten = ZipElim.apply(bar.ast)
-        info = TypeInfer.check(rewritten)  # raised before the fix
+        info = TypeInfer.check(rewritten)
         assert isinstance(info.fn_type.return_type, fp.types.RealType)
 
 

--- a/tests/unit/backend/cpp/test_compile.py
+++ b/tests/unit/backend/cpp/test_compile.py
@@ -57,6 +57,36 @@ class TestCppCompilerStub:
         with pytest.raises(TypeError, match='Function'):
             compiler.compile('not a function')  # type: ignore[arg-type]
 
+    def test_real_accumulator_loop_terminates(self):
+        """A loop that accumulates into a literal-initialized scalar
+        under ``with fp.REAL:`` must surface a finite ``CppCompileError``
+        (the REAL phi can't be assigned finite storage), not hang the
+        format-inference fixpoint.
+
+        Regression for the hang where the phi join's widen flag was
+        ignored in the ``SetFormat × Format`` branch — see
+        ``test_format_infer.test_loop_with_set_init_and_real_body_terminates``.
+        """
+        from fpy2.types import ListType, RealType
+
+        @fp.fpy
+        def foo(a: list[fp.Real], b: list[fp.Real]) -> fp.Real:
+            s = 0
+            with fp.REAL:
+                for ai, bi in zip(a, b):
+                    s += ai * bi
+            return fp.round(s)
+
+        compiler = CppCompiler()
+        with pytest.raises(CppCompileError, match='cannot pick storage'):
+            compiler.compile(
+                foo, ctx=fp.FP64,
+                arg_types=[
+                    ListType(RealType(fp.FP64)),
+                    ListType(RealType(fp.FP64)),
+                ],
+            )
+
 
 class TestSpecializationNameCollisions:
     """Distinct :class:`FuncDef`s that share a source name (e.g.

--- a/tests/unit/backend/cpp/test_compile.py
+++ b/tests/unit/backend/cpp/test_compile.py
@@ -58,12 +58,9 @@ class TestCppCompilerStub:
             compiler.compile('not a function')  # type: ignore[arg-type]
 
     def test_zip_elim_preserves_tuple_unpack(self):
-        """With ``optimize=True``, ``ZipElim`` rewrites
-        ``for a, b in zip(x, x): a1, a2 = a`` into
-        ``a = _src[_i]; a1, a2 = a``.  The tuple-unpack must still
-        type-check after the rewrite — regression for a missing
-        union-find resolve in ``TypeInfer._visit_binding`` that left
-        ``a``'s type as an unresolved ``VarType`` and failed unpacking.
+        """``ZipElim`` rewrites ``for a, b in zip(x, x): a1, a2 = a``
+        into ``a = _src[_i]; a1, a2 = a``.  The tuple-unpack must still
+        type-check against ``a``'s union-find resolved shape.
         """
         from fpy2.types import ListType, RealType, TupleType
 
@@ -84,13 +81,9 @@ class TestCppCompilerStub:
 
     def test_real_accumulator_loop_terminates(self):
         """A loop that accumulates into a literal-initialized scalar
-        under ``with fp.REAL:`` must surface a finite ``CppCompileError``
-        (the REAL phi can't be assigned finite storage), not hang the
+        under ``with fp.REAL:`` must surface a ``CppCompileError`` (the
+        REAL phi can't be assigned finite storage) rather than hang the
         format-inference fixpoint.
-
-        Regression for the hang where the phi join's widen flag was
-        ignored in the ``SetFormat × Format`` branch — see
-        ``test_format_infer.test_loop_with_set_init_and_real_body_terminates``.
         """
         from fpy2.types import ListType, RealType
 

--- a/tests/unit/backend/cpp/test_compile.py
+++ b/tests/unit/backend/cpp/test_compile.py
@@ -57,6 +57,31 @@ class TestCppCompilerStub:
         with pytest.raises(TypeError, match='Function'):
             compiler.compile('not a function')  # type: ignore[arg-type]
 
+    def test_zip_elim_preserves_tuple_unpack(self):
+        """With ``optimize=True``, ``ZipElim`` rewrites
+        ``for a, b in zip(x, x): a1, a2 = a`` into
+        ``a = _src[_i]; a1, a2 = a``.  The tuple-unpack must still
+        type-check after the rewrite — regression for a missing
+        union-find resolve in ``TypeInfer._visit_binding`` that left
+        ``a``'s type as an unresolved ``VarType`` and failed unpacking.
+        """
+        from fpy2.types import ListType, RealType, TupleType
+
+        @fp.fpy
+        def bar(x: list[tuple[fp.Real, fp.Real]]) -> fp.Real:
+            for a, b in zip(x, x):
+                a1, a2 = a
+            return 0
+
+        compiler = CppCompiler(optimize=True)
+        out = compiler.compile(
+            bar, ctx=fp.FP64,
+            arg_types=[ListType(TupleType(
+                RealType(fp.FP64), RealType(fp.FP64),
+            ))],
+        )
+        assert 'std::vector<std::tuple<double, double>>' in out
+
     def test_real_accumulator_loop_terminates(self):
         """A loop that accumulates into a literal-initialized scalar
         under ``with fp.REAL:`` must surface a finite ``CppCompileError``

--- a/tests/unit/number/number/test_real_float.py
+++ b/tests/unit/number/number/test_real_float.py
@@ -215,24 +215,21 @@ class TestRealFloatArithmetic():
         actual = fp.RealFloat.from_float(a) + b
         assert isinstance(actual, fp.RealFloat)
 
-    def test_add_inf_does_not_require_float_conversion(self):
-        """``RealFloat + inf`` returns ``inf`` directly without trying to
-        convert ``self`` to a Python float.  Regression: previously the
-        code did ``float(self) + other`` even when ``other`` was inf or
-        nan, raising ``ValueError`` for any RealFloat large enough to
-        overflow ``float`` (e.g. the abstract REAL bounds produced by
-        format inference during loop fixpoints).
+    def test_add_inf_nan_for_out_of_range_self(self):
+        """``RealFloat + inf/nan`` must return the absorbing value
+        without converting ``self`` to a Python float — otherwise
+        ``RealFloat``s outside ``float``'s range raise ``ValueError``.
         """
-        huge = fp.RealFloat(s=False, exp=2000, c=1)  # well past float max
+        huge = fp.RealFloat(s=False, exp=2000, c=1)
         with pytest.raises(ValueError, match='not representable'):
-            float(huge)  # establishes the precondition
+            float(huge)
         assert huge + float('inf') == float('inf')
         assert huge + float('-inf') == float('-inf')
         assert math.isnan(huge + float('nan'))
 
-    def test_sub_inf_does_not_require_float_conversion(self):
-        """Same as :meth:`test_add_inf_does_not_require_float_conversion`,
-        via ``__sub__`` (which delegates to ``__add__(-other)``)."""
+    def test_sub_inf_for_out_of_range_self(self):
+        """``__sub__`` delegates to ``__add__(-other)`` so the same
+        out-of-range path must succeed."""
         huge = fp.RealFloat(s=False, exp=2000, c=1)
         assert huge - float('inf') == float('-inf')
         assert huge - float('-inf') == float('inf')

--- a/tests/unit/number/number/test_real_float.py
+++ b/tests/unit/number/number/test_real_float.py
@@ -1,5 +1,6 @@
 import fpy2 as fp
 import math
+import pytest
 
 from fractions import Fraction
 from hypothesis import assume, given, strategies as st
@@ -213,6 +214,28 @@ class TestRealFloatArithmetic():
     def test_add_mixed(self, a: float, b: int | float | Fraction):
         actual = fp.RealFloat.from_float(a) + b
         assert isinstance(actual, fp.RealFloat)
+
+    def test_add_inf_does_not_require_float_conversion(self):
+        """``RealFloat + inf`` returns ``inf`` directly without trying to
+        convert ``self`` to a Python float.  Regression: previously the
+        code did ``float(self) + other`` even when ``other`` was inf or
+        nan, raising ``ValueError`` for any RealFloat large enough to
+        overflow ``float`` (e.g. the abstract REAL bounds produced by
+        format inference during loop fixpoints).
+        """
+        huge = fp.RealFloat(s=False, exp=2000, c=1)  # well past float max
+        with pytest.raises(ValueError, match='not representable'):
+            float(huge)  # establishes the precondition
+        assert huge + float('inf') == float('inf')
+        assert huge + float('-inf') == float('-inf')
+        assert math.isnan(huge + float('nan'))
+
+    def test_sub_inf_does_not_require_float_conversion(self):
+        """Same as :meth:`test_add_inf_does_not_require_float_conversion`,
+        via ``__sub__`` (which delegates to ``__add__(-other)``)."""
+        huge = fp.RealFloat(s=False, exp=2000, c=1)
+        assert huge - float('inf') == float('-inf')
+        assert huge - float('-inf') == float('inf')
 
     @given(
         st.floats(allow_infinity=False, allow_nan=False),


### PR DESCRIPTION
Multiple fixes:
 - `RealFloat`: fix `__add__` with special values
 - type infer: fix type checking when unpacking tuples
 - format infer: fix widening