### PR TITLE
Fix negative zero rounding

### DIFF
--- a/fpy2/number/context/mp_float.py
+++ b/fpy2/number/context/mp_float.py
@@ -198,9 +198,9 @@ class MPFloatContext(Context):
             else:
                 x = x._real
 
-        # step 2. shortcut for exact zero values
+        # step 2. shortcut for exact zero values (preserve signed zero)
         if x.is_zero():
-            return Float(ctx=self)
+            return Float(s=x.s, ctx=self)
 
         # step 3. round value based on rounding parameters
         xr = x.round(self.pmax, n, self.rm, self.num_randbits, rng=self.rng, exact=exact)

--- a/fpy2/number/context/mpb_float.py
+++ b/fpy2/number/context/mpb_float.py
@@ -428,9 +428,9 @@ class MPBFloatContext(SizedContext):
             else:
                 x = x.as_real()
 
-        # step 2. shortcut for exact zero values
+        # step 2. shortcut for exact zero values (preserve signed zero)
         if x.is_zero():
-            return Float(ctx=self)
+            return Float(s=x.s, ctx=self)
 
         # step 3. select rounding parameter `n`
         if n is None or n < self.nmin:

--- a/fpy2/number/context/mps_float.py
+++ b/fpy2/number/context/mps_float.py
@@ -367,9 +367,9 @@ class MPSFloatContext(OrdinalContext):
             else:
                 x = x._real
 
-        # step 2. shortcut for exact zero values
+        # step 2. shortcut for exact zero values (preserve signed zero)
         if x.is_zero():
-            return Float(ctx=self)
+            return Float(s=x.s, ctx=self)
 
         # step 3. select rounding parameter `n`
         if n is None or n < self.nmin:

--- a/tests/unit/number/test_ops.py
+++ b/tests/unit/number/test_ops.py
@@ -91,6 +91,22 @@ class TestOps():
         op = _cvt_to_frac(fp.neg(a))
         self.assertEqualOrNan(op, -af, f'Failed negation: {a} ({af})')
 
+    def test_neg_preserves_signed_zero(self):
+        """``neg(+0)`` produces ``-0`` and vice versa, in every float
+        context.  The IEEE-754 negation is bit-exact on the sign — the
+        rounded result must carry it through, not collapse to ``+0``.
+        """
+        from fpy2.number import Float
+        pos_zero = Float.from_float(0.0)
+        neg_zero = fp.neg(pos_zero, ctx=fp.FP32)
+        assert neg_zero.is_zero() and neg_zero.s, (
+            f'expected -0.0, got {neg_zero!r}'
+        )
+        re_pos = fp.neg(neg_zero, ctx=fp.FP32)
+        assert re_pos.is_zero() and not re_pos.s, (
+            f'expected +0.0, got {re_pos!r}'
+        )
+
     @given(number())
     def test_abs(self, a):
         af = _cvt_to_frac(a)


### PR DESCRIPTION
Rounding -0 `MPFloatContext`/`MPSFloatContext`/`MPBFloatContext` produced +0 instead.