### PR TITLE
Add amax/amin nodes

### DIFF
--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -328,8 +328,8 @@ class _TypeInferInstance(Visitor):
                     ty = self._fresh_type_var()
                     self._unify(arg_ty, ListType(ty))
                     return ListType(TupleType(RealType(None), ty))
-                case Sum():
-                    # sum operator
+                case Sum() | AMin() | AMax():
+                    # list-reduce operators: list[real] -> real
                     self._unify(arg_ty, ListType(RealType(None)))
                     return RealType(None)
                 case DeclContext():

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -104,6 +104,8 @@ __all__ = [
     # Other arithmetic
     'Max',
     'Min',
+    'AMax',
+    'AMin',
     'Mod',
     'Fmod',
     'Remainder',
@@ -861,6 +863,22 @@ class Max(NamedNaryOp):
 
 class Min(NamedNaryOp):
     """FPy node: `min(x, y, ...)`"""
+    __slots__ = ()
+
+class AMax(NamedUnaryOp):
+    """FPy node: ``max(xs)`` reduce-form over ``xs : list[real]``.
+
+    Distinct AST class from :class:`Max` (the variadic scalar form) so
+    type checking is syntax-directed — ``isinstance(e, AMax)`` is the
+    complete discriminator between the two type signatures
+    (``list[real] -> real`` vs ``real -> ... -> real``).  Name follows
+    NumPy's :func:`numpy.amax`.
+    """
+    __slots__ = ()
+
+class AMin(NamedUnaryOp):
+    """FPy node: ``min(xs)`` reduce-form — list-form analogue of
+    :class:`AMax`."""
     __slots__ = ()
 
 class Mod(BinaryOp):

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -1522,21 +1522,15 @@ class CppEmitter(Visitor):
         return result
 
     def _emit_amin_amax(self, e: 'AMin | AMax', arg_str: str) -> str:
-        """Reduce ``min(xs)`` / ``max(xs)`` over ``xs``.
+        """Reduce ``min(xs)`` / ``max(xs)`` to a hoisted for-loop.
 
-        Combiner choice mirrors :meth:`_emit_min_max`: ``std::fmin`` /
-        ``std::fmax`` for FP results, ``std::min`` / ``std::max`` for
-        integer ones.  Both forms require uniform operand types — the
-        templated integer overload deduces ``T`` from both args, and
-        ``std::fmin`` / ``std::fmax`` only overload on ``(float,
-        float)``, ``(double, double)``, ``(long double, long double)``.
-        We force uniformity by casting each list element to ``result_ty``
-        via :meth:`_maybe_cast`, which raises if the cast would be lossy
-        (the right behavior — we can't safely store a wider element in a
-        narrower result).
+        Combiner mirrors :meth:`_emit_min_max`: ``std::fmin``/``fmax``
+        for FP results, ``std::min``/``max`` (templated) for integer
+        ones.  Both demand uniform operand types — we cast each element
+        to ``result_ty`` via :meth:`_maybe_cast`, which raises on a
+        lossy cast.
 
-        Hoists a temp + for-loop for iterative reduction.  Empty-list
-        behavior is undefined (matches the interpreter's
+        Empty-list behavior is undefined (matches the interpreter's
         ``min([]) → ValueError`` contract); the emit indexes ``xs[0]``
         without a guard.
         """

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -40,12 +40,12 @@ from ...analysis import (
     DefineUseAnalysis, FormatAnalysis
 )
 from ...ast.fpyast import (
-    And, Argument, Assign, AssertStmt, Ast, BinaryOp, BoolVal, Cast, Compare,
-    ContextStmt, Decnum, Digits, Dim, EffectStmt, Empty, Enumerate, Expr,
-    ForStmt, FuncDef, Hexnum, If1Stmt, IfStmt, IndexedAssign, Integer,
-    IsFinite, IsInf, IsNan, IsNormal, Len, ListComp, ListExpr, ListRef,
-    ListSlice, Max, Min, NamedId, NaryOp, Not, Or, Range1, Range2, Range3,
-    Rational, ReturnStmt, Round, Signbit, Size, StmtBlock, Sum,
+    AMax, AMin, And, Argument, Assign, AssertStmt, Ast, BinaryOp, BoolVal,
+    Cast, Compare, ContextStmt, Decnum, Digits, Dim, EffectStmt, Empty,
+    Enumerate, Expr, ForStmt, FuncDef, Hexnum, If1Stmt, IfStmt, IndexedAssign,
+    Integer, IsFinite, IsInf, IsNan, IsNormal, Len, ListComp, ListExpr,
+    ListRef, ListSlice, Max, Min, NamedId, NaryOp, Not, Or, Range1, Range2,
+    Range3, Rational, ReturnStmt, Round, Signbit, Size, StmtBlock, Sum,
     TernaryOp, TupleBinding, TupleExpr, UnaryOp, UnderscoreId, Var,
     WhileStmt, Zip,
 )
@@ -1095,6 +1095,8 @@ class CppEmitter(Visitor):
                     f'std::accumulate({arg}.begin(), {arg}.end(), '
                     f'static_cast<{result_ty.format()}>(0))'
                 )
+            case AMin() | AMax():
+                return self._emit_amin_amax(e, arg)
             case Enumerate():
                 return self._emit_enumerate(e, arg)
             case UnaryOp() if type(e) in self.op_table.unary:
@@ -1518,6 +1520,61 @@ class CppEmitter(Visitor):
         for nxt in casted[1:]:
             result = f'{fn}({result}, {nxt})'
         return result
+
+    def _emit_amin_amax(self, e: 'AMin | AMax', arg_str: str) -> str:
+        """Reduce ``min(xs)`` / ``max(xs)`` over ``xs``.
+
+        Combiner choice mirrors :meth:`_emit_min_max`: ``std::fmin`` /
+        ``std::fmax`` for FP results, ``std::min`` / ``std::max`` for
+        integer ones.  Both forms require uniform operand types — the
+        templated integer overload deduces ``T`` from both args, and
+        ``std::fmin`` / ``std::fmax`` only overload on ``(float,
+        float)``, ``(double, double)``, ``(long double, long double)``.
+        We force uniformity by casting each list element to ``result_ty``
+        via :meth:`_maybe_cast`, which raises if the cast would be lossy
+        (the right behavior — we can't safely store a wider element in a
+        narrower result).
+
+        Hoists a temp + for-loop for iterative reduction.  Empty-list
+        behavior is undefined (matches the interpreter's
+        ``min([]) → ValueError`` contract); the emit indexes ``xs[0]``
+        without a guard.
+        """
+        result_ty = self._storage_for_expr(e)
+        if not isinstance(result_ty, CppScalar):
+            raise CppEmitError(
+                f'expected scalar result for {type(e).__name__}, got {result_ty!r}',
+                at=e,
+            )
+        arg_storage = self._storage_for_expr(e.arg)
+        if not (isinstance(arg_storage, CppList)
+                and isinstance(arg_storage.elt, CppScalar)):
+            raise CppEmitError(
+                f'expected list[scalar] arg for {type(e).__name__}, '
+                f'got {arg_storage!r}',
+                at=e,
+            )
+        elt_ty = arg_storage.elt
+        if result_ty.is_float():
+            fn = 'std::fmin' if isinstance(e, AMin) else 'std::fmax'
+        else:
+            fn = 'std::min' if isinstance(e, AMin) else 'std::max'
+
+        src = self._fresh_temp()
+        self.writer.add_line(f'auto {src} = {arg_str};')
+        acc = self._fresh_temp()
+        init = self._maybe_cast(f'{src}[0]', elt_ty, result_ty, at=e)
+        self.writer.add_line(f'{result_ty.format()} {acc} = {init};')
+        i = self._fresh_temp()
+        self.writer.add_line(
+            f'for (size_t {i} = 1; {i} < {src}.size(); ++{i}) {{'
+        )
+        self.writer.indent()
+        elt = self._maybe_cast(f'{src}[{i}]', elt_ty, result_ty, at=e)
+        self.writer.add_line(f'{acc} = {fn}({acc}, {elt});')
+        self.writer.dedent()
+        self.writer.add_line('}')
+        return acc
 
     def _emit_empty(self, e: Empty, ctx) -> str:
         """``empty(d1, ..., dN)`` builds an ``N``-dimensional zero-

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -414,12 +414,8 @@ class _FPCoreCompileInstance(Visitor):
         return min_expr
 
     def _visit_sum(self, arg: Expr, ctx: None) -> fpc.Expr:
-        # expand sum expression by left associativity
-        # the sum expression has at most one argument
-        # (let ([t <tuple>])
-        #   (for ([i (! :precision integer (- (size t 0) 1))]
-        #         [accum (ref t i) (+ accum (ref t (! :precision integer (+ i 1))))])
-        #     accum))
+        # sum(xs) → fold over the list with +.  Shape documented on
+        # :meth:`_visit_list_reduce`.
         return self._visit_list_reduce(arg, fpc.Add, ctx)
 
     def _visit_amin(self, arg: Expr, ctx: None) -> fpc.Expr:

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -1,5 +1,7 @@
 """Compilation from FPy to FPCore."""
 
+from typing import Callable
+
 import titanfp.fpbench.fpcast as fpc
 
 from ..analysis import DefineUse, DefineUseAnalysis
@@ -418,6 +420,34 @@ class _FPCoreCompileInstance(Visitor):
         #   (for ([i (! :precision integer (- (size t 0) 1))]
         #         [accum (ref t i) (+ accum (ref t (! :precision integer (+ i 1))))])
         #     accum))
+        return self._visit_list_reduce(arg, fpc.Add, ctx)
+
+    def _visit_amin(self, arg: Expr, ctx: None) -> fpc.Expr:
+        # min(xs) → fold over the list with fmin.  Mirrors _visit_sum.
+        return self._visit_list_reduce(arg, fpc.Fmin, ctx)
+
+    def _visit_amax(self, arg: Expr, ctx: None) -> fpc.Expr:
+        # max(xs) → fold over the list with fmax.  Mirrors _visit_sum.
+        return self._visit_list_reduce(arg, fpc.Fmax, ctx)
+
+    def _visit_list_reduce(
+        self,
+        arg: Expr,
+        combine: Callable[[fpc.Expr, fpc.Expr], fpc.Expr],
+        ctx: None,
+    ) -> fpc.Expr:
+        """Shared lowering for left-associative list reductions
+        (``sum``/``min``/``max``).  Builds::
+
+            (let ([t <tuple>])
+              (for ([i (! :precision integer (- (size t 0) 1))]
+                    [accum (ref t i) (<combine> accum (ref t (! :precision integer (+ i 1))))])
+                accum))
+
+        Empty-input semantics are inherited from FPCore's ``for`` over a
+        zero count (the init expression still runs at ``i = 0`` — same
+        UB as the interpreter / cpp emitter contract).
+        """
         tuple_id = str(self.gensym.fresh('t'))
         iter_id = str(self.gensym.fresh('i'))
         accum_id = str(self.gensym.fresh('accum'))
@@ -431,7 +461,7 @@ class _FPCoreCompileInstance(Visitor):
                 [(
                     accum_id,
                     fpc.Ref(fpc.Var(tuple_id), fpc.Var(iter_id)),
-                    fpc.Ctx(idx_ctx, fpc.Add(accum_id, fpc.Ref(fpc.Var(tuple_id), fpc.Add(fpc.Var(iter_id), fpc.Integer(1)))))
+                    fpc.Ctx(idx_ctx, combine(accum_id, fpc.Ref(fpc.Var(tuple_id), fpc.Add(fpc.Var(iter_id), fpc.Integer(1)))))
                 )],
                 fpc.Var(accum_id)
             )
@@ -469,6 +499,12 @@ class _FPCoreCompileInstance(Visitor):
                 case Sum():
                     # sum expression
                     return self._visit_sum(e.arg, ctx)
+                case AMin():
+                    # min(xs) reduce-form
+                    return self._visit_amin(e.arg, ctx)
+                case AMax():
+                    # max(xs) reduce-form
+                    return self._visit_amax(e.arg, ctx)
                 case _:
                     raise NotImplementedError('no FPCore operator for', e)
 

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -508,8 +508,15 @@ class Parser:
                 return cls3(args[0], args[1], args[2], loc)
         elif fn in _nary_table:
             cls = _nary_table[fn]
-            if (cls is Min or cls is Max) and len(args) < 2:
-                raise self._parse_error(f'FPy expects at least 2 arguments for `{fn}`', e)
+            # min/max/fmin/fmax split at parse time by arity: 1 arg →
+            # reduce-form (AMin/AMax over a list), ≥ 2 args → variadic
+            # scalar form.  See AMin/AMax docstrings for the rationale.
+            if cls is Min and len(args) == 1:
+                return AMin(func, args[0], loc)
+            if cls is Max and len(args) == 1:
+                return AMax(func, args[0], loc)
+            if (cls is Min or cls is Max) and len(args) == 0:
+                raise self._parse_error(f'FPy expects at least 1 argument for `{fn}`', e)
             elif cls is Empty and len(args) < 1:
                 raise self._parse_error(f'FPy expects at least 1 argument for `{fn}`', e)
             if kwargs:

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -517,7 +517,7 @@ class Parser:
                 return AMax(func, args[0], loc)
             if (cls is Min or cls is Max) and len(args) == 0:
                 raise self._parse_error(f'FPy expects at least 1 argument for `{fn}`', e)
-            elif cls is Empty and len(args) < 1:
+            if cls is Empty and len(args) < 1:
                 raise self._parse_error(f'FPy expects at least 1 argument for `{fn}`', e)
             if kwargs:
                 raise self._parse_error(f'FPy does not support keyword arguments for `{fn}`', e)

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -586,6 +586,14 @@ class BytecodeCompiler(Visitor):
                 func = pyast.Name(id='__fpy_range', ctx=pyast.Load(), **attrs)
                 arg_none = pyast.Constant(value=None, kind=None, **attrs)
                 return pyast.Call(func=func, args=[arg_none, arg, arg_none], keywords=[], **attrs)
+            case AMin() | AMax():
+                # List-reduce form lowers to Python's built-in min/max on the
+                # iterable.  Matches the n-ary Min/Max emit (lines around 647)
+                # so ``min([a, b])`` and ``min(a, b)`` are observationally
+                # equivalent.
+                builtin = 'min' if isinstance(e, AMin) else 'max'
+                func = pyast.Name(id=builtin, ctx=pyast.Load(), **attrs)
+                return pyast.Call(func=func, args=[arg], keywords=[], **attrs)
             case _:
                 raise NotImplementedError(f'unsupported unary operation: {type(e).__name__}')
 

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -587,10 +587,8 @@ class BytecodeCompiler(Visitor):
                 arg_none = pyast.Constant(value=None, kind=None, **attrs)
                 return pyast.Call(func=func, args=[arg_none, arg, arg_none], keywords=[], **attrs)
             case AMin() | AMax():
-                # List-reduce form lowers to Python's built-in min/max on the
-                # iterable.  Matches the n-ary Min/Max emit (lines around 647)
-                # so ``min([a, b])`` and ``min(a, b)`` are observationally
-                # equivalent.
+                # Reduce-form lowers to Python's built-in min/max on the
+                # list, matching the n-ary Min/Max emit.
                 builtin = 'min' if isinstance(e, AMin) else 'max'
                 func = pyast.Name(id=builtin, ctx=pyast.Load(), **attrs)
                 return pyast.Call(func=func, args=[arg], keywords=[], **attrs)

--- a/tests/unit/generators/fpy_program.py
+++ b/tests/unit/generators/fpy_program.py
@@ -59,6 +59,8 @@ import fpy2 as fp
 from fpy2.ast.fpyast import (
     Abs,
     Add,
+    AMax,
+    AMin,
     And,
     Argument,
     Assign,
@@ -199,6 +201,8 @@ class RealProd(Flag):
     LOG = auto()
     EXP = auto()
     LEN = auto()
+    AMIN = auto()          # ``min(xs)`` reduce-form over ``xs : list[real]``
+    AMAX = auto()          # ``max(xs)`` reduce-form
     IF_EXPR = auto()
     ROUND = auto()
     CAST = auto()          # deferred; raises if generated
@@ -208,8 +212,9 @@ class RealProd(Flag):
     NUMERIC_LITERAL = INTEGER | DECNUM | HEXNUM | RATIONAL
     ARITH = ADD | SUB | MUL | DIV | NEG | ABS
     NAMED_UNARY = SQRT | SIN | COS | LOG | EXP
+    LIST_REDUCE = AMIN | AMAX
     LEAVES = NUMERIC_LITERAL | VAR
-    ALL = (LEAVES | ARITH | NAMED_UNARY | LEN | IF_EXPR | ROUND | CAST)
+    ALL = (LEAVES | ARITH | NAMED_UNARY | LEN | LIST_REDUCE | IF_EXPR | ROUND | CAST)
 
 
 class BoolProd(Flag):
@@ -319,7 +324,16 @@ _DEFERRED_STMT: StmtProd = StmtProd.INDEXED_ASSIGN | StmtProd.TUPLE_UNPACK_ASSIG
 # Productions whose generators are implemented but noticeably slow to
 # draw — opt in explicitly when the test needs them (typically by
 # OR-ing into a narrowed ``real_prods``).
-_SLOW_REAL: RealProd = RealProd.DECNUM | RealProd.HEXNUM | RealProd.RATIONAL
+#
+# ``AMIN`` / ``AMAX`` are slow because each draw spins up a fresh
+# ``_list_expr`` sub-strategy that recursively generates a list of
+# reals — twice over (one per production).  ``LEN`` already takes this
+# path on its own; adding AMIN+AMAX triples that cost and pushes
+# Hypothesis past the ``too_slow`` health check.
+_SLOW_REAL: RealProd = (
+    RealProd.DECNUM | RealProd.HEXNUM | RealProd.RATIONAL
+    | RealProd.AMIN | RealProd.AMAX
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -494,6 +508,23 @@ def _real_expr(
             inner.append(sub_real_list.map(
                 lambda xs: Len(_func_sym('len'), xs, None)
             ))
+        # ``min(xs)`` / ``max(xs)`` over ``xs : list[real]``.  Distinct AST
+        # nodes from the variadic scalar ``Min``/``Max`` (which the
+        # generator does not yet emit).  Reuses the same list-of-real
+        # sub-strategy as ``LEN``.
+        if RealProd.AMIN in use or RealProd.AMAX in use:
+            sub_real_list = _list_expr(
+                RealType(), env, depth - 1, grammar=grammar,
+                range_arg_min=rmin, range_arg_max=rmax,
+            )
+            if RealProd.AMIN in use:
+                inner.append(sub_real_list.map(
+                    lambda xs: AMin(_func_sym('min'), xs, None)
+                ))
+            if RealProd.AMAX in use:
+                inner.append(sub_real_list.map(
+                    lambda xs: AMax(_func_sym('max'), xs, None)
+                ))
         if RealProd.ROUND in use:
             # ``Cast`` is deliberately not generated: it asserts the
             # rounded value is exact, which fails whenever the value


### PR DESCRIPTION
Adds a list-reduce form of min/max alongside the existing variadic scalar form, dispatched by arity at parse time:

  - `min(xs)` where xs: list[real] → new `AMin` node — signature `list[real] -> real`
  - `min(a, b, ...)` (≥ 2 args) → existing `Min` node — signature `real -> ... -> real`

The same split applies to max. Naming follows NumPy's amax/amin.