### PR TITLE
Support `uv` installs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,15 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
+          enable-cache: true
           python-version: "3.11"
-      - name: Install dependencies
-        run: python -m pip install --upgrade pip
       - name: Install fpy2
-        run: pip install -e .[dev]
+        run: uv sync
       - name: "Create empty directories"
         run: mkdir docs/source/_static
       - name: "Generate documentation"
-        run: make html -C docs/ 
+        run: uv run make html -C docs/

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -6,8 +6,30 @@ env:
   FPBENCH: ~/fpbench
 
 jobs:
-  build:
-    name: "Build"
+  # Verify the project builds and installs cleanly under each supported
+  # Python version, via both install paths.  ``uv`` is our primary
+  # workflow; the ``pip`` variant keeps the legacy ``pip install -e .[dev]``
+  # entry point from regressing.
+  build-uv:
+    name: "Build (uv)"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - name: Build package
+        run: uv build
+      - name: Install fpy2
+        run: uv sync
+
+  build-pip:
+    name: "Build (pip)"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,39 +46,35 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Install fpy2
-        run: pip install .
+        run: pip install -e .[dev]
 
   mypy:
     name: "Mypy analyzer"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
+          enable-cache: true
           python-version: "3.11"
-      - name: Install dependencies
-        run: python -m pip install --upgrade pip mypy
-      - name: Install fpy2
-        run: pip install .
+      - name: Install
+        run: uv sync
       - name: Check
-        run: mypy fpy2
+        run: uv run mypy fpy2
 
   ruff:
     name: "Ruff linter"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
+          enable-cache: true
           python-version: "3.11"
-      - name: Install dependencies
-        run: python -m pip install --upgrade pip ruff
-      - name: Install fpy2
-        run: pip install .
+      - name: Install
+        run: uv sync
       - name: Lint
-        run: ruff check fpy2/
+        run: uv run ruff check fpy2/
 
   unit:
     name: "Unit Tests"
@@ -68,20 +86,16 @@ jobs:
         with:
           repository: fpbench/fpbench
           path: ~/fpbench
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.11'
-      - name: Create virtual environment
-        run: python3 -m venv .env/
-      - name: Activate virtual environment
-        run: source .env/bin/activate
+          enable-cache: true
+          python-version: "3.11"
       - name: Install
-        run: pip install -e .[dev]
+        run: uv sync
       - name: Unit Tests
-        run: make unittest
+        run: uv run make unittest
       - name: Infrastucture Tests
-        run: python3 -m tests.infra
+        run: uv run python -m tests.infra
 
   fpcore:
     name: "FPCore tests"
@@ -93,18 +107,14 @@ jobs:
         with:
           repository: fpbench/fpbench
           path: ~/fpbench
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.11'
-      - name: Create virtual environment
-        run: python3 -m venv .env/
-      - name: Activate virtual environment
-        run: source .env/bin/activate
+          enable-cache: true
+          python-version: "3.11"
       - name: Install
-        run: pip install -e .[dev]
+        run: uv sync
       - name: Compilation tests
-        run: python3 -m tests.infra.fpcore
+        run: uv run python -m tests.infra.fpcore
 
   cpp:
     name: "C++ tests"
@@ -116,18 +126,14 @@ jobs:
         with:
           repository: fpbench/fpbench
           path: ~/fpbench
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.11'
-      - name: Create virtual environment
-        run: python3 -m venv .env/
-      - name: Activate virtual environment
-        run: source .env/bin/activate
+          enable-cache: true
+          python-version: "3.11"
       - name: Install
-        run: pip install -e .[dev]
+        run: uv sync
       - name: Tests (C++)
-        run: python3 -m tests.infra.backend.cpp
+        run: uv run python -m tests.infra.backend.cpp
 
   sweep:
     name: "Sweep"
@@ -140,15 +146,11 @@ jobs:
         with:
           repository: fpbench/fpbench
           path: ~/fpbench
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.11'
-      - name: Create virtual environment
-        run: python3 -m venv .env/
-      - name: Activate virtual environment
-        run: source .env/bin/activate
+          enable-cache: true
+          python-version: "3.11"
       - name: Install
-        run: pip install -e .[dev]
+        run: uv sync
       - name: Sweep (fused_dp)
-        run: python3 -m exploration.fused_dp.sweep --threads 2 1_000
+        run: uv run python -m exploration.fused_dp.sweep --threads 2 1_000

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# uv — fpy2 is a library; contributors should resolve fresh deps
+uv.lock
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,9 +87,8 @@ make ruff    # Lint only
 ## Development Setup
 
 ```bash
-python3 -m venv .venv/
-source .venv/bin/activate
-make install-dev   # Installs fpy2 in editable mode with dev dependencies
+uv sync                       # creates .venv/ and installs fpy2 + dev deps
+source .venv/bin/activate     # or prefix commands with `uv run`
 ```
 
 ## Examples

--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,6 @@ docs:
 	@echo "Building documentation..."
 	make html -C docs/
 
-install:
-	@echo "Installing fpy2..."
-	pip install .
-
-install-dev:
-	@echo "Installing fpy2 in development mode..."
-	pip install -e .[dev]
-
-uninstall:
-	@echo "Uninstalling fpy2..."
-	pip uninstall -y fpy2
-
 lint:
 	@echo "Running linters..."
 	$(MAKE) mypy
@@ -73,11 +61,8 @@ help:
 	@echo "   - make mypy       Run mypy type checker"
 	@echo "   - make ruff       Run ruff linter"
 	@echo ""
-	@echo "Install / Build"
-	@echo "  make build         Build the fpy2 package"
-	@echo "  make install       Install the fpy2 package"
-	@echo "  make install-dev   Install the fpy2 package in development mode"
-	@echo "  make uninstall     Uninstall the fpy2 package"
+	@echo "Build"
+	@echo "  make build         Build the fpy2 package (sdist + wheel)"
 	@echo ""
 	@echo "Documentation"
 	@echo "  make docs          Build the documentation"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Requirements:
  - Python 3.11 or later
  - `make`
 
-### Installation
+#### With `pip`
 
 If you do not have a Python virtual environment,
 create one using
@@ -54,6 +54,20 @@ To uninstall FPy, run:
 ```bash
 pip uninstall fpy2
 ```
+
+#### With `uv`
+
+[uv](https://docs.astral.sh/uv/) handles the virtual environment and
+dependency installation in one step:
+```bash
+uv sync
+```
+This creates `.venv/` and installs FPy in editable mode along with the
+`dev` dependency group.  Activate the environment with
+```bash
+source .venv/bin/activate
+```
+or prefix individual commands with `uv run` (e.g. `uv run pytest tests/unit`).
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -10,16 +10,20 @@ Important links:
 
 ## Installation
 
-The recommended way to install FPy is through `pip`.
-FPy can also be installed from source for development.
-The following instructions assume a `bash`-like shell.
+FPy can be installed from PyPI with either `uv` or `pip`, or built from
+source for development.  The following instructions assume a `bash`-like
+shell.
 
-### Installing with `pip`
+### Installing from PyPI
 
 Requirements:
  - Python 3.11 or later
 
 To install the latest stable release of FPy, run:
+```bash
+uv pip install fpy2
+```
+or, with `pip`:
 ```bash
 pip install fpy2
 ```
@@ -30,35 +34,11 @@ Requirements:
  - Python 3.11 or later
  - `make`
 
-#### With `pip`
+#### With `uv` (preferred)
 
-If you do not have a Python virtual environment,
-create one using
-```bash
-python3 -m venv .env/
-```
-and activate it using using
-```bash
-source .env/bin/activate
-```
-To install an instance of FPy for development, run:
-```bash
-pip install -e .[dev]
-```
-or with `make`, run
-```bash
-make install-dev
-```
-
-To uninstall FPy, run:
-```bash
-pip uninstall fpy2
-```
-
-#### With `uv`
-
-[uv](https://docs.astral.sh/uv/) handles the virtual environment and
-dependency installation in one step:
+[uv](https://docs.astral.sh/uv/) is the recommended development
+workflow — it handles the virtual environment and dependency
+installation in a single step:
 ```bash
 uv sync
 ```
@@ -68,6 +48,30 @@ This creates `.venv/` and installs FPy in editable mode along with the
 source .venv/bin/activate
 ```
 or prefix individual commands with `uv run` (e.g. `uv run pytest tests/unit`).
+
+#### With `pip` (legacy)
+
+This path is preserved for compatibility with existing tooling; new
+contributors should prefer `uv` above.
+
+If you do not have a Python virtual environment,
+create one using
+```bash
+python3 -m venv .venv/
+```
+and activate it using
+```bash
+source .venv/bin/activate
+```
+To install an instance of FPy for development, run:
+```bash
+pip install -e .[dev]
+```
+
+To uninstall FPy, run:
+```bash
+pip uninstall fpy2
+```
 
 ### Testing
 

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -7,29 +7,46 @@ Developers of FPy should read this section since
 installing FPy is actually different.
 
 Requirements:
- 
+
 * Python 3.11 or later
 * `make`
 
 Installation
 ------------------
 
-If you do not have a Python virtual environment,
-create one using::
+With ``uv`` (preferred)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    python3 -m venv .env/
+`uv <https://docs.astral.sh/uv/>`_ is the recommended development
+workflow.  It handles the virtual environment and dependency
+installation in a single step::
 
-and activate it using using::
+    uv sync
 
-    source .env/bin/activate
+This creates ``.venv/`` and installs FPy in editable mode along with
+the ``dev`` dependency group.  Activate the environment with::
+
+    source .venv/bin/activate
+
+or prefix individual commands with ``uv run`` (e.g. ``uv run pytest tests/unit``).
+
+With ``pip`` (legacy)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This path is preserved for compatibility with existing tooling; new
+contributors should prefer ``uv`` above.
+
+If you do not have a Python virtual environment, create one using::
+
+    python3 -m venv .venv/
+
+and activate it using::
+
+    source .venv/bin/activate
 
 To install an instance of FPy for development, run::
 
     pip install -e .[dev]
-
-or with `make`, run::
-
-    make install-dev
 
 Testing
 ------------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -7,32 +7,12 @@ Requirements:
 
 * Python 3.11 or later
 
-The following instructions assume a `bash`-like shell.
-If you do not have a Python virtual environment,
-create one using::
+To install the latest stable release of FPy from PyPI, run::
 
-    python3 -m venv .env/
+    uv pip install fpy2
 
-and activate it using using::
+or, with ``pip``::
 
-    source .env/bin/activate
+    pip install fpy2
 
-To install a _frozen_ instance of FPy, run::
-
-    pip install .
-
-or with `make`, run::
-
-    make install
-
-Note that this will not install the necessary dependencies for
-development and installs a copy of the `fpy2` package.
-
-.. note::
-
-    If you checkout a different commit or branch, you will
-    need to reinstall FPy to overwrite the previous version.
-
-    To uninstall FPy, run::
-
-        pip uninstall fpy2
+To install from source, see :doc:`developers`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,24 @@ dependencies = [
   "matplotlib"
 ]
 
+# ``dev`` deps are listed twice on purpose: ``[project.optional-dependencies]``
+# keeps ``pip install -e .[dev]`` working, while ``[dependency-groups]`` is
+# the PEP 735 surface uv reads when running plain ``uv sync``.  Keep the two
+# lists in sync when adding or removing dev deps.
 [project.optional-dependencies]
+dev = [
+  "pytest",
+  "hypothesis==6.135",
+  "mypy",
+  "ruff",
+  "build",
+  "twine",
+  "sphinx",
+  "sphinx-rtd-theme",
+  "sphinx-pyproject"
+]
+
+[dependency-groups]
 dev = [
   "pytest",
   "hypothesis==6.135",


### PR DESCRIPTION
Updates the pyproject.toml, CI, and docs to support `uv` installation, the now preferred installation method.