### PR TITLE
Fix `min/max` semantics

### DIFF
--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -1513,7 +1513,10 @@ class CppEmitter(Visitor):
             for a, s in zip(args, arg_storages)
         ]
         if target.is_float():
-            fn = 'std::fmin' if isinstance(e, Min) else 'std::fmax'
+            # NaN-propagating wrapper around ``std::fmin`` / ``std::fmax``
+            # (see :data:`CPP_HELPERS`).  ±0 ordering is delegated to the
+            # underlying ``std::fmin`` / ``std::fmax``.
+            fn = '__fpy_min' if isinstance(e, Min) else '__fpy_max'
         else:
             fn = 'std::min' if isinstance(e, Min) else 'std::max'
         result = casted[0]
@@ -1550,7 +1553,9 @@ class CppEmitter(Visitor):
             )
         elt_ty = arg_storage.elt
         if result_ty.is_float():
-            fn = 'std::fmin' if isinstance(e, AMin) else 'std::fmax'
+            # NaN-propagating wrapper around ``std::fmin`` / ``std::fmax``;
+            # see :meth:`_emit_min_max` and :data:`CPP_HELPERS`.
+            fn = '__fpy_min' if isinstance(e, AMin) else '__fpy_max'
         else:
             fn = 'std::min' if isinstance(e, AMin) else 'std::max'
 

--- a/fpy2/backend/cpp/utils.py
+++ b/fpy2/backend/cpp/utils.py
@@ -37,9 +37,38 @@ CPP_HEADERS: tuple[str, ...] = (
     '#include <cmath>',
     '#include <cstddef>',
     '#include <cstdint>',
+    '#include <limits>',
     '#include <numeric>',
     '#include <vector>',
     '#include <tuple>',
 )
 
-CPP_HELPERS: str = ''
+# IEEE 754-2019 ``minimum`` / ``maximum`` for floating-point ``T``:
+# NaN-propagating and signed-zero-correct.  ``std::fmin`` / ``std::fmax``
+# follow C99 / IEEE 754-2008 ``minNum`` (NaN-ignoring), and on libstdc++
+# the non-constant-folded path is just ``(a < b) ? a : b``, which loses
+# the ±0 distinction (``std::fmin(-0.0, +0.0)`` with variable operands
+# returns ``+0`` instead of ``-0``).  The explicit ``a == b`` tie-break
+# fixes both issues.
+#
+# Only emitted for floating-point ``T``; integer ``min`` / ``max``
+# continue to use ``std::min`` / ``std::max`` (no NaN, no signed-zero).
+CPP_HELPERS: str = '''\
+template <typename T>
+inline T __fpy_min(T a, T b) {
+    if (std::isnan(a) || std::isnan(b))
+        return std::numeric_limits<T>::quiet_NaN();
+    if (a == b)
+        return std::signbit(a) ? a : b;
+    return (a < b) ? a : b;
+}
+
+template <typename T>
+inline T __fpy_max(T a, T b) {
+    if (std::isnan(a) || std::isnan(b))
+        return std::numeric_limits<T>::quiet_NaN();
+    if (a == b)
+        return std::signbit(a) ? b : a;
+    return (a < b) ? b : a;
+}
+'''

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -393,25 +393,72 @@ class _FPCoreCompileInstance(Visitor):
                 )
             )
 
+    def _fpc_minimum(self, a: fpc.Expr, b: fpc.Expr) -> fpc.Expr:
+        """IEEE 754-2019 ``minimum(a, b)`` — NaN-propagating and
+        signed-zero-correct.  Built as::
+
+            (let ([_a a] [_b b])
+              (if (or (isnan _a) (isnan _b))
+                  NAN
+                  (if (== _a _b)
+                      (if (signbit _a) _a _b)    ; min picks -0 over +0
+                      (if (< _a _b) _a _b))))
+
+        FPCore's built-in ``fmin`` follows C99 / IEEE 754-2008 ``minNum``
+        (NaN-ignoring, ±0 unspecified), which doesn't match FPy's
+        interpreter; this wrapper makes the emitted FPCore deterministic.
+        """
+        a_id = str(self.gensym.fresh('a'))
+        b_id = str(self.gensym.fresh('b'))
+        return fpc.Let(
+            [(a_id, a), (b_id, b)],
+            fpc.If(
+                fpc.Or(fpc.Isnan(a_id), fpc.Isnan(b_id)),
+                fpc.Constant('NAN'),
+                fpc.If(
+                    fpc.EQ(a_id, b_id),
+                    fpc.If(fpc.Signbit(a_id), a_id, b_id),
+                    fpc.If(fpc.LT(a_id, b_id), a_id, b_id),
+                ),
+            ),
+        )
+
+    def _fpc_maximum(self, a: fpc.Expr, b: fpc.Expr) -> fpc.Expr:
+        """IEEE 754-2019 ``maximum(a, b)`` — mirrors :meth:`_fpc_minimum`
+        with the branches swapped so the equal-magnitude tie picks ``+0``
+        and the inequality branch picks the larger operand."""
+        a_id = str(self.gensym.fresh('a'))
+        b_id = str(self.gensym.fresh('b'))
+        return fpc.Let(
+            [(a_id, a), (b_id, b)],
+            fpc.If(
+                fpc.Or(fpc.Isnan(a_id), fpc.Isnan(b_id)),
+                fpc.Constant('NAN'),
+                fpc.If(
+                    fpc.EQ(a_id, b_id),
+                    fpc.If(fpc.Signbit(a_id), b_id, a_id),
+                    fpc.If(fpc.LT(a_id, b_id), b_id, a_id),
+                ),
+            ),
+        )
+
     def _visit_min(self, args: tuple[Expr, ...], ctx: None) -> fpc.Expr:
-        # expand min expression by left associativity
-        # at least two arguments
-        # (fmin (fmin (fmin t1 t2) t3) ... tn)
+        # Left-fold pairwise via the NaN-propagating, signed-zero-correct
+        # minimum (see :meth:`_fpc_minimum`).
         vals = [self._visit_expr(arg, ctx) for arg in args]
         min_expr = vals[0]
         for val in vals[1:]:
-            min_expr = fpc.Fmin(min_expr, val)
+            min_expr = self._fpc_minimum(min_expr, val)
         return min_expr
 
     def _visit_max(self, args: tuple[Expr, ...], ctx: None) -> fpc.Expr:
-        # expand max expression by left associativity
-        # at least two arguments
-        # (fmax (fmax (fmax t1 t2) t3) ... tn)
+        # Left-fold pairwise via the NaN-propagating, signed-zero-correct
+        # maximum (see :meth:`_fpc_maximum`).
         vals = [self._visit_expr(arg, ctx) for arg in args]
-        min_expr = vals[0]
+        max_expr = vals[0]
         for val in vals[1:]:
-            min_expr = fpc.Fmax(min_expr, val)
-        return min_expr
+            max_expr = self._fpc_maximum(max_expr, val)
+        return max_expr
 
     def _visit_sum(self, arg: Expr, ctx: None) -> fpc.Expr:
         # sum(xs) → fold over the list with +.  Shape documented on
@@ -419,12 +466,13 @@ class _FPCoreCompileInstance(Visitor):
         return self._visit_list_reduce(arg, fpc.Add, ctx)
 
     def _visit_amin(self, arg: Expr, ctx: None) -> fpc.Expr:
-        # min(xs) → fold over the list with fmin.  Mirrors _visit_sum.
-        return self._visit_list_reduce(arg, fpc.Fmin, ctx)
+        # min(xs) → fold over the list with the IEEE 754-2019 ``minimum``
+        # (see :meth:`_fpc_minimum`).
+        return self._visit_list_reduce(arg, self._fpc_minimum, ctx)
 
     def _visit_amax(self, arg: Expr, ctx: None) -> fpc.Expr:
-        # max(xs) → fold over the list with fmax.  Mirrors _visit_sum.
-        return self._visit_list_reduce(arg, fpc.Fmax, ctx)
+        # max(xs) → fold over the list with the IEEE 754-2019 ``maximum``.
+        return self._visit_list_reduce(arg, self._fpc_maximum, ctx)
 
     def _visit_list_reduce(
         self,

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -320,6 +320,91 @@ def _eval_sum(val: list[RealValue], ctx: Context):
             accum = ops.add(accum, x, ctx=ctx)
         return accum
 
+def _unchecked_min(vals: list[RealValue]):
+    # propagate any NaN input
+    for x in vals:
+        if isinstance(x, Float) and x.isnan:
+            return x
+
+    # cannot use the built-in min function because of signed zeros
+    result = vals[0]
+    for x in vals[1:]:
+        if x < result:
+            result = x
+        elif (x == result
+            and isinstance(x, Float) and isinstance(result, Float)
+            and x.s and not result.s):
+            result = x  # x is -0, result is +0 → prefer -0 for min
+    return result
+
+def _unchecked_max(vals: list[RealValue]):
+    """
+    Performs IEEE 754 compliant maximum operation.
+    - propagates NaN inputs (if any argument is NaN, the result is NaN).
+    - max(+0.0, -0.0) == max(-0.0, +0.0) == +0.0.
+    """
+    # propagate any NaN input
+    for x in vals:
+        if isinstance(x, Float) and x.isnan:
+            return x
+
+    # cannot use the built-in max function because of signed zeros
+    result = vals[0]
+    for x in vals[1:]:
+        if x > result:
+            result = x
+        elif (x == result
+            and isinstance(x, Float) and isinstance(result, Float)
+            and not x.s and result.s):
+            result = x  # x is +0, result is -0 → prefer +0 for max
+    return result
+
+def _eval_min(arg, *args):
+    """
+    Performs IEEE 754 compliant minimum operation.
+    - propagates NaN inputs (if any argument is NaN, the result is NaN).
+    - min(+0.0, -0.0) == min(-0.0, +0.0) == -0.0.
+    """
+    if args:
+        # if there are additional values, combine them with the first value into a single list
+        vals = [arg] + list(args)
+    else:
+        # if there are no additional values, we assume its a non-empty list
+        if not isinstance(arg, list):
+            raise TypeError(f'expected a list, got {arg}')
+        if len(arg) == 0:
+            raise ValueError('min() arg is an empty sequence')
+        vals = arg
+
+    # every element must be a real number
+    for x in vals:
+        if not isinstance(x, RealValue):
+            raise TypeError(f'expected a real number argument, got {x}')
+
+    # call the underlying NaN-propagating minimum function
+    return _unchecked_min(vals)
+
+
+def _eval_max(arg, *args):
+    if args:
+        # if there are additional values, combine them with the first value into a single list
+        vals = [arg] + list(args)
+    else:
+        # if there are no additional values, we assume its a non-empty list
+        if not isinstance(arg, list):
+            raise TypeError(f'expected a list, got {arg}')
+        if len(arg) == 0:
+            raise ValueError('max() arg is an empty sequence')
+        vals = arg
+
+    # every element must be a real number
+    for x in vals:
+        if not isinstance(x, RealValue):
+            raise TypeError(f'expected a real number argument, got {x}')
+
+    # call the underlying NaN-propagating maximum function
+    return _unchecked_max(vals)
+
 ###########################################################
 # Operator tables
 
@@ -429,6 +514,8 @@ def make_namespace() -> dict[str, object]:
         '__fpy_list_set': _eval_list_set,
         '__fpy_list_slice': _eval_list_slice,
         '__fpy_range': _eval_range,
+        '__fpy_min': _eval_min,
+        '__fpy_max': _eval_max,
     }
 
     # add operations to the namespace
@@ -593,7 +680,7 @@ class BytecodeCompiler(Visitor):
             case AMin() | AMax():
                 # Reduce-form lowers to Python's built-in min/max on the
                 # list, matching the n-ary Min/Max emit.
-                builtin = 'min' if isinstance(e, AMin) else 'max'
+                builtin = '__fpy_min' if isinstance(e, AMin) else '__fpy_max'
                 func = pyast.Name(id=builtin, ctx=pyast.Load(), **attrs)
                 return pyast.Call(func=func, args=[arg], keywords=[], **attrs)
             case _:
@@ -655,10 +742,10 @@ class BytecodeCompiler(Visitor):
             case Or():
                 return pyast.BoolOp(op=pyast.Or(), values=args, **attrs)
             case Max():
-                func = pyast.Name(id='max', ctx=pyast.Load(), **attrs)
+                func = pyast.Name(id='__fpy_max', ctx=pyast.Load(), **attrs)
                 return pyast.Call(func=func, args=args, keywords=[], **attrs)
             case Min():
-                func = pyast.Name(id='min', ctx=pyast.Load(), **attrs)
+                func = pyast.Name(id='__fpy_min', ctx=pyast.Load(), **attrs)
                 return pyast.Call(func=func, args=args, keywords=[], **attrs)
             case Zip():
                 # first zip the arguments with `strict=True` to ensure they have the same length

--- a/tests/unit/interpret/test_min_max.py
+++ b/tests/unit/interpret/test_min_max.py
@@ -1,0 +1,261 @@
+"""
+Interpreter behaviour of ``min`` and ``max`` for IEEE 754 special values.
+
+Two cases the interpreter must handle to match the cpp / FPCore backends:
+
+1. **NaN propagation.** FPy's contract is that any NaN input yields a
+   NaN result.  Python's built-in ``min`` / ``max`` are based on ``<``
+   comparisons and pick whichever operand they see first, so
+   ``max(1.0, nan) == 1.0`` and ``max(nan, 1.0)`` is ``nan`` — an
+   order-dependent quirk that no IEEE 754 variant defines.  The
+   interpreter wraps Python's builtins with a NaN-aware helper to fix
+   this.
+
+2. **Signed zero.** IEEE 754 specifies ``min(-0, +0) = -0`` and
+   ``max(-0, +0) = +0`` regardless of argument order; Python's
+   ``min(+0.0, -0.0) == +0.0`` violates the order-independence.
+
+Each test class covers both the variadic form (``min(a, b, …)`` →
+:class:`Min` / :class:`Max`) and the reduce form (``min(xs)`` →
+:class:`AMin` / :class:`AMax`).
+"""
+
+import math
+import pytest
+
+import fpy2 as fp
+
+
+def _is_nan(x) -> bool:
+    """True iff *x* is a NaN of any precision."""
+    return math.isnan(float(x))
+
+
+def _is_neg_zero(x) -> bool:
+    """True iff *x* is the negative-zero representative."""
+    f = float(x)
+    return f == 0.0 and math.copysign(1.0, f) == -1.0
+
+
+def _is_pos_zero(x) -> bool:
+    """True iff *x* is the positive-zero representative."""
+    f = float(x)
+    return f == 0.0 and math.copysign(1.0, f) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Variadic form — ``min(a, b, ...)`` → ``Min``, ``max(a, b, ...)`` → ``Max``
+# ---------------------------------------------------------------------------
+
+
+class TestVariadicNaN:
+    """``Min`` / ``Max`` propagate NaN regardless of argument position."""
+
+    def test_min_nan_first(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return min(a, b)
+        assert _is_nan(f(math.nan, 1.0, ctx=fp.FP64))
+
+    def test_min_nan_second(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return min(a, b)
+        assert _is_nan(f(1.0, math.nan, ctx=fp.FP64))
+
+    def test_max_nan_first(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return max(a, b)
+        assert _is_nan(f(math.nan, 1.0, ctx=fp.FP64))
+
+    def test_max_nan_second(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return max(a, b)
+        assert _is_nan(f(1.0, math.nan, ctx=fp.FP64))
+
+    def test_min_both_nan(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return min(a, b)
+        assert _is_nan(f(math.nan, math.nan, ctx=fp.FP64))
+
+    def test_max_nan_in_middle_of_three(self):
+        """Three-arg min/max with NaN sandwiched between finite values."""
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
+            return max(a, b, c)
+        assert _is_nan(f(1.0, math.nan, 2.0, ctx=fp.FP64))
+
+    def test_min_nan_at_end_of_three(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
+            return min(a, b, c)
+        assert _is_nan(f(1.0, 2.0, math.nan, ctx=fp.FP64))
+
+
+class TestVariadicSignedZero:
+    """``Min`` / ``Max`` respect IEEE 754 signed-zero ordering."""
+
+    def test_min_neg_pos_zero(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return min(a, b)
+        assert _is_neg_zero(f(-0.0, 0.0, ctx=fp.FP64))
+
+    def test_min_pos_neg_zero(self):
+        """Order-independent: ``min(+0, -0)`` must still be ``-0``."""
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return min(a, b)
+        assert _is_neg_zero(f(0.0, -0.0, ctx=fp.FP64))
+
+    def test_max_neg_pos_zero(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return max(a, b)
+        assert _is_pos_zero(f(-0.0, 0.0, ctx=fp.FP64))
+
+    def test_max_pos_neg_zero(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return max(a, b)
+        assert _is_pos_zero(f(0.0, -0.0, ctx=fp.FP64))
+
+
+class TestVariadicSanity:
+    """``Min`` / ``Max`` still behave correctly on ordinary inputs —
+    the NaN / signed-zero handling must not break the finite case."""
+
+    def test_min_pairwise(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return min(a, b)
+        assert float(f(1.0, 2.0, ctx=fp.FP64)) == 1.0
+        assert float(f(2.0, 1.0, ctx=fp.FP64)) == 1.0
+
+    def test_max_pairwise(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return max(a, b)
+        assert float(f(1.0, 2.0, ctx=fp.FP64)) == 2.0
+        assert float(f(2.0, 1.0, ctx=fp.FP64)) == 2.0
+
+    def test_min_three_args(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
+            return min(a, b, c)
+        assert float(f(3.0, 1.0, 2.0, ctx=fp.FP64)) == 1.0
+
+    def test_max_with_inf(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return max(a, b)
+        assert math.isinf(float(f(math.inf, 1.0, ctx=fp.FP64)))
+
+    def test_min_with_neg_inf(self):
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            return min(a, b)
+        result = float(f(-math.inf, 1.0, ctx=fp.FP64))
+        assert math.isinf(result) and result < 0
+
+
+# ---------------------------------------------------------------------------
+# Reduce form — ``min(xs)`` → ``AMin``, ``max(xs)`` → ``AMax``
+# ---------------------------------------------------------------------------
+
+
+class TestReduceNaN:
+    """``AMin`` / ``AMax`` propagate NaN from any list position."""
+
+    def test_amin_nan_first(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        assert _is_nan(f([math.nan, 1.0, 2.0], ctx=fp.FP64))
+
+    def test_amin_nan_last(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        assert _is_nan(f([1.0, 2.0, math.nan], ctx=fp.FP64))
+
+    def test_amax_nan_middle(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return max(xs)
+        assert _is_nan(f([1.0, math.nan, 2.0], ctx=fp.FP64))
+
+    def test_amin_singleton_nan(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        assert _is_nan(f([math.nan], ctx=fp.FP64))
+
+
+class TestReduceSignedZero:
+    """``AMin`` / ``AMax`` respect IEEE 754 signed-zero ordering."""
+
+    def test_amin_neg_then_pos_zero(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        assert _is_neg_zero(f([-0.0, 0.0], ctx=fp.FP64))
+
+    def test_amin_pos_then_neg_zero(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        assert _is_neg_zero(f([0.0, -0.0], ctx=fp.FP64))
+
+    def test_amax_neg_then_pos_zero(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return max(xs)
+        assert _is_pos_zero(f([-0.0, 0.0], ctx=fp.FP64))
+
+    def test_amax_pos_then_neg_zero(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return max(xs)
+        assert _is_pos_zero(f([0.0, -0.0], ctx=fp.FP64))
+
+    def test_amin_zeros_among_positives(self):
+        """``min([1.0, -0.0, 0.0, 2.0])`` → -0 (not just any zero)."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        assert _is_neg_zero(f([1.0, -0.0, 0.0, 2.0], ctx=fp.FP64))
+
+
+class TestReduceSanity:
+    """``AMin`` / ``AMax`` correctness on ordinary lists."""
+
+    def test_amin_basic(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        assert float(f([3.0, 1.0, 4.0, 1.0, 5.0], ctx=fp.FP64)) == 1.0
+
+    def test_amax_basic(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return max(xs)
+        assert float(f([3.0, 1.0, 4.0, 1.0, 5.0], ctx=fp.FP64)) == 5.0
+
+    def test_amin_singleton(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        assert float(f([42.0], ctx=fp.FP64)) == 42.0
+
+    def test_amin_empty_raises(self):
+        """Empty list is UB at the FPy contract level; the interpreter
+        surfaces it as a Python ``ValueError`` (matches ``min([])``)."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return min(xs)
+        with pytest.raises(ValueError):
+            f([], ctx=fp.FP64)


### PR DESCRIPTION
Python's `min/max` is not IEEE 754 compliant. This PR ensures that the functions agree with the IEEE 754 "minimum" and "maximum" functions. They propagate any NaN input and they prefer one zero over the other (+0 is "larger" than -0).