### PR TITLE
Better simplification passes

### DIFF
--- a/fpy2/analysis/partial_eval.py
+++ b/fpy2/analysis/partial_eval.py
@@ -238,6 +238,22 @@ class _PartialEvalInstance(DefaultVisitor):
             e_eval = ListSlice(v, s, t, e.loc)
             self._record(e, self._try_eval(e_eval, ctx))
 
+    def _visit_if_expr(self, e: IfExpr, ctx: Context | None):
+        # Selection, not arithmetic — no rounding; ctx is irrelevant.
+        # When the condition is statically known we copy the chosen
+        # branch's value (the other branch need not be foldable).
+        self._visit_expr(e.cond, ctx)
+        self._visit_expr(e.ift, ctx)
+        self._visit_expr(e.iff, ctx)
+        if not self._is_value(e.cond):
+            return
+        cond_val = self.by_expr[e.cond]
+        if not isinstance(cond_val, bool):
+            return
+        branch = e.ift if cond_val else e.iff
+        if self._is_value(branch):
+            self.by_expr[e] = self.by_expr[branch]
+
     def _visit_attribute(self, e: Attribute, ctx: Context | None):
         self._visit_expr(e.value, ctx)
         if self._is_value(e.value):

--- a/fpy2/analysis/partial_eval.py
+++ b/fpy2/analysis/partial_eval.py
@@ -239,9 +239,8 @@ class _PartialEvalInstance(DefaultVisitor):
             self._record(e, self._try_eval(e_eval, ctx))
 
     def _visit_if_expr(self, e: IfExpr, ctx: Context | None):
-        # Selection, not arithmetic — no rounding; ctx is irrelevant.
-        # When the condition is statically known we copy the chosen
-        # branch's value (the other branch need not be foldable).
+        # When the condition is statically known, copy the chosen
+        # branch's value — the unchosen branch need not be foldable.
         self._visit_expr(e.cond, ctx)
         self._visit_expr(e.ift, ctx)
         self._visit_expr(e.iff, ctx)

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -1313,7 +1313,7 @@ class ListExpr(Expr):
 
     def is_equiv(self, other) -> bool:
         return (
-            isinstance(other, TupleExpr)
+            isinstance(other, ListExpr)
             and len(self.elts) == len(other.elts)
             and all(arg.is_equiv(other_arg) for arg, other_arg in zip(self.elts, other.elts))
         )

--- a/fpy2/strategies/simple.py
+++ b/fpy2/strategies/simple.py
@@ -16,20 +16,24 @@ def simplify(
     enable_dead_code_elim: bool = True
 ) -> Function:
     """Apply :class:`ConstFold` + :class:`CopyPropagate` +
-    :class:`DeadCodeEliminate` to *func* until fixpoint."""
+    :class:`DeadCodeEliminate` to *func* until none of the enabled
+    passes report a change."""
     if not isinstance(func, Function):
         raise TypeError(f"Expected a \'Function\', got {func}")
     ast = func.ast
 
-    eliminated = True
-    while eliminated:
+    while True:
+        changed = False
         if enable_const_fold:
-            ast = ConstFold.apply(ast)
+            ast, c = ConstFold.apply_with_status(ast)
+            changed |= c
         if enable_copy_prop:
-            ast = CopyPropagate.apply(ast)
+            ast, c = CopyPropagate.apply_with_status(ast)
+            changed |= c
         if enable_dead_code_elim:
-            ast, eliminated = DeadCodeEliminate.apply_with_status(ast)
-        else:
-            eliminated = False
+            ast, c = DeadCodeEliminate.apply_with_status(ast)
+            changed |= c
+        if not changed:
+            break
 
     return func.with_ast(ast)

--- a/fpy2/strategies/simple.py
+++ b/fpy2/strategies/simple.py
@@ -12,12 +12,21 @@ from ..transform import (
 def simplify(
     func: Function, *,
     enable_const_fold: bool = True,
+    enable_const_fold_context: bool = True,
+    enable_const_fold_op: bool = True,
     enable_copy_prop: bool = True,
     enable_dead_code_elim: bool = True
 ) -> Function:
     """Apply :class:`ConstFold` + :class:`CopyPropagate` +
     :class:`DeadCodeEliminate` to *func* until none of the enabled
-    passes report a change."""
+    passes report a change.
+
+    The two ``enable_const_fold_*`` flags forward to
+    :class:`ConstFold`'s ``enable_context`` / ``enable_op`` knobs
+    (ignored when ``enable_const_fold=False``).  A common use is
+    ``enable_const_fold_context=False`` to simplify boolean / numeric
+    expressions while leaving ``with``-block contexts untouched.
+    """
     if not isinstance(func, Function):
         raise TypeError(f"Expected a \'Function\', got {func}")
     ast = func.ast
@@ -25,7 +34,11 @@ def simplify(
     while True:
         changed = False
         if enable_const_fold:
-            ast, c = ConstFold.apply_with_status(ast)
+            ast, c = ConstFold.apply_with_status(
+                ast,
+                enable_context=enable_const_fold_context,
+                enable_op=enable_const_fold_op,
+            )
             changed |= c
         if enable_copy_prop:
             ast, c = CopyPropagate.apply_with_status(ast)

--- a/fpy2/transform/const_fold.py
+++ b/fpy2/transform/const_fold.py
@@ -24,6 +24,7 @@ class _ConstFoldInstance(DefaultTransformVisitor):
     pe: PartialEvalInfo
     enable_context: bool
     enable_op: bool
+    changed: bool
 
     def __init__(
         self,
@@ -36,6 +37,7 @@ class _ConstFoldInstance(DefaultTransformVisitor):
         self.pe = pe
         self.enable_context = enable_context
         self.enable_op = enable_op
+        self.changed = False
 
     def _value_to_literal(self, val: Value, loc):
         """Convert a :data:`Value` to an AST literal; return ``None`` if
@@ -64,16 +66,26 @@ class _ConstFoldInstance(DefaultTransformVisitor):
 
     def _fold(self, e: Expr) -> Expr | None:
         """Look up ``e`` in ``pe.by_expr`` and convert to a literal,
-        gated by ``enable_op`` / ``enable_context``."""
+        gated by ``enable_op`` / ``enable_context``.  Returns ``None``
+        when the substitution would be a structural no-op (the AST
+        already has the same literal at this position) so ``simplify``
+        can detect fixpoint."""
         if e not in self.pe.by_expr:
             return None
         lit = self._value_to_literal(self.pe.by_expr[e], e.loc)
         if lit is None:
             return None
+        # No-op: the literal we'd substitute is already at this site.
+        if type(e) is type(lit) and e.is_equiv(lit):
+            return None
         is_ctx_fold = isinstance(lit, ForeignVal) and isinstance(lit.val, Context)
         if is_ctx_fold:
-            return lit if self.enable_context else None
-        return lit if self.enable_op else None
+            if not self.enable_context:
+                return None
+        elif not self.enable_op:
+            return None
+        self.changed = True
+        return lit
 
     def _visit_expr(self, e: Expr, ctx) -> Expr:
         # Single chokepoint: every expression in the tree comes here
@@ -115,12 +127,31 @@ class ConstFold:
         / ``partial_eval`` to share with other passes.  Set
         ``enable_context=False`` to skip ``Context`` folds or
         ``enable_op=False`` to skip everything else."""
+        func, _ = ConstFold.apply_with_status(
+            func,
+            def_use=def_use,
+            partial_eval=partial_eval,
+            enable_context=enable_context,
+            enable_op=enable_op,
+        )
+        return func
+
+    @staticmethod
+    def apply_with_status(
+        func: FuncDef,
+        *,
+        def_use: DefineUseAnalysis | None = None,
+        partial_eval: PartialEvalInfo | None = None,
+        enable_context: bool = True,
+        enable_op: bool = True,
+    ) -> tuple[FuncDef, bool]:
+        """Same as :meth:`apply` but also returns a ``changed`` flag
+        — ``True`` iff at least one substitution occurred."""
         if not isinstance(func, FuncDef):
             raise TypeError(f'Expected `FuncDef`, got {type(func)} for {func}')
         if def_use is None:
             def_use = DefineUse.analyze(func)
         if partial_eval is None:
             partial_eval = PartialEval.apply(func, def_use=def_use)
-        return _ConstFoldInstance(
-            func, partial_eval, enable_context, enable_op,
-        ).apply()
+        inst = _ConstFoldInstance(func, partial_eval, enable_context, enable_op)
+        return inst.apply(), inst.changed

--- a/fpy2/transform/copy_propagate.py
+++ b/fpy2/transform/copy_propagate.py
@@ -17,6 +17,15 @@ class CopyPropagate:
     @staticmethod
     def apply(func: FuncDef, *, names: set[NamedId] | None = None) -> FuncDef:
         """Applies copy propagation to the given AST."""
+        func, _ = CopyPropagate.apply_with_status(func, names=names)
+        return func
+
+    @staticmethod
+    def apply_with_status(
+        func: FuncDef, *, names: set[NamedId] | None = None,
+    ) -> tuple[FuncDef, bool]:
+        """Same as :meth:`apply` but also returns a ``changed`` flag —
+        ``True`` iff at least one alias was propagated."""
         if not isinstance(func, FuncDef):
             raise TypeError(f'Expected \'FuncDef\' for {func}, got {type(func)}')
 
@@ -38,9 +47,9 @@ class CopyPropagate:
                     # optimization: only propagate if there is at least one use
                     prop[d] = d.site.expr
 
-        if prop:
-            # at least one variable to propagate
-            func = SubstVar.apply(func, def_use, prop)
-            SyntaxCheck.check(func, ignore_unknown=True)
+        if not prop:
+            return func, False
 
-        return func
+        func = SubstVar.apply(func, def_use, prop)
+        SyntaxCheck.check(func, ignore_unknown=True)
+        return func, True

--- a/fpy2/transform/dead_code.py
+++ b/fpy2/transform/dead_code.py
@@ -1,10 +1,4 @@
-"""
-Dead code elimination.
-
-TODO:
-- rewrite `if True: ... else: ...` to just the `if` body
-- eliminate unused context statement
-"""
+"""Dead code elimination."""
 
 from typing import cast
 
@@ -143,6 +137,25 @@ class _Eliminator(DefaultTransformVisitor):
         self.eliminated = True
         return None, ctx
 
+    def _visit_assert(self, stmt: AssertStmt, ctx: None):
+        # ``assert True`` (with or without message) is a no-op: the
+        # message is only evaluated when the test is False, so dropping
+        # the whole statement is sound regardless of msg purity.
+        # ``assert False`` is preserved — it's a deliberate runtime
+        # failure point.
+        if isinstance(stmt.test, BoolVal) and stmt.test.val:
+            self.eliminated = True
+            return None, ctx
+        return super()._visit_assert(stmt, ctx)
+
+    def _visit_effect(self, stmt: EffectStmt, ctx: None):
+        # An expression statement whose value is discarded and whose
+        # evaluation is observably pure has no effect.
+        if Purity.analyze_expr(stmt.expr, self.def_use):
+            self.eliminated = True
+            return None, ctx
+        return super()._visit_effect(stmt, ctx)
+
     def _visit_block(self, block: StmtBlock, ctx: None) -> tuple[StmtBlock, None]:
         if self._is_empty_block(block):
             # do nothing
@@ -252,12 +265,14 @@ class _DeadCodeEliminate:
 
 
 class DeadCodeEliminate:
-    """
-    Dead code elimination.
-    - removes any unused statements
-    - removes any unused free variables
-    - removes any never-executed branch
-    - removes empty bodies
+    """Dead code elimination.
+
+    - removes unused assignments / phi defs / free variables
+    - removes never-executed branches (``if False:``, ``while False:``)
+    - collapses trivially-true / trivially-false ``if`` / ``while``
+    - removes ``assert True`` and pure ``EffectStmt`` s
+    - removes self-assignments (``x = x``) and stray ``pass``
+    - drops empty bodies and unused ``with``-block targets
     """
 
     @staticmethod

--- a/fpy2/transform/dead_code.py
+++ b/fpy2/transform/dead_code.py
@@ -48,8 +48,56 @@ class _Eliminator(DefaultTransformVisitor):
             # remove self-assignment
             self.eliminated = True
             return None, ctx
-        else:
-            return super()._visit_assign(assign, ctx)
+        if isinstance(assign.target, TupleBinding):
+            # Two-step destructure cleanup:
+            #   (i)  unused ``NamedId`` leaves → ``UnderscoreId``
+            #   (ii) all-underscore binding + pure RHS → drop the assign
+            scrubbed = self._scrub_binding(assign.target, assign)
+            target = scrubbed if scrubbed is not assign.target else assign.target
+            if self._all_underscore(target) and Purity.analyze_expr(assign.expr, self.def_use):
+                self.eliminated = True
+                return None, ctx
+            if scrubbed is not assign.target:
+                self.eliminated = True
+                return Assign(scrubbed, assign.type, assign.expr, assign.loc), ctx
+        return super()._visit_assign(assign, ctx)
+
+    def _scrub_binding(self, binding: TupleBinding, site: Assign) -> TupleBinding:
+        """Replace each ``NamedId`` leaf whose def has no uses (and
+        doesn't feed a phi) with ``UnderscoreId``.  Recurses into
+        nested bindings.  Returns the original object if unchanged."""
+        new_elts: list[Id | TupleBinding] = []
+        changed = False
+        for elt in binding.elts:
+            if isinstance(elt, NamedId):
+                d = self.def_use.find_def_from_site(elt, site)
+                live = (
+                    len(self.def_use.uses[d]) > 0
+                    or any(isinstance(s, PhiDef) for s in self.def_use.successors[d])
+                )
+                if live:
+                    new_elts.append(elt)
+                else:
+                    new_elts.append(UnderscoreId())
+                    changed = True
+            elif isinstance(elt, TupleBinding):
+                inner = self._scrub_binding(elt, site)
+                if inner is not elt:
+                    changed = True
+                new_elts.append(inner)
+            else:
+                new_elts.append(elt)
+        return TupleBinding(new_elts, binding.loc) if changed else binding
+
+    @staticmethod
+    def _all_underscore(binding: TupleBinding) -> bool:
+        """True iff every leaf in *binding* is an ``UnderscoreId``."""
+        for elt in binding.elts:
+            if isinstance(elt, NamedId):
+                return False
+            if isinstance(elt, TupleBinding) and not _Eliminator._all_underscore(elt):
+                return False
+        return True
 
     def _visit_if1(self, stmt: If1Stmt, ctx: None) -> tuple[Stmt | StmtBlock | None, None]:
         if isinstance(stmt.cond, BoolVal):
@@ -268,6 +316,9 @@ class DeadCodeEliminate:
     """Dead code elimination.
 
     - removes unused assignments / phi defs / free variables
+    - rewrites unused ``TupleBinding`` leaves to ``UnderscoreId``;
+      drops the whole assign when every leaf becomes ``_`` and the
+      RHS is pure
     - removes never-executed branches (``if False:``, ``while False:``)
     - collapses trivially-true / trivially-false ``if`` / ``while``
     - removes ``assert True`` and pure ``EffectStmt`` s

--- a/fpy2/transform/dead_code.py
+++ b/fpy2/transform/dead_code.py
@@ -1,10 +1,8 @@
 """Dead code elimination."""
 
-from typing import cast
-
 from ..ast import *
 from ..analysis import (
-    DefineUse, DefineUseAnalysis, AssignDef, PhiDef, DefSite,
+    DefineUse, DefineUseAnalysis, AssignDef, PhiDef,
     Purity, SyntaxCheck
 )
 
@@ -53,8 +51,7 @@ class _Eliminator(DefaultTransformVisitor):
             #   (i)  unused ``NamedId`` leaves → ``UnderscoreId``
             #   (ii) all-underscore binding + pure RHS → drop the assign
             scrubbed = self._scrub_binding(assign.target, assign)
-            target = scrubbed if scrubbed is not assign.target else assign.target
-            if self._all_underscore(target) and Purity.analyze_expr(assign.expr, self.def_use):
+            if self._all_underscore(scrubbed) and Purity.analyze_expr(assign.expr, self.def_use):
                 self.eliminated = True
                 return None, ctx
             if scrubbed is not assign.target:
@@ -213,7 +210,6 @@ class _Eliminator(DefaultTransformVisitor):
             stmts: list[Stmt] = []
             for stmt in block.stmts:
                 s, _ = self._visit_statement(stmt, ctx)
-                # s = cast(Stmt | StmtBlock | None, s)
                 match s:
                     case None:
                         pass

--- a/tests/unit/analysis/test_partial_eval.py
+++ b/tests/unit/analysis/test_partial_eval.py
@@ -124,6 +124,63 @@ class TestListFolding:
         assert _return_expr(f.ast) not in info.by_expr
 
 
+class TestIfExprFolding:
+    """``IfExpr`` folds to the chosen branch's value when the
+    condition is statically known."""
+
+    def test_cond_true_picks_ift(self):
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return 1.0 if True else 2.0
+
+        info = PartialEval.apply(f.ast)
+        v = info.by_expr.get(_return_expr(f.ast))
+        assert v is not None and float(v) == 1.0
+
+    def test_cond_false_picks_iff(self):
+        @fp.fpy
+        def f():
+            with fp.FP64:
+                return 1.0 if False else 2.0
+
+        info = PartialEval.apply(f.ast)
+        v = info.by_expr.get(_return_expr(f.ast))
+        assert v is not None and float(v) == 2.0
+
+    def test_cond_unknown_does_not_fold(self):
+        @fp.fpy
+        def f(c: bool, x: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return 1.0 if c else x
+
+        info = PartialEval.apply(f.ast)
+        assert _return_expr(f.ast) not in info.by_expr
+
+    def test_taken_branch_unknown_does_not_fold(self):
+        """Cond is known True but the chosen branch (ift) isn't a
+        value — no fold."""
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return x if True else 2.0
+
+        info = PartialEval.apply(f.ast)
+        assert _return_expr(f.ast) not in info.by_expr
+
+    def test_unchosen_branch_unknown_still_folds(self):
+        """When cond is True, the iff branch's value is irrelevant —
+        fold still proceeds based on ift's value."""
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return 7.0 if True else x
+
+        info = PartialEval.apply(f.ast)
+        v = info.by_expr.get(_return_expr(f.ast))
+        assert v is not None and float(v) == 7.0
+
+
 class TestRobustness:
     """Interpreter exceptions must be swallowed: PE is best-effort."""
 

--- a/tests/unit/strategies/test_simplify.py
+++ b/tests/unit/strategies/test_simplify.py
@@ -61,10 +61,6 @@ def _kitchen_sink(x: fp.Real) -> fp.Real:
 @fp.fpy
 def _kitchen_sink_expect(x: fp.Real) -> fp.Real:
     with fp.FP64:
-        # The tuple destructure survives because DCE doesn't drop
-        # ``TupleBinding`` assigns even when every bound name is
-        # unused (a known limitation).
-        first, second = (3, 10)
         return 1 * (10 + 2 * x)
 
 

--- a/tests/unit/strategies/test_simplify.py
+++ b/tests/unit/strategies/test_simplify.py
@@ -1,0 +1,238 @@
+"""Unit tests for :func:`fpy2.strategies.simplify`.
+
+The expect-test fixtures use ``enable_const_fold_context=False`` so
+the ``with fp.FP64:`` expression stays as an ``Attribute`` — the
+concrete ``IEEEContext`` produced by the default context-fold can't
+be written in FPy surface syntax, so we'd have no way to express
+the expected AST.  Context-folding itself is tested separately.
+"""
+
+import fpy2 as fp
+
+from fpy2.ast import Attribute, BinaryOp, ContextStmt, ForeignVal
+from fpy2.ast.visitor import DefaultVisitor
+from fpy2.strategies import simplify
+
+
+# Module-level free vars referenced by the fixtures below.  Both
+# should disappear after ``simplify`` folds them and DCE drops the
+# gated code.
+DEBUG = False
+SCALE = 2.0
+
+
+# ---------------------------------------------------------------------------
+# Fixture pairs: (input, expected after simplify)
+# ---------------------------------------------------------------------------
+
+
+@fp.fpy
+def _kitchen_sink(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        # Numeric folding bottom-up.
+        a = 1.0 + 2.0
+        b = a * a
+        c = b - 1.0
+        # List + reduce.
+        coeffs = [c, c + 1.0, c + 2.0]
+        peak = max(coeffs)
+        # Tuple destructure carries values forward.
+        pair = (a, peak)
+        first, second = pair
+        # Compare-folds → branch elimination.
+        if peak < 0.0:
+            return -1.0
+        # IfExpr — Compare folds to True, IfExpr picks the ift branch.
+        sign = 1.0 if first > 0.0 else -1.0
+        # Copy chain.
+        y = second
+        z = y
+        w = z
+        # Foreign-var gated dead block.
+        if DEBUG:
+            assert w > 999.0, "impossible"
+        # Pure effect.
+        a + b + peak
+        # Always-true assert.
+        assert True
+        return sign * (w + SCALE * x)
+
+
+@fp.fpy
+def _kitchen_sink_expect(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        # The tuple destructure survives because DCE doesn't drop
+        # ``TupleBinding`` assigns even when every bound name is
+        # unused (a known limitation).
+        first, second = (3, 10)
+        return 1 * (10 + 2 * x)
+
+
+@fp.fpy
+def _just_const_fold(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        a = 3.0
+        b = a + 2.0
+        return b * x
+
+
+@fp.fpy
+def _just_const_fold_expect(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        return 5 * x
+
+
+@fp.fpy
+def _just_copy_prop(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        y = x
+        z = y
+        return z
+
+
+@fp.fpy
+def _just_copy_prop_expect(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        return x
+
+
+@fp.fpy
+def _just_dead_branches(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        if False:
+            return -1.0
+        assert True
+        return x
+
+
+@fp.fpy
+def _just_dead_branches_expect(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        return x
+
+
+@fp.fpy
+def _if_expr_fold(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        # IfExpr with a foldable cond — picks the matching branch's
+        # value even though the other branch isn't statically known.
+        sign = 1.0 if True else x
+        return sign * x
+
+
+@fp.fpy
+def _if_expr_fold_expect(x: fp.Real) -> fp.Real:
+    with fp.FP64:
+        return 1 * x
+
+
+_examples: list[tuple[fp.Function, fp.Function]] = [
+    (_kitchen_sink, _kitchen_sink_expect),
+    (_just_const_fold, _just_const_fold_expect),
+    (_just_copy_prop, _just_copy_prop_expect),
+    (_just_dead_branches, _just_dead_branches_expect),
+    (_if_expr_fold, _if_expr_fold_expect),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_node(fd, predicate) -> bool:
+    """True iff some AST node in *fd* satisfies *predicate*."""
+    hit = [False]
+
+    class _Search(DefaultVisitor):
+        def _visit_statement(self, stmt, ctx):
+            if predicate(stmt):
+                hit[0] = True
+            return super()._visit_statement(stmt, ctx)
+
+        def _visit_expr(self, e, ctx):
+            if predicate(e):
+                hit[0] = True
+            return super()._visit_expr(e, ctx)
+
+    _Search()._visit_function(fd, None)
+    return hit[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSimplifyExpect:
+    """Pin the exact simplified AST for each fixture pair."""
+
+    def test_fixtures(self):
+        for f, f_expect in _examples:
+            simplified = simplify(f, enable_const_fold_context=False).ast
+            simplified.name = f_expect.name
+            assert simplified.is_equiv(f_expect.ast), (
+                f'\nexpect:\n{f_expect.ast.format()}\n'
+                f'actual:\n{simplified.format()}'
+            )
+
+
+class TestSimplifyRuntime:
+    """Even when the AST shape drifts (e.g. future passes get more
+    aggressive), runtime behaviour must be preserved."""
+
+    def test_runtime_equivalent(self):
+        for f, _ in _examples:
+            simplified = simplify(f)
+            for x in (0.0, 1.0, -1.5, 2.5, 100.0):
+                assert float(f(x)) == float(simplified(x)), (
+                    f'{f.name}: simplified differs at x={x}: '
+                    f'{f(x)} vs {simplified(x)}'
+                )
+
+
+class TestSimplifyIdempotent:
+    def test_idempotent(self):
+        for f, _ in _examples:
+            once = simplify(f)
+            twice = simplify(once)
+            assert once.ast.is_equiv(twice.ast), (
+                f'{f.name}: simplify is not idempotent:\n'
+                f'once:\n{once.ast.format()}\n'
+                f'twice:\n{twice.ast.format()}'
+            )
+
+
+class TestSimplifyContextFold:
+    """The default ``simplify`` folds ``fp.FP64`` (an ``Attribute``)
+    to a ``ForeignVal`` carrying the concrete ``IEEEContext``.  The
+    knob ``enable_const_fold_context=False`` opts out."""
+
+    def test_default_folds_to_foreign_val(self):
+        simplified = simplify(_kitchen_sink).ast
+        assert _has_node(
+            simplified,
+            lambda n: isinstance(n, ContextStmt) and isinstance(n.ctx, ForeignVal),
+        )
+        # No Attribute remaining in context position.
+        assert not _has_node(
+            simplified,
+            lambda n: isinstance(n, ContextStmt) and isinstance(n.ctx, Attribute),
+        )
+
+    def test_disable_keeps_attribute(self):
+        simplified = simplify(_kitchen_sink, enable_const_fold_context=False).ast
+        assert _has_node(
+            simplified,
+            lambda n: isinstance(n, ContextStmt) and isinstance(n.ctx, Attribute),
+        )
+
+
+class TestSimplifyOpFold:
+    """``enable_const_fold_op=False`` preserves arithmetic, leaves the
+    context-fold knob active."""
+
+    def test_disable_keeps_arithmetic(self):
+        simplified = simplify(_just_const_fold, enable_const_fold_op=False).ast
+        # Some BinaryOp must remain (the un-folded ``a + 2.0`` etc.).
+        assert _has_node(simplified, lambda n: isinstance(n, BinaryOp))

--- a/tests/unit/transform/test_dead_code.py
+++ b/tests/unit/transform/test_dead_code.py
@@ -259,6 +259,47 @@ def example_simple_4_expect():
     return x
 
 
+@fp.fpy
+def _example_assert_true():
+    assert True
+    return 1
+
+@fp.fpy
+def _example_assert_true_expect():
+    return 1
+
+
+@fp.fpy
+def _example_assert_true_with_msg():
+    assert True, 'should never fire'
+    return 1
+
+@fp.fpy
+def _example_assert_true_with_msg_expect():
+    return 1
+
+
+@fp.fpy
+def _example_assert_false_preserved():
+    assert False
+    return 1
+
+@fp.fpy
+def _example_assert_false_preserved_expect():
+    assert False
+    return 1
+
+
+@fp.fpy
+def _example_pure_effect():
+    1 + 2
+    return 0
+
+@fp.fpy
+def _example_pure_effect_expect():
+    return 0
+
+
 _examples: list[tuple[fp.Function, fp.Function]] = [
     (_example_simple_1, _example_simple_1_expect),
     (_example_simple_2, _example_simple_2_expect),
@@ -279,7 +320,11 @@ _examples: list[tuple[fp.Function, fp.Function]] = [
     (_example_dead_while_2, _example_dead_while_2_expect),
     (_example_while_1, _example_while_1_expect),
     (example_simple_3, example_simple_3_expect),
-    (example_simple_4, example_simple_4_expect)
+    (example_simple_4, example_simple_4_expect),
+    (_example_assert_true, _example_assert_true_expect),
+    (_example_assert_true_with_msg, _example_assert_true_with_msg_expect),
+    (_example_assert_false_preserved, _example_assert_false_preserved_expect),
+    (_example_pure_effect, _example_pure_effect_expect),
 ]
 
 

--- a/tests/unit/transform/test_dead_code.py
+++ b/tests/unit/transform/test_dead_code.py
@@ -300,6 +300,52 @@ def _example_pure_effect_expect():
     return 0
 
 
+# Rule (i): unused TupleBinding leaf → UnderscoreId.
+@fp.fpy
+def _example_tuple_scrub_one(x: fp.Real) -> fp.Real:
+    a, b = (1.0, 2.0)
+    return a + x
+
+@fp.fpy
+def _example_tuple_scrub_one_expect(x: fp.Real) -> fp.Real:
+    a, _ = (1.0, 2.0)
+    return a + x
+
+
+# Rule (ii): all-underscore + pure RHS → drop.
+@fp.fpy
+def _example_tuple_drop_all_unused(x: fp.Real) -> fp.Real:
+    a, b = (1.0, 2.0)
+    return x
+
+@fp.fpy
+def _example_tuple_drop_all_unused_expect(x: fp.Real) -> fp.Real:
+    return x
+
+
+# Rule (ii) composed with already-present underscore.
+@fp.fpy
+def _example_tuple_drop_with_underscore(x: fp.Real) -> fp.Real:
+    _, b = (1.0, 2.0)
+    return x
+
+@fp.fpy
+def _example_tuple_drop_with_underscore_expect(x: fp.Real) -> fp.Real:
+    return x
+
+
+# Nested binding: outer leaf still used, inner all-unused → scrubbed.
+@fp.fpy
+def _example_tuple_nested_scrub(x: fp.Real) -> fp.Real:
+    (a, b), c = ((1.0, 2.0), 3.0)
+    return c + x
+
+@fp.fpy
+def _example_tuple_nested_scrub_expect(x: fp.Real) -> fp.Real:
+    (_, _), c = ((1.0, 2.0), 3.0)
+    return c + x
+
+
 _examples: list[tuple[fp.Function, fp.Function]] = [
     (_example_simple_1, _example_simple_1_expect),
     (_example_simple_2, _example_simple_2_expect),
@@ -325,6 +371,10 @@ _examples: list[tuple[fp.Function, fp.Function]] = [
     (_example_assert_true_with_msg, _example_assert_true_with_msg_expect),
     (_example_assert_false_preserved, _example_assert_false_preserved_expect),
     (_example_pure_effect, _example_pure_effect_expect),
+    (_example_tuple_scrub_one, _example_tuple_scrub_one_expect),
+    (_example_tuple_drop_all_unused, _example_tuple_drop_all_unused_expect),
+    (_example_tuple_drop_with_underscore, _example_tuple_drop_with_underscore_expect),
+    (_example_tuple_nested_scrub, _example_tuple_nested_scrub_expect),
 ]
 
 


### PR DESCRIPTION
Enhances the simplification passes (dead code, const fold, copy propagate):
- dead code: add missing cases for asserts and effects
- const fold: simplify if expressions with concrete conditions
- simplify: actually run to fixpoint, add knobs to control the strategy