### PR TITLE
Partial evaluation performs SCCP

### DIFF
--- a/fpy2/analysis/partial_eval.py
+++ b/fpy2/analysis/partial_eval.py
@@ -30,15 +30,18 @@ Value: TypeAlias = ScalarValue | TupleValue | ListValue
 
 class _TopType:
     """SCCP lattice top — internal sentinel for "def was analyzed; not
-    a single foldable value".  Stored only in ``by_def``; ``_visit_var``
-    filters it before writing to ``by_expr`` so external consumers
-    never see it."""
+    a single foldable value".  Stored only in the analysis instance's
+    ``by_def``; stripped from the public :class:`PartialEvalInfo`."""
 
     def __repr__(self):
         return '_TOP'
 
 
 _TOP: _TopType = _TopType()
+
+# Internal lattice value: a public :data:`Value`, BOT (absent from
+# the map), or the ``_TOP`` sentinel.
+_Lattice: TypeAlias = Value | _TopType
 
 
 @dataclass
@@ -57,7 +60,7 @@ class _PartialEvalInstance(DefaultVisitor):
     def_use: DefineUseAnalysis
     rt: Interpreter
 
-    by_def: dict[Definition, Value]
+    by_def: dict[Definition, _Lattice]
     by_expr: dict[Expr, Value]
 
     def __init__(
@@ -73,7 +76,12 @@ class _PartialEvalInstance(DefaultVisitor):
 
     def apply(self) -> PartialEvalInfo:
         self._visit_function(self.func, None)
-        return PartialEvalInfo(self.by_def, self.by_expr, self.def_use)
+        # Strip ``_TOP`` from the public view — consumers see only
+        # foldable :data:`Value` entries.
+        public_by_def: dict[Definition, Value] = {
+            d: v for d, v in self.by_def.items() if v is not _TOP  # type: ignore[misc]
+        }
+        return PartialEvalInfo(public_by_def, self.by_expr, self.def_use)
 
     def _base_env(self) -> dict[NamedId, object]:
         return {
@@ -121,7 +129,7 @@ class _PartialEvalInstance(DefaultVisitor):
             rhs = self.by_def.get(self.def_use.defs[phi.rhs], _TOP)
             merged = self._meet(lhs, rhs)
             if merged is not None:
-                self.by_def[phi] = merged  # type: ignore[assignment]
+                self.by_def[phi] = merged
 
     def _visit_bool(self, e: BoolVal, ctx: Context | None):
         self.by_expr[e] = e.val
@@ -369,7 +377,7 @@ class _PartialEvalInstance(DefaultVisitor):
             if lhs is None:
                 self.by_def.pop(phi, None)
             else:
-                self.by_def[phi] = lhs  # type: ignore[assignment]
+                self.by_def[phi] = lhs
         while True:
             run_body()
             changed = False
@@ -382,7 +390,7 @@ class _PartialEvalInstance(DefaultVisitor):
                     if new is None:
                         self.by_def.pop(phi, None)
                     else:
-                        self.by_def[phi] = new  # type: ignore[assignment]
+                        self.by_def[phi] = new
                     changed = True
             if not changed:
                 return

--- a/fpy2/analysis/partial_eval.py
+++ b/fpy2/analysis/partial_eval.py
@@ -354,24 +354,23 @@ class _PartialEvalInstance(DefaultVisitor):
         self._visit_block(stmt.iff, ctx)
         self._merge_branch_phis(stmt)
 
-    # Defensive cap for ``_loop_fixpoint`` — the lattice has height 3
-    # (``None`` → :data:`Value` → :data:`_TOP`), so convergence happens
-    # in a handful of passes; this guards pathological cases.
-    _loop_iter_cap: int = 8
-
     def _loop_fixpoint(self, stmt: Stmt, run_body):
         """Drive a loop's header-phis to fixpoint.  Seed each phi from
         its lhs (pre-loop) value, then iterate ``run_body`` until phi
-        bounds stop changing."""
+        bounds stop changing.
+
+        Termination: the lattice has height 3 (``None`` → :data:`Value`
+        → :data:`_TOP`) and :meth:`_meet` is monotone, so every phi
+        transitions at most twice before stabilizing.
+        """
         phis = self.def_use.phis.get(stmt, set())
-        # Seed each phi with its pre-loop value.
         for phi in phis:
             lhs = self.by_def.get(self.def_use.defs[phi.lhs])
             if lhs is None:
                 self.by_def.pop(phi, None)
             else:
                 self.by_def[phi] = lhs  # type: ignore[assignment]
-        for _ in range(self._loop_iter_cap):
+        while True:
             run_body()
             changed = False
             for phi in phis:
@@ -387,9 +386,6 @@ class _PartialEvalInstance(DefaultVisitor):
                     changed = True
             if not changed:
                 return
-        # Didn't converge — promote every phi to _TOP defensively.
-        for phi in phis:
-            self.by_def[phi] = _TOP  # type: ignore[assignment]
 
     def _visit_while(self, stmt: WhileStmt, ctx: Context | None):
         self._visit_expr(stmt.cond, ctx)

--- a/fpy2/analysis/partial_eval.py
+++ b/fpy2/analysis/partial_eval.py
@@ -28,6 +28,19 @@ ListValue: TypeAlias = list['Value']
 Value: TypeAlias = ScalarValue | TupleValue | ListValue
 
 
+class _TopType:
+    """SCCP lattice top — internal sentinel for "def was analyzed; not
+    a single foldable value".  Stored only in ``by_def``; ``_visit_var``
+    filters it before writing to ``by_expr`` so external consumers
+    never see it."""
+
+    def __repr__(self):
+        return '_TOP'
+
+
+_TOP: _TopType = _TopType()
+
+
 @dataclass
 class PartialEvalInfo:
     by_def: dict[Definition, Value]
@@ -72,10 +85,43 @@ class _PartialEvalInstance(DefaultVisitor):
     def _is_value(self, e: Expr) -> bool:
         return e in self.by_expr
 
+    def _visit_expr(self, e: Expr, ctx: Context | None):
+        # Pop any stale entry from a previous pass (matters for the
+        # loop fixpoint, which revisits the body — without this, a
+        # foldable value from an early iteration sticks around after
+        # the phi has promoted to ``_TOP``).
+        self.by_expr.pop(e, None)
+        super()._visit_expr(e, ctx)
+
     def _visit_var(self, e: Var, ctx: Context | None):
         d = self.def_use.find_def_from_use(e)
         if d in self.by_def:
-            self.by_expr[e] = self.by_def[d]
+            val = self.by_def[d]
+            if val is not _TOP:
+                self.by_expr[e] = val
+
+    def _meet(self, a, b):
+        """SCCP meet — ``None`` is BOT (unit), :data:`_TOP` is top;
+        anything else is a :data:`Value`."""
+        if a is None:
+            return b
+        if b is None:
+            return a
+        if a is _TOP or b is _TOP:
+            return _TOP
+        return a if a == b else _TOP
+
+    def _merge_branch_phis(self, stmt: Stmt):
+        """Merge phis after an ``if`` / ``if-else``: both branches are
+        visited unconditionally, so absence from ``by_def`` means "we
+        visited and couldn't fold" (i.e. ``_TOP``-equivalent) rather
+        than "haven't seen yet"."""
+        for phi in self.def_use.phis[stmt]:
+            lhs = self.by_def.get(self.def_use.defs[phi.lhs], _TOP)
+            rhs = self.by_def.get(self.def_use.defs[phi.rhs], _TOP)
+            merged = self._meet(lhs, rhs)
+            if merged is not None:
+                self.by_def[phi] = merged  # type: ignore[assignment]
 
     def _visit_bool(self, e: BoolVal, ctx: Context | None):
         self.by_expr[e] = e.val
@@ -281,6 +327,80 @@ class _PartialEvalInstance(DefaultVisitor):
         self._visit_expr(stmt.expr, ctx)
         if self._is_value(stmt.expr):
             self._visit_binding(stmt, stmt.target, self.by_expr[stmt.expr])
+        else:
+            # RHS isn't statically foldable — clear any stale by_def
+            # entry for the target (matters for loop re-iteration).
+            self._clear_binding(stmt, stmt.target)
+
+    def _clear_binding(self, site: DefSite, binding: Id | TupleBinding):
+        match binding:
+            case NamedId():
+                d = self.def_use.find_def_from_site(binding, site)
+                self.by_def.pop(d, None)
+            case UnderscoreId():
+                pass
+            case TupleBinding():
+                for elt in binding.elts:
+                    self._clear_binding(site, elt)
+
+    def _visit_if1(self, stmt: If1Stmt, ctx: Context | None):
+        self._visit_expr(stmt.cond, ctx)
+        self._visit_block(stmt.body, ctx)
+        self._merge_branch_phis(stmt)
+
+    def _visit_if(self, stmt: IfStmt, ctx: Context | None):
+        self._visit_expr(stmt.cond, ctx)
+        self._visit_block(stmt.ift, ctx)
+        self._visit_block(stmt.iff, ctx)
+        self._merge_branch_phis(stmt)
+
+    # Defensive cap for ``_loop_fixpoint`` — the lattice has height 3
+    # (``None`` → :data:`Value` → :data:`_TOP`), so convergence happens
+    # in a handful of passes; this guards pathological cases.
+    _loop_iter_cap: int = 8
+
+    def _loop_fixpoint(self, stmt: Stmt, run_body):
+        """Drive a loop's header-phis to fixpoint.  Seed each phi from
+        its lhs (pre-loop) value, then iterate ``run_body`` until phi
+        bounds stop changing."""
+        phis = self.def_use.phis.get(stmt, set())
+        # Seed each phi with its pre-loop value.
+        for phi in phis:
+            lhs = self.by_def.get(self.def_use.defs[phi.lhs])
+            if lhs is None:
+                self.by_def.pop(phi, None)
+            else:
+                self.by_def[phi] = lhs  # type: ignore[assignment]
+        for _ in range(self._loop_iter_cap):
+            run_body()
+            changed = False
+            for phi in phis:
+                lhs = self.by_def.get(self.def_use.defs[phi.lhs], _TOP)
+                rhs = self.by_def.get(self.def_use.defs[phi.rhs], _TOP)
+                new = self._meet(lhs, rhs)
+                old = self.by_def.get(phi)
+                if new != old:
+                    if new is None:
+                        self.by_def.pop(phi, None)
+                    else:
+                        self.by_def[phi] = new  # type: ignore[assignment]
+                    changed = True
+            if not changed:
+                return
+        # Didn't converge — promote every phi to _TOP defensively.
+        for phi in phis:
+            self.by_def[phi] = _TOP  # type: ignore[assignment]
+
+    def _visit_while(self, stmt: WhileStmt, ctx: Context | None):
+        self._visit_expr(stmt.cond, ctx)
+        self._loop_fixpoint(stmt, lambda: self._visit_block(stmt.body, ctx))
+
+    def _visit_for(self, stmt: ForStmt, ctx: Context | None):
+        self._visit_expr(stmt.iterable, ctx)
+        # The loop variable is fresh-bound per iteration; we don't
+        # analyse it specially, just iterate the body so other phis
+        # converge.
+        self._loop_fixpoint(stmt, lambda: self._visit_block(stmt.body, ctx))
 
     def _visit_context(self, stmt: ContextStmt, ctx: Context | None):
         self._visit_expr(stmt.ctx, REAL)

--- a/fpy2/analysis/partial_eval.py
+++ b/fpy2/analysis/partial_eval.py
@@ -79,7 +79,7 @@ class _PartialEvalInstance(DefaultVisitor):
         # Strip ``_TOP`` from the public view — consumers see only
         # foldable :data:`Value` entries.
         public_by_def: dict[Definition, Value] = {
-            d: v for d, v in self.by_def.items() if v is not _TOP  # type: ignore[misc]
+            d: v for d, v in self.by_def.items() if not isinstance(v, _TopType)
         }
         return PartialEvalInfo(public_by_def, self.by_expr, self.def_use)
 
@@ -105,7 +105,7 @@ class _PartialEvalInstance(DefaultVisitor):
         d = self.def_use.find_def_from_use(e)
         if d in self.by_def:
             val = self.by_def[d]
-            if val is not _TOP:
+            if not isinstance(val, _TopType):
                 self.by_expr[e] = val
 
     def _meet(self, a, b):

--- a/fpy2/transform/dead_code.py
+++ b/fpy2/transform/dead_code.py
@@ -147,14 +147,14 @@ class _Eliminator(DefaultTransformVisitor):
             return super()._visit_if(stmt, ctx)
 
     def _visit_while(self, stmt: WhileStmt, ctx: None) -> tuple[Stmt | StmtBlock | None, None]:
-        # remove `while False: ...`
-        # remove `while _: pass`
-        if (isinstance(stmt.cond, BoolVal) and not stmt.cond.val) or self._is_empty_block(stmt.body):
-            # eliminate unnecessary while statement
+        # ``while False:`` — cond is statically false, body never runs.
+        # Eliminating ``while <unknown>: pass`` is *unsound*: the loop
+        # may diverge at runtime, and removing it converts divergence
+        # into termination.
+        if isinstance(stmt.cond, BoolVal) and not stmt.cond.val:
             self.eliminated = True
             return None, ctx
-        else:
-            return super()._visit_while(stmt, ctx)
+        return super()._visit_while(stmt, ctx)
 
     def _visit_context(self, stmt: ContextStmt, ctx: None):
         # eliminate if the body is empty

--- a/tests/unit/analysis/test_partial_eval.py
+++ b/tests/unit/analysis/test_partial_eval.py
@@ -181,6 +181,146 @@ class TestIfExprFolding:
         assert v is not None and float(v) == 7.0
 
 
+class TestPhiMerge:
+    """SCCP phi-merge: a use reachable only via paths that assign the
+    same value should fold to that value."""
+
+    def test_if_else_same_value_folds(self):
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                if c:
+                    x = 5.0
+                else:
+                    x = 5.0
+                return x
+
+        info = PartialEval.apply(f.ast)
+        v = info.by_expr.get(_return_expr(f.ast))
+        assert v is not None and float(v) == 5.0
+
+    def test_if_else_different_values_no_fold(self):
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                if c:
+                    x = 5.0
+                else:
+                    x = 7.0
+                return x
+
+        info = PartialEval.apply(f.ast)
+        assert _return_expr(f.ast) not in info.by_expr
+
+    def test_if_else_one_unfoldable_no_fold(self):
+        @fp.fpy
+        def f(c: bool, dyn: fp.Real) -> fp.Real:
+            with fp.FP64:
+                if c:
+                    x = 5.0
+                else:
+                    x = dyn
+                return x
+
+        info = PartialEval.apply(f.ast)
+        assert _return_expr(f.ast) not in info.by_expr
+
+    def test_if1_pre_and_branch_same_value(self):
+        """``If1Stmt``: phi merges the pre-if def with the in-branch
+        def.  Same value → fold."""
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                x = 5.0
+                if c:
+                    x = 5.0
+                return x
+
+        info = PartialEval.apply(f.ast)
+        v = info.by_expr.get(_return_expr(f.ast))
+        assert v is not None and float(v) == 5.0
+
+    def test_if1_pre_and_branch_differ_no_fold(self):
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                x = 5.0
+                if c:
+                    x = 7.0
+                return x
+
+        info = PartialEval.apply(f.ast)
+        assert _return_expr(f.ast) not in info.by_expr
+
+    def test_nested_if_with_shared_constant(self):
+        """Two nested if-else, all four leaves assign the same value."""
+        @fp.fpy
+        def f(c: bool, d: bool) -> fp.Real:
+            with fp.FP64:
+                if c:
+                    if d:
+                        x = 3.0
+                    else:
+                        x = 3.0
+                else:
+                    if d:
+                        x = 3.0
+                    else:
+                        x = 3.0
+                return x
+
+        info = PartialEval.apply(f.ast)
+        v = info.by_expr.get(_return_expr(f.ast))
+        assert v is not None and float(v) == 3.0
+
+
+class TestLoopPhiMerge:
+    """SCCP loop fixpoint: header phi merges pre-loop value and
+    post-body value.  Same value → fold; differing value → ``_TOP``."""
+
+    def test_while_invariant_folds(self):
+        """``x = 5; while c: x = 5; return x`` folds the return — the
+        phi merges 5 (lhs) and 5 (rhs)."""
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                x = 5.0
+                while c:
+                    x = 5.0
+                return x
+
+        info = PartialEval.apply(f.ast)
+        v = info.by_expr.get(_return_expr(f.ast))
+        assert v is not None and float(v) == 5.0
+
+    def test_while_mutating_no_fold(self):
+        """Loop where the variable's body value differs from its
+        pre-loop value — phi promotes to ``_TOP``."""
+        @fp.fpy
+        def f(n: fp.Real) -> fp.Real:
+            with fp.FP64:
+                i = 0
+                while i < n:
+                    i = i + 1
+                return i
+
+        info = PartialEval.apply(f.ast)
+        assert _return_expr(f.ast) not in info.by_expr
+
+    def test_for_invariant_folds(self):
+        @fp.fpy
+        def f() -> fp.Real:
+            with fp.FP64:
+                x = 5.0
+                for i in range(3):
+                    x = 5.0
+                return x
+
+        info = PartialEval.apply(f.ast)
+        v = info.by_expr.get(_return_expr(f.ast))
+        assert v is not None and float(v) == 5.0
+
+
 class TestRobustness:
     """Interpreter exceptions must be swallowed: PE is best-effort."""
 

--- a/tests/unit/strategies/test_simplify.py
+++ b/tests/unit/strategies/test_simplify.py
@@ -122,12 +122,51 @@ def _if_expr_fold_expect(x: fp.Real) -> fp.Real:
         return 1 * x
 
 
+@fp.fpy
+def _branch_merge(c: bool) -> fp.Real:
+    with fp.FP64:
+        # Both branches assign the same value — SCCP phi-merges to 5,
+        # ConstFold substitutes ``return 5``, DCE prunes the if.
+        if c:
+            x = 5.0
+        else:
+            x = 5.0
+        return x
+
+
+@fp.fpy
+def _branch_merge_expect(c: bool) -> fp.Real:
+    with fp.FP64:
+        return 5
+
+
+@fp.fpy
+def _loop_invariant(c: bool) -> fp.Real:
+    with fp.FP64:
+        # Loop-invariant variable — SCCP phi-merges 5 (pre-loop) and
+        # 5 (body), ConstFold substitutes ``return 5``.
+        x = 5.0
+        while c:
+            x = 5.0
+        return x
+
+
+@fp.fpy
+def _loop_invariant_expect(c: bool) -> fp.Real:
+    with fp.FP64:
+        while c:
+            pass
+        return 5
+
+
 _examples: list[tuple[fp.Function, fp.Function]] = [
     (_kitchen_sink, _kitchen_sink_expect),
     (_just_const_fold, _just_const_fold_expect),
     (_just_copy_prop, _just_copy_prop_expect),
     (_just_dead_branches, _just_dead_branches_expect),
     (_if_expr_fold, _if_expr_fold_expect),
+    (_branch_merge, _branch_merge_expect),
+    (_loop_invariant, _loop_invariant_expect),
 ]
 
 

--- a/tests/unit/strategies/test_simplify.py
+++ b/tests/unit/strategies/test_simplify.py
@@ -140,13 +140,6 @@ def _branch_merge_expect(c: bool) -> fp.Real:
         return 5
 
 
-# Loop-phi coverage lives at the PE level in
-# ``tests/unit/analysis/test_partial_eval.py::TestLoopPhiMerge`` —
-# integration-testing it through ``simplify`` interacts with DCE's
-# unsound "empty-body while" elimination (changes a possibly-
-# divergent loop into a value), which is orthogonal to SCCP.
-
-
 _examples: list[tuple[fp.Function, fp.Function]] = [
     (_kitchen_sink, _kitchen_sink_expect),
     (_just_const_fold, _just_const_fold_expect),

--- a/tests/unit/strategies/test_simplify.py
+++ b/tests/unit/strategies/test_simplify.py
@@ -140,23 +140,11 @@ def _branch_merge_expect(c: bool) -> fp.Real:
         return 5
 
 
-@fp.fpy
-def _loop_invariant(c: bool) -> fp.Real:
-    with fp.FP64:
-        # Loop-invariant variable — SCCP phi-merges 5 (pre-loop) and
-        # 5 (body), ConstFold substitutes ``return 5``.
-        x = 5.0
-        while c:
-            x = 5.0
-        return x
-
-
-@fp.fpy
-def _loop_invariant_expect(c: bool) -> fp.Real:
-    with fp.FP64:
-        while c:
-            pass
-        return 5
+# Loop-phi coverage lives at the PE level in
+# ``tests/unit/analysis/test_partial_eval.py::TestLoopPhiMerge`` —
+# integration-testing it through ``simplify`` interacts with DCE's
+# unsound "empty-body while" elimination (changes a possibly-
+# divergent loop into a value), which is orthogonal to SCCP.
 
 
 _examples: list[tuple[fp.Function, fp.Function]] = [
@@ -166,7 +154,6 @@ _examples: list[tuple[fp.Function, fp.Function]] = [
     (_just_dead_branches, _just_dead_branches_expect),
     (_if_expr_fold, _if_expr_fold_expect),
     (_branch_merge, _branch_merge_expect),
-    (_loop_invariant, _loop_invariant_expect),
 ]
 
 

--- a/tests/unit/transform/test_const_fold.py
+++ b/tests/unit/transform/test_const_fold.py
@@ -10,6 +10,7 @@ from fpy2.ast import (
     Integer,
     Rational,
     ReturnStmt,
+    Var,
 )
 from fpy2.number import Context
 from fpy2.transform import ConstFold
@@ -342,7 +343,6 @@ class TestPhiMergeFolding:
 
         folded = ConstFold.apply(f.ast)
         e = _return_expr(folded)
-        from fpy2.ast import Var
         assert isinstance(e, Var), f'expected Var; got {type(e).__name__}'
 
     def test_if1_same_value(self):
@@ -389,5 +389,4 @@ class TestPhiMergeFolding:
 
         folded = ConstFold.apply(f.ast)
         e = _return_expr(folded)
-        from fpy2.ast import Var
         assert isinstance(e, Var), f'expected Var; got {type(e).__name__}'

--- a/tests/unit/transform/test_const_fold.py
+++ b/tests/unit/transform/test_const_fold.py
@@ -307,3 +307,87 @@ class TestVariableSubstitution:
             f'op should not fold under enable_op=False; got {type(e).__name__}'
         ctx_stmt = _outer_context_stmt(folded)
         assert isinstance(ctx_stmt.ctx, ForeignVal)
+
+
+class TestPhiMergeFolding:
+    """SCCP-driven folds at phi nodes: ConstFold substitutes uses of
+    a phi-defined variable when both incoming branches assign the
+    same value."""
+
+    def test_if_else_same_value(self):
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                if c:
+                    x = 5.0
+                else:
+                    x = 5.0
+                return x
+
+        folded = ConstFold.apply(f.ast)
+        e = _return_expr(folded)
+        assert isinstance(e, Integer), f'expected Integer; got {type(e).__name__}'
+        assert e.val == 5
+
+    def test_if_else_different_values(self):
+        """``Var(x)`` doesn't fold when branches disagree."""
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                if c:
+                    x = 5.0
+                else:
+                    x = 7.0
+                return x
+
+        folded = ConstFold.apply(f.ast)
+        e = _return_expr(folded)
+        from fpy2.ast import Var
+        assert isinstance(e, Var), f'expected Var; got {type(e).__name__}'
+
+    def test_if1_same_value(self):
+        """``If1Stmt``: pre-if def + in-branch def agree."""
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                x = 5.0
+                if c:
+                    x = 5.0
+                return x
+
+        folded = ConstFold.apply(f.ast)
+        e = _return_expr(folded)
+        assert isinstance(e, Integer)
+        assert e.val == 5
+
+    def test_loop_invariant_value_folds(self):
+        """Loop where the body re-assigns the same value the variable
+        already had — phi fixpoint stabilizes at the value."""
+        @fp.fpy
+        def f(c: bool) -> fp.Real:
+            with fp.FP64:
+                x = 5.0
+                while c:
+                    x = 5.0
+                return x
+
+        folded = ConstFold.apply(f.ast)
+        e = _return_expr(folded)
+        assert isinstance(e, Integer)
+        assert e.val == 5
+
+    def test_loop_mutating_does_not_fold(self):
+        """Loop where the body mutates the variable — phi goes to
+        ``_TOP``, the return stays as ``Var``."""
+        @fp.fpy
+        def f(n: fp.Real) -> fp.Real:
+            with fp.FP64:
+                i = 0
+                while i < n:
+                    i = i + 1
+                return i
+
+        folded = ConstFold.apply(f.ast)
+        e = _return_expr(folded)
+        from fpy2.ast import Var
+        assert isinstance(e, Var), f'expected Var; got {type(e).__name__}'

--- a/tests/unit/transform/test_dead_code.py
+++ b/tests/unit/transform/test_dead_code.py
@@ -209,6 +209,9 @@ def _example_dead_while_1_expect():
 
 @fp.fpy
 def _example_dead_while_2():
+    # ``while <cond>: pass`` with a non-trivially-False cond is
+    # preserved — eliminating it would convert possibly-divergent
+    # behaviour into termination, which is unsound.
     x = 0
     while x < 10:
         pass
@@ -217,6 +220,8 @@ def _example_dead_while_2():
 @fp.fpy
 def _example_dead_while_2_expect():
     x = 0
+    while x < 10:
+        pass
     return x
 
 @fp.fpy


### PR DESCRIPTION
Enhances partial evaluation so it computes even for branching programs. Like in [SCCP](https://en.wikipedia.org/wiki/Sparse_conditional_constant_propagation), the program analysis operates over a flat lattice. At a merge point, contradictory values results in a "unknown" value.