### PR TITLE
Fixes for empty ranges

### DIFF
--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -183,7 +183,9 @@ class _ArraySizeInferInstance(DefaultVisitor):
             case Range1():
                 stop = self._get_eval(e.arg)
                 if isinstance(stop, Float | Fraction):
-                    size = int(INTEGER.round(stop))
+                    # ``range(stop)`` with ``stop <= 0`` is empty (mirrors
+                    # Python); clamp so the size is never negative.
+                    size = max(0, int(INTEGER.round(stop)))
                     return ListSize(None, size)
                 else:
                     return ListSize(None, None)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -1476,7 +1476,11 @@ class _FormatInferInstance(Visitor):
         for phi in phis:
             self._set_def_bound(phi, self._bound_of_def(self.def_use.defs[phi.lhs]))
         if n == 0:
-            # Body never runs; the phi stays at the pre-loop value.
+            # The body never executes at runtime, so the phi stays at the
+            # pre-loop value.  But the backend still emits the body, so its
+            # inner definitions need format bounds: visit the body once to
+            # populate them, without folding the result into the phi.
+            run_body()
             return
         for _ in range(n):
             run_body()

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -1475,7 +1475,7 @@ class _FormatInferInstance(Visitor):
         phis = list(phis)
         for phi in phis:
             self._set_def_bound(phi, self._bound_of_def(self.def_use.defs[phi.lhs]))
-        if n == 0:
+        if n <= 0:
             # The body never executes at runtime, so the phi stays at the
             # pre-loop value.  But the backend still emits the body, so its
             # inner definitions need format bounds: visit the body once to

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -1202,8 +1202,14 @@ class CppEmitter(Visitor):
                 stop = self._visit_expr(e.arg, ctx)
                 stop_ty = self._scalar_storage_for_expr(e.arg)
                 stop_cast = self._maybe_cast(stop, stop_ty, result_ty.elt)
+                # ``range(stop)`` with ``stop <= 0`` is empty; clamp before
+                # the unsigned cast so a negative stop doesn't wrap to a
+                # huge allocation.
+                size_expr = (
+                    f'static_cast<size_t>({stop_cast} > 0 ? {stop_cast} : 0)'
+                )
                 self.writer.add_line(
-                    f'{result_ty.format()} {tmp}(static_cast<size_t>({stop_cast}));'
+                    f'{result_ty.format()} {tmp}({size_expr});'
                 )
                 self.writer.add_line(
                     f'std::iota({tmp}.begin(), {tmp}.end(), '

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -330,8 +330,30 @@ def _regression_quant_dot_real_widen(
         return sum(prods)
 
 
+@fp.fpy
+def _regression_empty_range() -> fp.Real:
+    """Empty/flipped/negative ranges compile and behave as empty
+    iterables (mirroring Python).  Pins:
+
+    - ``range(-5)`` (statically-known empty Range1): the loop body is
+      never executed but is still emitted, so its inner definitions
+      need format/storage bounds — a negative iteration count must be
+      treated as zero, not skipped.
+    - ``range(5, 0)`` (statically-known flipped Range2): emitted as an
+      empty ``for`` loop.
+    """
+    with fp.SINT32:
+        acc = 0
+        for _ in range(-5):
+            acc = acc + 1
+        for _ in range(5, 0):
+            acc = acc + 1
+        return acc
+
+
 _regression_funcs: list[fp.Function] = [
     _regression_quant_dot_real_widen,
+    _regression_empty_range,
 ]
 
 

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -222,6 +222,35 @@ class TestArraySizeInfer:
         ]
         assert range_bounds, f'expected a ListSize with size 5, got {info.by_expr.values()}'
 
+    def test_range1_negative_is_empty(self):
+        """``range(n)`` with ``n <= 0`` is empty (size 0), mirroring
+        Python — the size must be clamped, not negative."""
+
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            return [0.0 for _ in range(-5)]
+
+        info = self._run(f)
+        range_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'Range1'
+        ]
+        assert range_bounds and range_bounds[0].size == 0
+
+    def test_range2_flipped_is_empty(self):
+        """``range(start, stop)`` with ``start >= stop`` is empty (size 0)."""
+
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            return [0.0 for _ in range(5, 0)]
+
+        info = self._run(f)
+        range_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'Range2'
+        ]
+        assert range_bounds and range_bounds[0].size == 0
+
     def test_range2_known_size(self):
         """``range(start, stop)`` with both static yields ``stop - start``."""
 

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -711,8 +711,14 @@ class TestFormatInfer:
     def test_for_loop_with_zero_count_keeps_pre_loop_bound(self):
         """
         ``for _ in range(0, 0)`` runs 0 iterations.  The body never
-        executes, so the loop phi stays at the pre-loop value.
+        executes, so the loop phi stays at the pre-loop value (no
+        widening to REAL).  The body itself is still visited once so
+        its inner definitions receive bounds — the backend emits the
+        body even when the loop is statically empty — but those bounds
+        are *not* folded into the phi.
         """
+        from fpy2.analysis.reaching_defs import PhiDef
+
         @fp.fpy
         def f(x: fp.Real) -> fp.Real:
             with fp.FP32:
@@ -724,11 +730,15 @@ class TestFormatInfer:
             return z
 
         info = self._run(f)
-        # All z-bounds must be FP32 (no widening since body didn't run).
-        z_bounds = [b for d, b in info.by_def.items() if d.name.base == 'z']
         fp32 = fp.FP32.format()
-        assert all(b == fp32 for b in z_bounds), (
-            f'expected all z bounds to be FP32 with N=0, got {z_bounds}'
+        # The loop phi (and thus the post-loop value of z) must stay
+        # FP32 — the body's REAL context must not leak into the result.
+        z_phis = [
+            b for d, b in info.by_def.items()
+            if d.name.base == 'z' and isinstance(d, PhiDef) and d.is_loop
+        ]
+        assert z_phis and all(b == fp32 for b in z_phis), (
+            f'expected loop phi for z to stay FP32 with N=0, got {z_phis}'
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Fixes array size inference, format inference, and C++ compilation for empty ranges, i.e., `range(0)` or even `range(-1)`.