### PR TITLE
Update array size inference

### DIFF
--- a/docs/todos/array-size-integer-exactness.md
+++ b/docs/todos/array-size-integer-exactness.md
@@ -1,0 +1,200 @@
+# Array-size analysis: integer-valued arithmetic as an exactness witness
+
+## Context
+
+`array_size`'s slice- and range-size logic pins a size from a *symbolic*
+bound when the offset cancels — e.g. `x[i : i + 32]` -> 32, or
+`range(i, i + 32)` -> 32. The cancellation `(i + 32) - i == 32` is only
+sound when the `+` does **not** round, so `_affine` only descends through
+`+` / `-` nodes for which `_is_exact(e)` holds:
+
+```python
+def _is_exact(self, e: Expr) -> bool:
+    scope = self._ctx_use.use_to_scope.get(e)
+    return scope is not None and scope.ctx == REAL
+```
+
+i.e. the node must sit inside a `with fp.REAL:` scope.
+
+That test is too weak. The motivating example:
+
+```python
+@fp.fpy
+def foo(xs):
+    acc = 0
+    for i in range(0, len(xs), 32):
+        slc = xs[i:i+32]          # <- no size derived
+        with fp.REAL:
+            slc_acc = sum(slc)
+        with fp.FP32:
+            acc += slc_acc
+    return acc
+```
+
+`slc` gets **no** size. The slice bound `i + 32` is evaluated under the
+function's (symbolic) default context, not `REAL`, so `_is_exact` returns
+`False` and `_affine` refuses to peel the `+ 32` offset.
+
+But the arithmetic *is* exact, for a reason `_is_exact` can't see: `i` is
+a `range` loop index, hence integer-valued, and FPy computes integer
+arithmetic exactly. `FormatInfer` already reaches this conclusion with no
+`REAL` annotation:
+
+```
+i        : MPFixedFormat(...)   # range elements are integers
+32       : SetFormat({32})
+(i + 32) : RealFormat()         # exact
+```
+
+The only current workaround is to wrap the slice in an explicit
+`with fp.REAL:` — a non-obvious requirement for ordinary index math that
+nobody writes in practice.
+
+## Goals
+
+1. Derive a size for slice / range bounds whose offset cancels over
+   **integer** index arithmetic, without requiring an explicit `REAL`
+   scope (`x[i : i + k]`, `range(i, i + k)`, `range(0, len(xs), s)`,
+   etc.).
+2. Stay sound: only treat arithmetic as exact when it provably is.
+3. Don't regress: bounds that are genuinely unknown-to-be-exact (e.g.
+   arithmetic on a `Real` parameter) must still yield `None`.
+4. No new analysis-dependency cycle.
+
+## Non-goals
+
+- Reasoning about size *expressions* / non-cancelling offsets
+  (`len(xs) + 1`, `2 * i`). Out of scope, same as the symbolic-size
+  proposal (`array-size-symbolic.md`).
+- Proving integer arithmetic can't overflow a narrow format. We match
+  `FormatInfer`'s existing assumption that integer index arithmetic is
+  exact; we do not independently bound magnitudes.
+- Tracking integer-ness for any purpose beyond the slice/range exactness
+  witness.
+
+## Root cause
+
+`_is_exact` answers *"is this node inside a `with fp.REAL` scope?"* when
+the question affine cancellation actually needs is *"does this arithmetic
+round?"*. There are two independent sufficient conditions for "no
+rounding":
+
+1. the node is under the exact (`REAL`) context — what we check today;
+2. the operands are integer-valued — integers are exact, and FPy
+   computes integer arithmetic exactly (this is why `FormatInfer` gives
+   `i + 32` a `RealFormat`).
+
+Index math hits (2), essentially never (1).
+
+## Design
+
+Add an **integer-valued witness** to the exactness test, *in addition to*
+the existing `REAL` check (strictly more permissive, never less):
+
+```python
+# in _affine, the descent guard becomes
+case Add() if self._is_exact(e) or self._is_int_op(e):
+    ...
+case Sub() if self._is_exact(e) or self._is_int_op(e):
+    ...
+```
+
+where `_is_int_op(Add/Sub)` holds iff both operands are integer-valued,
+and `_is_int_valued(e)` is a small structural predicate:
+
+| Expression form | integer-valued? | how we know |
+|---|---|---|
+| `Integer` literal / `_const_int(e) is not None` | yes | a known integer constant |
+| `Len`, `Dim`, `Size` | yes | integer-producing builtins |
+| `Var` bound to a `range` loop target | yes | `range` yields integers |
+| `enumerate` index projection | yes | the `int` slot of the tuple |
+| `Add` / `Sub` / `Mul` / `Neg` / `Mod` of integer-valued operands | yes | integer arithmetic is closed |
+| anything else | no | — |
+
+These rules mirror the integer-producing cases `FormatInfer` already
+encodes (`Len`/`Dim`/`Size`/`Range`/`Enumerate` -> `INTEGER` regardless
+of context).
+
+### The only stateful piece: `range` loop targets
+
+`_is_int_valued(Var i)` needs to know `i` is a `range` index. Record
+`range` loop targets as they're bound:
+
+- In `_visit_for`, when `stmt.iterable` is a `Range1` / `Range2` /
+  `Range3`, add the loop target's `Definition`(s) to a set
+  `self._int_defs`.
+- `_is_int_valued(Var)` resolves the use to its def (`def_use`) and
+  returns `True` if it's in `_int_defs`.
+- For a `Var` bound to an assignment `j = <expr>`, optionally recurse on
+  the RHS with memoization + an in-progress guard so loop phis terminate
+  (treat a still-in-progress def as `False`). In practice the base of a
+  slice/range bound is a bare loop index or a `len`, so the recursion is
+  shallow; the assignment-chain case can be deferred if it isn't needed.
+
+No call into `FormatInfer` — that would be a dependency cycle
+(`FormatInfer` already imports `ArraySizeInfer` for `_known_iter_count`).
+We replicate the small rule set instead.
+
+## Why it's sound
+
+- **Consistent with the compiler.** Treating integer index arithmetic as
+  exact is precisely the assumption `FormatInfer` — the correctness-
+  critical analysis the cpp backend trusts — already makes. This change
+  introduces no *new* unsoundness relative to the rest of the compiler.
+- **The existing negative tests are the guard.** The current
+  `test_list_slice_symbolic_offset_not_under_real_is_unknown` and
+  `test_range2_symbolic_offset_not_under_real_is_unknown` use a `Real`
+  *parameter* `i` (`def f(x, i: fp.Real)`), which is **not**
+  integer-valued — so those slices stay `None`, unchanged. The motivating
+  case differs precisely because `i` is a `range` index → integer →
+  exact. That distinction is the correct one: a `range` index is provably
+  an integer; an arbitrary `Real` argument is not.
+
+Post-fix behavior:
+
+- `xs[i : i + 32]` / `range(i, i + 32)` with `i` a `range` index, no
+  `REAL` → **size known** (fixes the example);
+- `x[i : i + 16]` with `i` a `Real` parameter, no `REAL` → still `None`;
+- everything under `REAL` → unchanged.
+
+## Implementation plan
+
+1. Add `self._int_defs: set[Definition]`, populated in `_visit_for` for
+   `Range*` iterables (and, if cheap, the `enumerate` index target).
+2. Add `_is_int_valued(e)` (the table above) and `_is_int_op(e)` (both
+   operands integer-valued).
+3. Widen the `_affine` `Add` / `Sub` descent guard to
+   `self._is_exact(e) or self._is_int_op(e)`.
+4. Tests:
+   - integer-index slice / range *without* `REAL` → known
+     (`xs[i:i+32]`, `range(i, i+32)`, `range(i, i+32, 2)`);
+   - `len`-based bounds (already partially covered);
+   - `Real`-parameter base without `REAL` → still `None` (regression
+     guard, keep the existing ones);
+   - end-to-end: the `foo`/`MX_E4M3` reproducer derives size 32 for
+     `slc` with the explicit `with fp.REAL:` removed.
+
+## Risks / open questions
+
+1. **`Var` assignment-chain recursion + phis.** A `Var` bound to
+   `j = i + 1` needs RHS recursion; loop-carried defs need a cycle guard.
+   Start with the direct cases (loop target, `len`/`size`/`dim`, literal,
+   one-level arithmetic) and add chained resolution only if real programs
+   need it.
+2. **Duplication with `FormatInfer`.** The integer-ness rules now live in
+   two places. Acceptable short-term; see below.
+3. **`Mul` exactness.** Integer `*` is mathematically exact but more prone
+   to magnitude blow-up than `+`/`-`. Since `_affine` only peels additive
+   *constant* offsets, `Mul` only matters for deciding a *base* is
+   integer-valued (not for the offset), so it's safe to include — but if
+   in doubt, restrict the first cut to `+`/`-`/`Neg`.
+
+## Out of scope / possible follow-up
+
+- **Shared integer-valued analysis.** The cleaner long-term shape is a
+  small standalone "is this expression integer-valued?" analysis that
+  **both** `FormatInfer` and `ArraySize` consume, eliminating the
+  duplicated rule set. Larger change (touches `FormatInfer`); do the
+  self-contained version first and DRY it up only if the duplication
+  starts to bite.
+- Non-cancelling / size-expression bounds — see `array-size-symbolic.md`.

--- a/docs/todos/array-size-symbolic.md
+++ b/docs/todos/array-size-symbolic.md
@@ -1,5 +1,52 @@
 # Array-size analysis: symbolic sizes via union-find
 
+> **Status: implemented.**  The proposal below was the original design;
+> the as-built differs in a few deliberate ways, summarized here.  The
+> rest of the document is retained as design rationale.
+>
+> ### As-built summary
+>
+> - **Representation.** No bespoke `SymbolicSize` / `_SizeUF`.  Following
+>   the type-inference precedent, a *size variable* is a `NamedId` minted
+>   by a `Gensym`, and the analysis carries a shared
+>   `Unionfind[NamedId | int]` (`fpy2.utils.Unionfind`).  So:
+>   `ArraySize: TypeAlias = int | NamedId | None`.
+> - **Concrete int is the representative.** Pinning a class to a constant
+>   is just `union(int, var)` with the `int` as leader.  There is no
+>   separate `pin`/`resolve` map: `concrete_size(size, uf)` is a `find`
+>   that lands on an `int` (or `None`).  `ArraySizeAnalysis.size_uf` is
+>   the raw `Unionfind`; consumers use the module helpers
+>   `concrete_size(size, uf)` and `is_size_eq(b1, b2, uf)`.
+> - **Size-preserving propagation is mostly free.** `ys = xs`,
+>   `[f(x) for x in xs]`, `enumerate(xs)`, `xs[:]`, and `IndexedAssign`
+>   already thread `.size`, so the size variable rides along — no special
+>   per-op symbol plumbing was needed.  Arguments / free vars mint one
+>   fresh variable for their outer list dimension (`_arg_bound`).
+> - **Phase 3 (loop-phi merge) was NOT implemented — it is unsound.**
+>   Optimistically merging the pre-loop and post-body size vars assumes
+>   the body preserves length, which is false for size-changing bodies
+>   (e.g. `ys = ys[1:]`).  Instead the loop fixpoint uses the ordinary
+>   join: a size-preserving body re-propagates the *same* variable so the
+>   join keeps it; a size-changing body yields a different size so the
+>   join goes to `None`.  Sound, and no optimism required.
+> - **`zip` is strict, not min.** (Already corrected in the operation
+>   rules below.)  Any concrete input pins the symbolic inputs to it and
+>   the result is that int; all-symbolic inputs are merged and the result
+>   keeps the representative.
+> - **Cross-function safety.** `_refine_sizes` (call-result size overlay)
+>   adopts only *concrete* `int` callee sizes — a callee's size variables
+>   belong to its own run and must not leak across the call.
+> - **Convergence (open question #3) resolved.** The visitor keeps a
+>   monotone `_uf_changes` counter (bumped only on a real union); the loop
+>   fixpoint requires both stored-bound stability *and* a stable counter,
+>   so a `zip`-merge inside a loop body can't terminate the fixpoint one
+>   iteration early.
+> - **Deferred (not needed by any current consumer):** assertion-seeded
+>   equalities (`assert len(xs) == len(ys)`), and consumer integration
+>   (`format_infer`'s `Sum`, bounds-check elimination).  `format_infer`
+>   already ignores non-`int` sizes, so symbolic sizes are a safe no-op
+>   there until a consumer opts in.
+
 ## Context
 
 The current `array_size` analysis tracks list sizes as a flat lattice

--- a/docs/todos/array-size-symbolic.md
+++ b/docs/todos/array-size-symbolic.md
@@ -147,10 +147,15 @@ without minting:
 Where the rule isn't "fresh symbol" or "propagate symbol," the visitor
 needs to compute relationships explicitly.  Highlights:
 
-- **`zip(xs1, …, xsN)`**: result size = min of input sizes.  If any
-  input is concrete, the result size is at most that int; if all
-  inputs are *equal* (UF-equiv) symbols, the result keeps that symbol.
-  Otherwise: fresh symbol with no constraints.
+- **`zip(xs1, …, xsN)`**: FPy's `zip` is *strict* — it raises unless
+  every input has the same length (it does **not** truncate to the
+  shortest like Python's default `zip`).  So the result length *equals*
+  the common input length.  If all inputs are *equal* (UF-equiv)
+  symbols, the result keeps that symbol.  If any input is concrete,
+  every other input must equal it on the non-raising path, so the
+  result size is exactly that int — and a symbolic input can be
+  `pin`/`merge`d to it.  Statically-conflicting concrete sizes mean the
+  call always raises (the result is unreachable): report `None`.
 - **List concatenation `xs + ys`**: result size = `len(xs) + len(ys)`.
   Concrete + concrete → int.  Anything else → fresh symbol (we don't
   track sums, see Non-goals).

--- a/fpy2/analysis/__init__.py
+++ b/fpy2/analysis/__init__.py
@@ -7,6 +7,8 @@ from .array_size import (
     ArraySizeInfer,
     ListSize,
     TupleSize,
+    concrete_size,
+    is_size_eq,
 )
 from .call_graph import CallGraph, CallGraphAnalysis, CallGraphError
 from .context_use import (

--- a/fpy2/analysis/__init__.py
+++ b/fpy2/analysis/__init__.py
@@ -7,8 +7,6 @@ from .array_size import (
     ArraySizeInfer,
     ListSize,
     TupleSize,
-    concrete_size,
-    is_size_eq,
 )
 from .call_graph import CallGraph, CallGraphAnalysis, CallGraphError
 from .context_use import (

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -24,6 +24,7 @@ from ..ast.visitor import DefaultVisitor
 from ..function import Function
 from ..number import Float, INTEGER, REAL
 from ..types import ListType, TupleType, Type
+from ..utils import Gensym, NamedId, Unionfind
 from .context_use import ContextUse, ContextUseAnalysis
 from .define_use import Definition, DefSite, DefineUseAnalysis
 from .partial_eval import PartialEval, PartialEvalInfo, Value
@@ -35,29 +36,78 @@ __all__ = [
     'ArraySizeBound',
     'ArraySizeInfer',
     'ListSize',
+    'SizeUnionfind',
     'TupleSize',
+    'concrete_size',
+    'is_size_eq',
 ]
 
 
 #####################################################################
 # Array-size lattice
 
-ArraySize: TypeAlias = int | None
+ArraySize: TypeAlias = 'int | NamedId | None'
 """
-Static size of a list-valued expression: a concrete ``int`` when the
-size is known, ``None`` when unknown.
+Static size of a list-valued expression:
 
-This is a flat 3-element lattice — ``None`` is top; equal known sizes
-join to themselves; unequal known sizes join to ``None``.  It is *not*
-a set of possible sizes: every consumer that ever inspected the size
-treated "multiple possibilities" identically to "unknown", so the
-information was not load-bearing.
+- a concrete ``int`` when the size is a compile-time constant;
+- a :class:`NamedId` *size variable* when the length is unknown but
+  tracked, so equalities like ``len(ys) == len(xs)`` survive.  Two size
+  variables in the same :class:`SizeUnionfind` class denote the same
+  runtime length; a class whose representative is an ``int`` is pinned to
+  that constant.
+- ``None`` — top; no information.
+
+``None`` is top; equal sizes (same ``int``, or co-representative size
+variables) join to themselves; everything else joins to ``None``.  It is
+*not* a set of possible sizes.  Size variables are minted per analysis
+run and are **not** meaningful across functions.
 """
 
+SizeUnionfind: TypeAlias = 'Unionfind[NamedId | int]'
+"""Equivalence classes of size variables (and the concrete ``int``s they
+pin to) for one analysis run.  By convention a concrete ``int`` is always
+the representative of its class, so :func:`concrete_size` is just a
+``find`` that lands on an ``int``.  Use :func:`concrete_size` /
+:func:`is_size_eq` rather than poking the union-find directly."""
 
-def _join_size(a: ArraySize, b: ArraySize) -> ArraySize:
-    """Lattice join for :data:`ArraySize`.  Equal sizes survive; otherwise top."""
-    return a if a == b else None
+
+def _repr_size(size: ArraySize, uf: SizeUnionfind) -> int | NamedId | None:
+    """The representative of *size*'s class: an ``int`` if the class is
+    pinned to a constant, else the size variable itself (``None`` stays
+    ``None``)."""
+    if isinstance(size, NamedId):
+        return uf.get(size, size)
+    return size
+
+
+def concrete_size(size: ArraySize, uf: SizeUnionfind) -> int | None:
+    """The concrete ``int`` *size* denotes — directly, or via a pinned
+    size-variable class — or ``None`` if not a compile-time constant."""
+    rep = _repr_size(size, uf)
+    return rep if isinstance(rep, int) else None
+
+
+def _size_eq(a: ArraySize, b: ArraySize, uf: SizeUnionfind) -> bool:
+    """Are two sizes provably equal: same representative (concrete int or
+    co-representative size variable)?"""
+    ra = _repr_size(a, uf)
+    return ra is not None and ra == _repr_size(b, uf)
+
+
+def is_size_eq(b1: ArraySizeBound, b2: ArraySizeBound, uf: SizeUnionfind) -> bool:
+    """Structurally compare two bounds, treating equal-representative
+    sizes at each level as equal."""
+    match b1, b2:
+        case ListSize(), ListSize():
+            return _size_eq(b1.size, b2.size, uf) and is_size_eq(b1.elt, b2.elt, uf)
+        case TupleSize(), TupleSize():
+            return (len(b1.elts) == len(b2.elts)
+                    and all(is_size_eq(a, b, uf) for a, b in zip(b1.elts, b2.elts)))
+        case None, None:
+            return True
+        case _:
+            return False
 
 
 @dataclass(frozen=True)
@@ -100,6 +150,10 @@ class ArraySizeAnalysis:
     by_def: dict[Definition, ArraySizeBound]
     ret_size: ArraySizeBound
     def_use: DefineUseAnalysis
+    size_uf: SizeUnionfind
+    """Equivalence classes for the size variables appearing in the bounds
+    above.  Use :func:`concrete_size` / :func:`is_size_eq` (which take
+    this) rather than comparing sizes directly."""
 
 
 #####################################################################
@@ -115,6 +169,9 @@ class _ArraySizeInferInstance(DefaultVisitor):
     by_expr: dict[Expr, ArraySizeBound]
     by_def: dict[Definition, ArraySizeBound]
     ret_size: ArraySizeBound
+    uf: SizeUnionfind
+    gensym: Gensym
+    _uf_changes: int
     _callee_ret: dict[FuncDef, ArraySizeBound]
     _ctx_use_cache: ContextUseAnalysis | None
 
@@ -125,8 +182,42 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self.by_expr = {}
         self.by_def = {}
         self.ret_size = None
+        self.uf = Unionfind()
+        self.gensym = Gensym()
+        # Bumped whenever a union actually collapses two classes — lets the
+        # loop fixpoint detect union-find progress even when no stored bound
+        # changes (e.g. a ``zip`` inside the body merges two size vars).
+        self._uf_changes = 0
         self._callee_ret = {}
         self._ctx_use_cache = None
+
+    def _fresh_size(self) -> NamedId:
+        """Mint a fresh size variable (only ever for arguments / free
+        vars, which are bound once before any fixpoint — so no AST-keyed
+        memoization is needed)."""
+        s = self.gensym.fresh('n')
+        self.uf.add(s)
+        return s
+
+    def _pin_size(self, sym: NamedId, n: int) -> None:
+        """Constrain *sym*'s class to the concrete length *n*, making the
+        ``int`` the class representative."""
+        self.uf.add(n)
+        if self.uf.find(sym) != self.uf.find(n):
+            self.uf.union(n, sym)   # ``int`` first => it leads
+            self._uf_changes += 1
+
+    def _merge_sizes(self, a: NamedId, b: NamedId) -> None:
+        """Prove two size variables equal (e.g. via strict ``zip``),
+        keeping a concrete ``int`` as the representative if either class
+        already has one."""
+        ra, rb = self.uf.get(a, a), self.uf.get(b, b)
+        if ra == rb:
+            return
+        if isinstance(rb, int):
+            ra, rb = rb, ra          # keep the concrete as leader
+        self.uf.union(ra, rb)
+        self._uf_changes += 1
 
     @property
     def def_use(self) -> DefineUseAnalysis:
@@ -145,7 +236,10 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
     def analyze(self) -> ArraySizeAnalysis:
         self._visit_function(self.func, None)
-        return ArraySizeAnalysis(self.by_expr, self.by_def, self.ret_size, self.partial_eval.def_use)
+        return ArraySizeAnalysis(
+            self.by_expr, self.by_def, self.ret_size,
+            self.partial_eval.def_use, self.uf,
+        )
 
     def _cvt_type(self, ty: Type) -> ArraySizeBound:
         match ty:
@@ -158,17 +252,37 @@ class _ArraySizeInferInstance(DefaultVisitor):
             case _:
                 return None
 
+    def _arg_bound(self, ty: Type) -> ArraySizeBound:
+        """Like :meth:`_cvt_type`, but a list parameter's *outer* length
+        gets a fresh size variable (its length is fixed per call, just
+        unknown), so equalities such as ``ys = xs`` are tracked.  Inner
+        dimensions stay ``None`` (one size variable per argument)."""
+        match ty:
+            case ListType():
+                return ListSize(self._cvt_type(ty.elt), self._fresh_size())
+            case TupleType():
+                return TupleSize(tuple(self._arg_bound(e) for e in ty.elts))
+            case _:
+                return None
+
     def _get_eval(self, e: Expr) -> Value | None:
         if e in self.partial_eval.by_expr:
             return self.partial_eval.by_expr[e]
         else:
             return None
 
+    def _join_size(self, a: ArraySize, b: ArraySize) -> ArraySize:
+        """Lattice join: equal sizes (same int, or co-representative size
+        variables) survive as their representative — concrete when the
+        class is pinned; everything else goes to ``None``."""
+        ra = _repr_size(a, self.uf)
+        return ra if ra is not None and ra == _repr_size(b, self.uf) else None
+
     def _unify(self, t1: ArraySizeBound, t2: ArraySizeBound) -> ArraySizeBound:
         match t1, t2:
             case ListSize(), ListSize():
                 elt = self._unify(t1.elt, t2.elt)
-                size = _join_size(t1.size, t2.size)
+                size = self._join_size(t1.size, t2.size)
                 return ListSize(elt, size)
             case TupleSize(), TupleSize():
                 elts = tuple(self._unify(e1, e2) for e1, e2 in zip(t1.elts, t2.elts, strict=True))
@@ -260,9 +374,14 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
                 # FPy's ``zip`` is *strict*: it raises unless every input
                 # has the same length (no truncation to the shortest), so
-                # the result length is that common length — known only
-                # when all inputs are known and agree.  Conflicting known
-                # sizes always raise (result unreachable) => unknown.
+                # the result length *equals* every input length.  We use
+                # that runtime-enforced equality:
+                #   * any input concrete -> all inputs equal it (or the zip
+                #     raises); result is that int.  Conflicting concretes
+                #     => always-raising => unknown.
+                #   * else all symbolic -> merge their classes (sound: the
+                #     zip enforces equality) and keep the representative.
+                #   * any input truly unknown (``None``) -> unknown.
                 elt_tys: list[ArraySizeBound] = []
                 sizes: list[ArraySize] = []
                 for ty in tys:
@@ -270,12 +389,24 @@ class _ArraySizeInferInstance(DefaultVisitor):
                     elt_tys.append(ty.elt)
                     sizes.append(ty.size)
 
+                concretes = {concrete_size(s, self.uf) for s in sizes}
+                concretes.discard(None)
+                symbols = [s for s in sizes if isinstance(s, NamedId)]
+
                 if any(s is None for s in sizes):
                     size: ArraySize = None
-                elif len(set(sizes)) == 1:
-                    size = sizes[0]
+                elif concretes:
+                    # all inputs must equal the concrete length(s)
+                    size = next(iter(concretes)) if len(concretes) == 1 else None
+                    if size is not None:
+                        for s in symbols:
+                            self._pin_size(s, size)
                 else:
-                    size = None
+                    # all symbolic: strict zip proves them equal
+                    rep = symbols[0]
+                    for s in symbols[1:]:
+                        self._merge_sizes(rep, s)
+                    size = self.uf.find(rep)
 
                 return ListSize(TupleSize(tuple(elt_tys)), size)
 
@@ -347,10 +478,18 @@ class _ArraySizeInferInstance(DefaultVisitor):
         # process element expression
         elt_ty = self._visit_expr(e.elt, ctx)
 
-        # try to compute size
+        # A single-iterable comprehension has exactly the iterable's
+        # length — propagate its size verbatim, so a *symbolic* size flows
+        # through (``[f(x) for x in xs]`` stays length-linked to ``xs``).
+        if len(iter_tys) == 1:
+            return ListSize(elt_ty, iter_tys[0].size)
+
+        # Multiple iterables form a cartesian product; the size is the
+        # product of the lengths, known only when every one is a concrete
+        # ``int`` (symbolic sizes don't multiply).
         size = 1
         for ty in iter_tys:
-            if ty.size is None:
+            if not isinstance(ty.size, int):
                 return ListSize(elt_ty, None)
             size *= ty.size
 
@@ -370,6 +509,11 @@ class _ArraySizeInferInstance(DefaultVisitor):
         if e.stop is not None:
             self._visit_expr(e.stop, ctx)
 
+        # ``xs[:]`` spans the whole list — propagate its (possibly
+        # symbolic) size verbatim.
+        if e.start is None and e.stop is None:
+            return ListSize(ty.elt, ty.size)
+
         # The slice size is ``stop - start``, which we can pin whenever
         # that difference is a compile-time constant.  Decomposing each
         # bound into ``base + offset`` (see ``_affine``) covers two cases
@@ -378,10 +522,10 @@ class _ArraySizeInferInstance(DefaultVisitor):
         #   * both bounds share a symbolic base that cancels:
         #     ``x[i : i + 16]`` -> 16.
         # Omitted bounds: ``start`` defaults to 0; ``stop`` defaults to
-        # the list's own size (``ty.size``, itself possibly unknown).
+        # the list's own size — usable as an offset only if it's concrete.
         start = (None, 0) if e.start is None else self._affine(e.start)
         if e.stop is None:
-            stop = None if ty.size is None else (None, ty.size)
+            stop = (None, ty.size) if isinstance(ty.size, int) else None
         else:
             stop = self._affine(e.stop)
 
@@ -512,11 +656,15 @@ class _ArraySizeInferInstance(DefaultVisitor):
         generic callee monomorphized at this site — a possibly different
         element shape.  Where shapes agree, prefer *src*'s concrete size;
         on any mismatch, keep *shape* unchanged.
+
+        Only *concrete* ``int`` sizes are adopted: a :class:`SymbolicSize`
+        in *src* belongs to the callee's own analysis run and is
+        meaningless in ours, so it must not leak across the call.
         """
         match shape, src:
             case ListSize(), ListSize():
                 elt = self._refine_sizes(shape.elt, src.elt)
-                size = src.size if src.size is not None else shape.size
+                size = src.size if isinstance(src.size, int) else shape.size
                 return ListSize(elt, size)
             case TupleSize(), TupleSize() if len(shape.elts) == len(src.elts):
                 elts = tuple(
@@ -583,20 +731,28 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
         Initialises each phi from its pre-loop (lhs) definition, then
         repeatedly runs *run_body* and unifies the post-body (rhs) into
-        each phi until no phi changes.  The lattice has finite height
-        (``ArraySize`` is ``int | None``, structural lattice is
-        shape-preserving), so this terminates.
+        each phi until no phi changes *and* the union-find is stable.  The
+        height is finite (sizes are ``int``/symbol/``None``; the structural
+        lattice is shape-preserving; UF merges are monotone), so this
+        terminates.
+
+        The UF-stability check matters because a merge inside the body
+        (e.g. a ``zip``) can change which sizes are *equivalent* without
+        changing any stored phi value; without it the loop could stop one
+        iteration before that equivalence propagates.
         """
         for phi in phis:
             self.by_def[phi] = self.by_def[self.def_use.defs[phi.lhs]]
         while True:
             prev = {phi: self.by_def[phi] for phi in phis}
+            prev_changes = self._uf_changes
             run_body()
             for phi in phis:
                 lhs = self.by_def[self.def_use.defs[phi.lhs]]
                 rhs = self.by_def[self.def_use.defs[phi.rhs]]
                 self.by_def[phi] = self._unify(lhs, rhs)
-            if all(self.by_def[phi] == prev[phi] for phi in phis):
+            if (self._uf_changes == prev_changes
+                    and all(self.by_def[phi] == prev[phi] for phi in phis)):
                 break
 
     def _visit_while(self, stmt: WhileStmt, ctx: None):
@@ -642,17 +798,17 @@ class _ArraySizeInferInstance(DefaultVisitor):
         return ty
 
     def _visit_function(self, func: FuncDef, ctx: None):
-        # process arguments
+        # process arguments — list parameters get a fresh size variable
         for arg, ty in zip(func.args, self.type_info.arg_types):
             if isinstance(arg.name, NamedId):
                 d = self.def_use.find_def_from_site(arg.name, arg)
-                self.by_def[d] = self._cvt_type(ty)
+                self.by_def[d] = self._arg_bound(ty)
 
-        # process free variables
+        # process free variables — same treatment as arguments
         for fv in func.free_vars:
             d = self.def_use.find_def_from_site(fv, func)
             ty = self.type_info.by_def[d]
-            self.by_def[d] = self._cvt_type(ty)
+            self.by_def[d] = self._arg_bound(ty)
 
         # visit body
         self._visit_block(func.body, ctx)

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -198,14 +198,14 @@ class _ArraySizeInferInstance(DefaultVisitor):
         ty = self._visit_expr(e.arg, ctx)
         match e:
             case Range1():
-                stop = self._get_eval(e.arg)
-                if isinstance(stop, Float | Fraction):
-                    # ``range(stop)`` with ``stop <= 0`` is empty (mirrors
-                    # Python); clamp so the size is never negative.
-                    size = max(0, int(INTEGER.round(stop)))
-                    return ListSize(None, size)
-                else:
-                    return ListSize(None, None)
+                # ``range(stop)`` -> ``max(0, stop)`` when ``stop`` is a
+                # known integer (clamped: ``stop <= 0`` is empty, like
+                # Python).  ``_const_int`` also resolves ``len(xs)`` of a
+                # known-size list, so ``range(len(xs))`` is covered.
+                n = self._const_int(e.arg)
+                if n is not None:
+                    return ListSize(None, max(0, n))
+                return ListSize(None, None)
             case Enumerate():
                 assert isinstance(ty, ListSize)
                 return ListSize(TupleSize((None, ty.elt)), ty.size)
@@ -217,15 +217,16 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self._visit_expr(e.second, ctx)
         match e:
             case Range2():
-                start = self._get_eval(e.first)
-                stop = self._get_eval(e.second)
-                if isinstance(start, Float | Fraction) and isinstance(stop, Float | Fraction):
-                    start_i = int(INTEGER.round(start))
-                    stop_i = int(INTEGER.round(stop))
-                    size = max(0, stop_i - start_i)
-                    return ListSize(None, size)
-                else:
-                    return ListSize(None, None)
+                # ``range(start, stop)`` -> ``max(0, stop - start)``.  The
+                # difference is constant when both bounds are concrete or
+                # share a symbolic base that cancels (e.g.
+                # ``range(i, i + 16)`` under REAL -> 16).
+                diff = self._affine_diff(
+                    self._affine(e.first), self._affine(e.second)
+                )
+                if diff is not None:
+                    return ListSize(None, max(0, diff))
+                return ListSize(None, None)
             case _:
                 return None
 
@@ -235,23 +236,18 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self._visit_expr(e.third, ctx)
         match e:
             case Range3():
-                start = self._get_eval(e.first)
-                stop = self._get_eval(e.second)
-                step = self._get_eval(e.third)
-                if (
-                    isinstance(start, Float | Fraction)
-                    and isinstance(stop, Float | Fraction)
-                    and isinstance(step, Float | Fraction)
-                ):
-                    start_i = int(INTEGER.round(start))
-                    stop_i = int(INTEGER.round(stop))
-                    step_i = int(INTEGER.round(step))
-                    if step_i == 0:
-                        # invalid (Python's range raises); leave size unknown
-                        return ListSize(None, None)
-                    return ListSize(None, len(range(start_i, stop_i, step_i)))
-                else:
-                    return ListSize(None, None)
+                # The count depends only on the span ``stop - start`` and
+                # the step: ``len(range(a, b, s)) == len(range(0, b-a, s))``.
+                # So a constant span (concrete bounds, or a cancelling
+                # symbolic base) plus a concrete non-zero step is enough —
+                # e.g. ``range(i, i + 16, 2)`` under REAL -> 8.
+                span = self._affine_diff(
+                    self._affine(e.first), self._affine(e.second)
+                )
+                step = self._const_int(e.third)
+                if span is not None and step is not None and step != 0:
+                    return ListSize(None, len(range(0, span, step)))
+                return ListSize(None, None)
             case _:
                 return None
 
@@ -391,18 +387,13 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
         slice_size: int | None = None
         if stop is not None:
-            (sbase, soff), (tbase, toff) = start, stop
-            same_base = (
-                (sbase is None and tbase is None)
-                or (sbase is not None and tbase is not None
-                    and sbase.is_equiv(tbase))
-            )
+            diff = self._affine_diff(start, stop)
             # FPy slicing is *strict*: ``xs[a:b]`` is valid only when
             # ``0 <= a <= b <= len(xs)`` — out-of-range / inverted bounds
             # raise rather than clamp.  So a negative difference is an
             # always-raising slice: report unknown, never a bogus size.
-            if same_base and toff - soff >= 0:
-                slice_size = toff - soff
+            if diff is not None and diff >= 0:
+                slice_size = diff
 
         return ListSize(ty.elt, slice_size)
 
@@ -417,9 +408,9 @@ class _ArraySizeInferInstance(DefaultVisitor):
         be guaranteed to equal ``16``.  Falls back to ``(e, 0)`` when no
         constant offset can be peeled off — sound, just less precise.
         """
-        val = self._get_eval(e)
-        if isinstance(val, Float | Fraction):
-            return (None, int(INTEGER.round(val)))
+        c = self._const_int(e)
+        if c is not None:
+            return (None, c)
 
         match e:
             case Add() if self._is_exact(e):
@@ -439,11 +430,37 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
         return (e, 0)
 
+    def _affine_diff(
+        self,
+        lo: tuple[Expr | None, int],
+        hi: tuple[Expr | None, int],
+    ) -> int | None:
+        """``hi - lo`` as a compile-time constant, or ``None``.
+
+        Constant exactly when the two affine forms share a base — both
+        pure constants, or the same symbolic base (so it cancels).
+        """
+        (lbase, loff), (hbase, hoff) = lo, hi
+        same_base = (
+            (lbase is None and hbase is None)
+            or (lbase is not None and hbase is not None
+                and lbase.is_equiv(hbase))
+        )
+        return hoff - loff if same_base else None
+
     def _const_int(self, e: Expr) -> int | None:
-        """The integer value *e* partial-evaluates to, or ``None``."""
+        """The integer value *e* statically evaluates to, or ``None``.
+
+        Covers partial-eval constants and ``len(xs)`` of a list whose
+        size is statically known.
+        """
         val = self._get_eval(e)
         if isinstance(val, Float | Fraction):
             return int(INTEGER.round(val))
+        if isinstance(e, Len):
+            inner = self.by_expr.get(e.arg)
+            if isinstance(inner, ListSize) and isinstance(inner.size, int):
+                return inner.size
         return None
 
     def _is_exact(self, e: Expr) -> bool:

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -14,6 +14,7 @@ the pre-mutation bound from the use def, widens the element bound at
 depth ``len(indices)``, and writes the result to the fresh def.
 """
 
+from contextlib import contextmanager
 from dataclasses import dataclass
 from fractions import Fraction
 from functools import reduce
@@ -168,6 +169,7 @@ class _ArraySizeInferInstance(DefaultVisitor):
     uf: SizeUnionfind
     gensym: Gensym
     _uf_changes: int
+    _cond_depth: int
     _callee_ret: dict[FuncDef, ArraySizeBound]
     _ctx_use_cache: ContextUseAnalysis | None
 
@@ -183,8 +185,20 @@ class _ArraySizeInferInstance(DefaultVisitor):
         # Counts unions; lets the loop fixpoint detect progress when a
         # merge changes equivalences without changing any stored bound.
         self._uf_changes = 0
+        # Nesting depth in conditionally-executed regions (if / loop
+        # bodies); only depth-0 asserts hold on every execution.
+        self._cond_depth = 0
         self._callee_ret = {}
         self._ctx_use_cache = None
+
+    @contextmanager
+    def _branch(self):
+        """Mark the enclosed block as conditionally executed."""
+        self._cond_depth += 1
+        try:
+            yield
+        finally:
+            self._cond_depth -= 1
 
     def _fresh_size(self) -> NamedId:
         """Mint a fresh size variable (only ever for arguments / free
@@ -660,7 +674,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
     def _visit_if1(self, stmt: If1Stmt, ctx: None):
         self._visit_expr(stmt.cond, ctx)
-        self._visit_block(stmt.body, ctx)
+        with self._branch():
+            self._visit_block(stmt.body, ctx)
 
         # unify any merged variable
         for phi in self.def_use.phis[stmt]:
@@ -670,8 +685,9 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
     def _visit_if(self, stmt: IfStmt, ctx: None):
         self._visit_expr(stmt.cond, ctx)
-        self._visit_block(stmt.ift, ctx)
-        self._visit_block(stmt.iff, ctx)
+        with self._branch():
+            self._visit_block(stmt.ift, ctx)
+            self._visit_block(stmt.iff, ctx)
 
         # unify any merged variable
         for phi in self.def_use.phis[stmt]:
@@ -707,7 +723,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
             self._visit_expr(stmt.cond, ctx)
             self._visit_block(stmt.body, ctx)
 
-        self._iterate_to_fixpoint(self.def_use.phis[stmt], body)
+        with self._branch():
+            self._iterate_to_fixpoint(self.def_use.phis[stmt], body)
 
     def _visit_for(self, stmt, ctx):
         # iterable + target bound once, before the fixpoint
@@ -715,9 +732,10 @@ class _ArraySizeInferInstance(DefaultVisitor):
         assert isinstance(iter_ty, ListSize)
         self._visit_binding(stmt, stmt.target, iter_ty.elt)
 
-        self._iterate_to_fixpoint(
-            self.def_use.phis[stmt], lambda: self._visit_block(stmt.body, ctx)
-        )
+        with self._branch():
+            self._iterate_to_fixpoint(
+                self.def_use.phis[stmt], lambda: self._visit_block(stmt.body, ctx)
+            )
 
     def _visit_context(self, stmt, ctx):
         ty = self._visit_expr(stmt.ctx, ctx)
@@ -735,6 +753,43 @@ class _ArraySizeInferInstance(DefaultVisitor):
             self.ret_size = ret_size
         else:
             self.ret_size = self._unify(self.ret_size, ret_size)
+
+    def _visit_assert(self, stmt: AssertStmt, ctx: None):
+        self._visit_expr(stmt.test, ctx)
+        # Only an *unconditional* assert holds on every execution, so only
+        # then may it constrain sizes globally (cf. strict ``zip``).
+        if self._cond_depth == 0:
+            self._seed_from_assert(stmt.test)
+
+    def _seed_from_assert(self, test: Expr):
+        """Learn size equalities from ``len(a) == len(b)`` / ``len(a) == N``
+        (and chained ``==``) — pins or merges the size variables."""
+        if not isinstance(test, Compare):
+            return
+        for op, lhs, rhs in zip(test.ops, test.args, test.args[1:]):
+            if op == CompareOp.EQ:
+                self._relate_sizes(self._len_size(lhs), self._len_size(rhs))
+
+    def _len_size(self, e: Expr) -> ArraySize:
+        """The size ``e`` constrains: the list's size for ``len(xs)``, the
+        constant for an integer expression, else ``None`` (not relatable)."""
+        if isinstance(e, Len):
+            bound = self.by_expr.get(e.arg)
+            return bound.size if isinstance(bound, ListSize) else None
+        return self._const_int(e)
+
+    def _relate_sizes(self, a: ArraySize, b: ArraySize):
+        """Record that two sizes are equal: merge two variables, or pin a
+        variable to a concrete length."""
+        match a, b:
+            case NamedId(), NamedId():
+                self._merge_sizes(a, b)
+            case NamedId(), int():
+                self._pin_size(a, b)
+            case int(), NamedId():
+                self._pin_size(b, a)
+            case _:
+                pass  # both concrete (already constrained) or unknown
 
     def _visit_expr(self, expr: Expr, ctx: None) -> ArraySizeBound:
         ty = super()._visit_expr(expr, ctx)

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -21,6 +21,7 @@ from typing import TypeAlias
 
 from ..ast.fpyast import *
 from ..ast.visitor import DefaultVisitor
+from ..function import Function
 from ..number import Float, INTEGER
 from ..types import ListType, TupleType, Type
 from .define_use import Definition, DefSite, DefineUseAnalysis
@@ -113,6 +114,7 @@ class _ArraySizeInferInstance(DefaultVisitor):
     by_expr: dict[Expr, ArraySizeBound]
     by_def: dict[Definition, ArraySizeBound]
     ret_size: ArraySizeBound
+    _callee_ret: dict[FuncDef, ArraySizeBound]
 
     def __init__(self, func: FuncDef, partial_eval: PartialEvalInfo, type_info: TypeAnalysis):
         self.func = func
@@ -121,6 +123,7 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self.by_expr = {}
         self.by_def = {}
         self.ret_size = None
+        self._callee_ret = {}
 
     @property
     def def_use(self) -> DefineUseAnalysis:
@@ -403,9 +406,51 @@ class _ArraySizeInferInstance(DefaultVisitor):
     def _visit_call(self, e: Call, ctx: None):
         for arg in e.args:
             self._visit_expr(arg, ctx)
-        # just convert type for now
-        ty = self.type_info.by_expr[e]
-        return self._cvt_type(ty)
+        # Start from the call's type shapeeton (correct shape, all-``None``
+        # sizes), then overlay any statically-known sizes the callee's own
+        # return-size analysis proved.  A concrete size in a callee's
+        # ``ret_size`` is independent of the call's arguments (arg-derived
+        # sizes resolve to ``None``), so it's a constant property of the
+        # callee and sound to propagate to every call site.
+        shapeeton = self._cvt_type(self.type_info.by_expr[e])
+        return self._refine_sizes(shapeeton, self._callee_ret_size(e))
+
+    def _callee_ret_size(self, e: Call) -> ArraySizeBound:
+        """The callee's inferred return-size bound, or ``None`` when the
+        call target isn't an analyzable FPy function (primitive, context
+        constructor, or unbound call)."""
+        if not isinstance(e.fn, Function):
+            return None
+        callee = e.fn.ast
+        if callee not in self._callee_ret:
+            # The call graph is acyclic (enforced by ``TypeInfer.check``,
+            # which has already run), so this recursion terminates;
+            # memoize so each callee is analyzed once per analysis run.
+            self._callee_ret[callee] = ArraySizeInfer.analyze(callee).ret_size
+        return self._callee_ret[callee]
+
+    def _refine_sizes(self, shape: ArraySizeBound, src: ArraySizeBound) -> ArraySizeBound:
+        """Overlay concrete sizes from *src* onto the structural *shape*.
+
+        *shape* (from the call's type) has the correct shape; *src* (the
+        callee's ``ret_size``) may carry concrete sizes but — for a
+        generic callee monomorphized at this site — a possibly different
+        element shape.  Where shapes agree, prefer *src*'s concrete size;
+        on any mismatch, keep *shape* unchanged.
+        """
+        match shape, src:
+            case ListSize(), ListSize():
+                elt = self._refine_sizes(shape.elt, src.elt)
+                size = src.size if src.size is not None else shape.size
+                return ListSize(elt, size)
+            case TupleSize(), TupleSize() if len(shape.elts) == len(src.elts):
+                elts = tuple(
+                    self._refine_sizes(a, b)
+                    for a, b in zip(shape.elts, src.elts)
+                )
+                return TupleSize(elts)
+            case _:
+                return shape
 
     def _visit_assign(self, stmt: Assign, ctx: None):
         ty = self._visit_expr(stmt.expr, ctx)

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -22,8 +22,9 @@ from typing import TypeAlias
 from ..ast.fpyast import *
 from ..ast.visitor import DefaultVisitor
 from ..function import Function
-from ..number import Float, INTEGER
+from ..number import Float, INTEGER, REAL
 from ..types import ListType, TupleType, Type
+from .context_use import ContextUse, ContextUseAnalysis
 from .define_use import Definition, DefSite, DefineUseAnalysis
 from .partial_eval import PartialEval, PartialEvalInfo, Value
 from .type_infer import TypeInfer, TypeAnalysis
@@ -115,6 +116,7 @@ class _ArraySizeInferInstance(DefaultVisitor):
     by_def: dict[Definition, ArraySizeBound]
     ret_size: ArraySizeBound
     _callee_ret: dict[FuncDef, ArraySizeBound]
+    _ctx_use_cache: ContextUseAnalysis | None
 
     def __init__(self, func: FuncDef, partial_eval: PartialEvalInfo, type_info: TypeAnalysis):
         self.func = func
@@ -124,10 +126,22 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self.by_def = {}
         self.ret_size = None
         self._callee_ret = {}
+        self._ctx_use_cache = None
 
     @property
     def def_use(self) -> DefineUseAnalysis:
         return self.partial_eval.def_use
+
+    @property
+    def _ctx_use(self) -> ContextUseAnalysis:
+        # Computed lazily — only slices with symbolic-offset bounds need
+        # the active rounding context, so functions without them never
+        # pay for it.  Reuse our partial-eval info so it isn't recomputed.
+        if self._ctx_use_cache is None:
+            self._ctx_use_cache = ContextUse.analyze(
+                self.func, partial_eval=self.partial_eval
+            )
+        return self._ctx_use_cache
 
     def analyze(self) -> ArraySizeAnalysis:
         self._visit_function(self.func, None)
@@ -355,44 +369,88 @@ class _ArraySizeInferInstance(DefaultVisitor):
     def _visit_list_slice(self, e: ListSlice, ctx: None):
         ty = self._visit_expr(e.value, ctx)
         assert isinstance(ty, ListSize)
-
-        # Resolve the start bound.  Omitted ``e.start`` defaults to 0;
-        # otherwise we need partial-eval to pin it to a concrete int.
-        if e.start is None:
-            start: int | None = 0
-        else:
+        if e.start is not None:
             self._visit_expr(e.start, ctx)
-            start_val = self._get_eval(e.start)
-            if isinstance(start_val, Float | Fraction):
-                start = int(INTEGER.round(start_val))
-            else:
-                start = None
-
-        # Resolve the stop bound.  Omitted ``e.stop`` defaults to the
-        # *list's own size* (``ty.size``) — which itself may be ``None``
-        # if the list size isn't known.  Otherwise partial-eval it.
-        if e.stop is None:
-            stop = ty.size
-        else:
+        if e.stop is not None:
             self._visit_expr(e.stop, ctx)
-            stop_val = self._get_eval(e.stop)
-            if isinstance(stop_val, Float | Fraction):
-                stop = int(INTEGER.round(stop_val))
-            else:
-                stop = None
 
-        # FPy slicing is *strict*: ``xs[a:b]`` is valid only when
-        # ``0 <= a <= b <= len(xs)``.  Out-of-range bounds raise at
-        # runtime rather than being clamped (Python's behavior).  So
-        # when both bounds are concrete the static size is exactly
-        # ``stop - start`` — no ``min``/``max`` clamping.  We don't
-        # need ``ty.size`` to be known to compute the difference.
-        if start is not None and stop is not None and stop >= start:
-            slice_size: int | None = stop - start
+        # The slice size is ``stop - start``, which we can pin whenever
+        # that difference is a compile-time constant.  Decomposing each
+        # bound into ``base + offset`` (see ``_affine``) covers two cases
+        # with one rule:
+        #   * both bounds concrete (base ``None``): ``x[1:3]`` -> 2;
+        #   * both bounds share a symbolic base that cancels:
+        #     ``x[i : i + 16]`` -> 16.
+        # Omitted bounds: ``start`` defaults to 0; ``stop`` defaults to
+        # the list's own size (``ty.size``, itself possibly unknown).
+        start = (None, 0) if e.start is None else self._affine(e.start)
+        if e.stop is None:
+            stop = None if ty.size is None else (None, ty.size)
         else:
-            slice_size = None
+            stop = self._affine(e.stop)
+
+        slice_size: int | None = None
+        if stop is not None:
+            (sbase, soff), (tbase, toff) = start, stop
+            same_base = (
+                (sbase is None and tbase is None)
+                or (sbase is not None and tbase is not None
+                    and sbase.is_equiv(tbase))
+            )
+            # FPy slicing is *strict*: ``xs[a:b]`` is valid only when
+            # ``0 <= a <= b <= len(xs)`` — out-of-range / inverted bounds
+            # raise rather than clamp.  So a negative difference is an
+            # always-raising slice: report unknown, never a bogus size.
+            if same_base and toff - soff >= 0:
+                slice_size = toff - soff
 
         return ListSize(ty.elt, slice_size)
+
+    def _affine(self, e: Expr) -> tuple[Expr | None, int]:
+        """Decompose *e* into ``(base, offset)`` with ``e == base +
+        offset``, where *offset* is a compile-time integer and *base* is
+        the residual expression (``None`` when *e* is a pure constant).
+
+        Only descends through ``+`` / ``-`` whose result is computed
+        under the exact (``REAL``) context: under a rounding context the
+        addition could perturb the value, so ``(i + 16) - i`` would not
+        be guaranteed to equal ``16``.  Falls back to ``(e, 0)`` when no
+        constant offset can be peeled off — sound, just less precise.
+        """
+        val = self._get_eval(e)
+        if isinstance(val, Float | Fraction):
+            return (None, int(INTEGER.round(val)))
+
+        match e:
+            case Add() if self._is_exact(e):
+                c = self._const_int(e.second)
+                if c is not None:
+                    base, off = self._affine(e.first)
+                    return (base, off + c)
+                c = self._const_int(e.first)
+                if c is not None:
+                    base, off = self._affine(e.second)
+                    return (base, off + c)
+            case Sub() if self._is_exact(e):
+                c = self._const_int(e.second)
+                if c is not None:
+                    base, off = self._affine(e.first)
+                    return (base, off - c)
+
+        return (e, 0)
+
+    def _const_int(self, e: Expr) -> int | None:
+        """The integer value *e* partial-evaluates to, or ``None``."""
+        val = self._get_eval(e)
+        if isinstance(val, Float | Fraction):
+            return int(INTEGER.round(val))
+        return None
+
+    def _is_exact(self, e: Expr) -> bool:
+        """True iff *e* is evaluated under the exact (``REAL``) rounding
+        context, so its arithmetic introduces no rounding."""
+        scope = self._ctx_use.use_to_scope.get(e)
+        return scope is not None and scope.ctx == REAL
 
     def _visit_tuple_expr(self, e: TupleExpr, ctx: None):
         return TupleSize(tuple(self._visit_expr(elt, ctx) for elt in e.elts))

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -36,7 +36,6 @@ __all__ = [
     'ArraySizeBound',
     'ArraySizeInfer',
     'ListSize',
-    'SizeUnionfind',
     'TupleSize',
     'concrete_size',
     'is_size_eq',
@@ -81,29 +80,27 @@ def _repr_size(size: ArraySize, uf: SizeUnionfind) -> int | NamedId | None:
     return size
 
 
-def concrete_size(size: ArraySize, uf: SizeUnionfind) -> int | None:
-    """The concrete ``int`` *size* denotes — directly, or via a pinned
-    size-variable class — or ``None`` if not a compile-time constant."""
-    rep = _repr_size(size, uf)
-    return rep if isinstance(rep, int) else None
+def concrete_size(size: ArraySize) -> int | None:
+    """The concrete ``int`` *size* denotes, or ``None`` if unknown.
+    Assumes *size* comes from a resolved :class:`ArraySizeAnalysis`."""
+    return size if isinstance(size, int) else None
 
 
-def _size_eq(a: ArraySize, b: ArraySize, uf: SizeUnionfind) -> bool:
-    """Are two sizes provably equal: same representative (concrete int or
-    co-representative size variable)?"""
-    ra = _repr_size(a, uf)
-    return ra is not None and ra == _repr_size(b, uf)
+def _size_eq(a: ArraySize, b: ArraySize) -> bool:
+    """Are two (resolved) sizes provably equal — identical and not an
+    untracked unknown (``None`` is never equal, even to itself)?"""
+    return a is not None and a == b
 
 
-def is_size_eq(b1: ArraySizeBound, b2: ArraySizeBound, uf: SizeUnionfind) -> bool:
-    """Structurally compare two bounds, treating equal-representative
-    sizes at each level as equal."""
+def is_size_eq(b1: ArraySizeBound, b2: ArraySizeBound) -> bool:
+    """Structurally compare two (resolved) bounds, treating equal sizes
+    at each level as equal."""
     match b1, b2:
         case ListSize(), ListSize():
-            return _size_eq(b1.size, b2.size, uf) and is_size_eq(b1.elt, b2.elt, uf)
+            return _size_eq(b1.size, b2.size) and is_size_eq(b1.elt, b2.elt)
         case TupleSize(), TupleSize():
             return (len(b1.elts) == len(b2.elts)
-                    and all(is_size_eq(a, b, uf) for a, b in zip(b1.elts, b2.elts)))
+                    and all(is_size_eq(a, b) for a, b in zip(b1.elts, b2.elts)))
         case None, None:
             return True
         case _:
@@ -150,10 +147,6 @@ class ArraySizeAnalysis:
     by_def: dict[Definition, ArraySizeBound]
     ret_size: ArraySizeBound
     def_use: DefineUseAnalysis
-    size_uf: SizeUnionfind
-    """Equivalence classes for the size variables appearing in the bounds
-    above.  Use :func:`concrete_size` / :func:`is_size_eq` (which take
-    this) rather than comparing sizes directly."""
 
 
 #####################################################################
@@ -236,10 +229,25 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
     def analyze(self) -> ArraySizeAnalysis:
         self._visit_function(self.func, None)
-        return ArraySizeAnalysis(
-            self.by_expr, self.by_def, self.ret_size,
-            self.partial_eval.def_use, self.uf,
-        )
+        # Resolve every size to its union-find representative so the
+        # result is self-contained: afterwards a size is known iff it's an
+        # ``int`` and equal sizes are ``==`` — no union-find needed by
+        # consumers (cf. type inference's ``_resolve_type``).
+        by_expr = {e: self._resolve(b) for e, b in self.by_expr.items()}
+        by_def = {d: self._resolve(b) for d, b in self.by_def.items()}
+        ret_size = self._resolve(self.ret_size)
+        return ArraySizeAnalysis(by_expr, by_def, ret_size, self.partial_eval.def_use)
+
+    def _resolve(self, bound: ArraySizeBound) -> ArraySizeBound:
+        """Replace every size variable in *bound* with its union-find
+        representative (an ``int`` if pinned, else the canonical var)."""
+        match bound:
+            case ListSize():
+                return ListSize(self._resolve(bound.elt), _repr_size(bound.size, self.uf))
+            case TupleSize():
+                return TupleSize(tuple(self._resolve(e) for e in bound.elts))
+            case _:
+                return None
 
     def _cvt_type(self, ty: Type) -> ArraySizeBound:
         match ty:
@@ -389,8 +397,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
                     elt_tys.append(ty.elt)
                     sizes.append(ty.size)
 
-                concretes = {concrete_size(s, self.uf) for s in sizes}
-                concretes.discard(None)
+                concretes = {r for s in sizes
+                             if isinstance((r := _repr_size(s, self.uf)), int)}
                 symbols = [s for s in sizes if isinstance(s, NamedId)]
 
                 if any(s is None for s in sizes):

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -570,17 +570,43 @@ class _ArraySizeInferInstance(DefaultVisitor):
     def _const_int(self, e: Expr) -> int | None:
         """The integer value *e* statically evaluates to, or ``None``.
 
-        Covers partial-eval constants and ``len(xs)`` of a list whose
-        size is statically known.
+        Covers partial-eval constants and the integer-valued list queries
+        ``len(xs)`` / ``size(xs, d)`` / ``dim(xs)`` when the queried size
+        is statically known (``dim`` always is — it's the nesting depth).
         """
         val = self._get_eval(e)
         if isinstance(val, Float | Fraction):
             return int(INTEGER.round(val))
-        if isinstance(e, Len):
-            inner = self.by_expr.get(e.arg)
-            if isinstance(inner, ListSize) and isinstance(inner.size, int):
-                return inner.size
+        match e:
+            case Len():
+                bound = self.by_expr.get(e.arg)
+                if isinstance(bound, ListSize) and isinstance(bound.size, int):
+                    return bound.size
+            case Dim():
+                bound = self.by_expr.get(e.arg)
+                if isinstance(bound, ListSize):
+                    return self._list_depth(bound)
+            case Size():
+                d = self._const_int(e.second)
+                if d is None:
+                    return None
+                bound = self.by_expr.get(e.first)
+                for _ in range(d):
+                    if not isinstance(bound, ListSize):
+                        return None
+                    bound = bound.elt
+                if isinstance(bound, ListSize) and isinstance(bound.size, int):
+                    return bound.size
         return None
+
+    @staticmethod
+    def _list_depth(bound: ArraySizeBound) -> int:
+        """Number of nested list dimensions in *bound* (== ``dim``)."""
+        depth = 0
+        while isinstance(bound, ListSize):
+            depth += 1
+            bound = bound.elt
+        return depth
 
     def _is_exact(self, e: Expr) -> bool:
         """True iff *e* is evaluated under the exact (``REAL``) rounding

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -47,28 +47,31 @@ __all__ = [
 
 ArraySize: TypeAlias = 'int | NamedId | None'
 """
-Static size of a list-valued expression:
+Static size of a list-valued expression — a flat lattice:
 
-- a concrete ``int`` when the size is a compile-time constant;
-- a :class:`NamedId` *size variable* when the length is unknown but
-  tracked, so equalities like ``len(ys) == len(xs)`` survive.  Two size
-  variables in the same :class:`SizeUnionfind` class denote the same
-  runtime length; a class whose representative is an ``int`` is pinned to
-  that constant.
-- ``None`` — top; no information.
+- a concrete ``int`` — a known, compile-time-constant length;
+- a :class:`NamedId` *size variable* — an unknown-but-definite length,
+  tracked so equalities (``len(ys) == len(xs)``, strict ``zip``) survive:
+  in the resolved result, two equal variables denote equal lengths;
+- ``None`` — top: no tracked information.  Arises from a join of
+  disagreeing sizes *or* from an unknown we don't bother tracking; either
+  way it is never equal to anything, even another ``None``.
 
-``None`` is top; equal sizes (same ``int``, or co-representative size
-variables) join to themselves; everything else joins to ``None``.  It is
-*not* a set of possible sizes.  Size variables are minted per analysis
-run and are **not** meaningful across functions.
+Any two distinct atoms (``int``s / variable classes) join to ``None``.
+During analysis the variables live in a union-find; :class:`ArraySizeInfer`
+returns a result **resolved** to representatives (see :meth:`_resolve`), so
+afterwards a size is known iff it is an ``int`` and provable equality is
+just ``==`` (via :func:`is_size_eq`).  Variables are minted per run and are
+not meaningful across functions.
 """
 
 SizeUnionfind: TypeAlias = 'Unionfind[NamedId | int]'
-"""Equivalence classes of size variables (and the concrete ``int``s they
-pin to) for one analysis run.  By convention a concrete ``int`` is always
-the representative of its class, so :func:`concrete_size` is just a
-``find`` that lands on an ``int``.  Use :func:`concrete_size` /
-:func:`is_size_eq` rather than poking the union-find directly."""
+"""Internal: equivalence classes of size variables (and the concrete
+``int``s they are pinned to), used *during* analysis.  A concrete ``int``
+is always the class representative, so resolving a variable is a ``find``
+that lands on an ``int`` when known.  It is resolved away before the
+result is returned (see :meth:`_ArraySizeInferInstance._resolve`), so
+consumers never see it."""
 
 
 def _repr_size(size: ArraySize, uf: SizeUnionfind) -> int | NamedId | None:
@@ -177,9 +180,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self.ret_size = None
         self.uf = Unionfind()
         self.gensym = Gensym()
-        # Bumped whenever a union actually collapses two classes — lets the
-        # loop fixpoint detect union-find progress even when no stored bound
-        # changes (e.g. a ``zip`` inside the body merges two size vars).
+        # Counts unions; lets the loop fixpoint detect progress when a
+        # merge changes equivalences without changing any stored bound.
         self._uf_changes = 0
         self._callee_ret = {}
         self._ctx_use_cache = None
@@ -218,9 +220,7 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
     @property
     def _ctx_use(self) -> ContextUseAnalysis:
-        # Computed lazily — only slices with symbolic-offset bounds need
-        # the active rounding context, so functions without them never
-        # pay for it.  Reuse our partial-eval info so it isn't recomputed.
+        # Lazy: only symbolic-offset slices need it.  Reuses partial_eval.
         if self._ctx_use_cache is None:
             self._ctx_use_cache = ContextUse.analyze(
                 self.func, partial_eval=self.partial_eval
@@ -229,10 +229,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
     def analyze(self) -> ArraySizeAnalysis:
         self._visit_function(self.func, None)
-        # Resolve every size to its union-find representative so the
-        # result is self-contained: afterwards a size is known iff it's an
-        # ``int`` and equal sizes are ``==`` — no union-find needed by
-        # consumers (cf. type inference's ``_resolve_type``).
+        # Resolve every size to its representative so the result is
+        # self-contained (cf. type inference's ``_resolve_type``).
         by_expr = {e: self._resolve(b) for e, b in self.by_expr.items()}
         by_def = {d: self._resolve(b) for d, b in self.by_def.items()}
         ret_size = self._resolve(self.ret_size)
@@ -320,10 +318,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
         ty = self._visit_expr(e.arg, ctx)
         match e:
             case Range1():
-                # ``range(stop)`` -> ``max(0, stop)`` when ``stop`` is a
-                # known integer (clamped: ``stop <= 0`` is empty, like
-                # Python).  ``_const_int`` also resolves ``len(xs)`` of a
-                # known-size list, so ``range(len(xs))`` is covered.
+                # ``range(stop)`` -> ``max(0, stop)`` for a known ``stop``
+                # (``_const_int`` also resolves ``len(xs)``).
                 n = self._const_int(e.arg)
                 if n is not None:
                     return ListSize(None, max(0, n))
@@ -339,10 +335,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self._visit_expr(e.second, ctx)
         match e:
             case Range2():
-                # ``range(start, stop)`` -> ``max(0, stop - start)``.  The
-                # difference is constant when both bounds are concrete or
-                # share a symbolic base that cancels (e.g.
-                # ``range(i, i + 16)`` under REAL -> 16).
+                # ``range(start, stop)`` -> ``max(0, stop - start)`` when
+                # the difference is constant (see ``_affine_diff``).
                 diff = self._affine_diff(
                     self._affine(e.first), self._affine(e.second)
                 )
@@ -358,11 +352,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self._visit_expr(e.third, ctx)
         match e:
             case Range3():
-                # The count depends only on the span ``stop - start`` and
-                # the step: ``len(range(a, b, s)) == len(range(0, b-a, s))``.
-                # So a constant span (concrete bounds, or a cancelling
-                # symbolic base) plus a concrete non-zero step is enough —
-                # e.g. ``range(i, i + 16, 2)`` under REAL -> 8.
+                # ``len(range(a, b, s)) == len(range(0, b - a, s))``, so a
+                # constant span plus a concrete non-zero step suffices.
                 span = self._affine_diff(
                     self._affine(e.first), self._affine(e.second)
                 )
@@ -380,16 +371,10 @@ class _ArraySizeInferInstance(DefaultVisitor):
                 if len(e.args) == 0:
                     return ListSize(None, 0)
 
-                # FPy's ``zip`` is *strict*: it raises unless every input
-                # has the same length (no truncation to the shortest), so
-                # the result length *equals* every input length.  We use
-                # that runtime-enforced equality:
-                #   * any input concrete -> all inputs equal it (or the zip
-                #     raises); result is that int.  Conflicting concretes
-                #     => always-raising => unknown.
-                #   * else all symbolic -> merge their classes (sound: the
-                #     zip enforces equality) and keep the representative.
-                #   * any input truly unknown (``None``) -> unknown.
+                # ``zip`` is *strict*: it raises unless every input has the
+                # same length, so the result length equals them all.  A
+                # concrete input fixes the size (and pins the rest); else
+                # the unknowns are merged; any ``None`` input -> unknown.
                 elt_tys: list[ArraySizeBound] = []
                 sizes: list[ArraySize] = []
                 for ty in tys:
@@ -419,37 +404,23 @@ class _ArraySizeInferInstance(DefaultVisitor):
                 return ListSize(TupleSize(tuple(elt_tys)), size)
 
             case Empty():
-                # iterate from the inner dimension outwards to compute size
+                # Nest dimension sizes from the inside out; each dim is its
+                # concrete ``int`` if known, else ``None``.
                 arg_rev = list(reversed(e.args))
-
-                # extract the type of the innermost dimension
                 elt_ty = self._cvt_type(self.type_info.by_expr[e])
                 for _ in arg_rev:
                     assert isinstance(elt_ty, ListSize)
                     elt_ty = elt_ty.elt
 
-                # innermost dimension
-                size_v = self._get_eval(arg_rev[0])
-                size = (
-                    int(INTEGER.round(size_v))
-                    if isinstance(size_v, Float | Fraction)
-                    else None
-                )
-
-                # type of the innermost dimension
-                ty = ListSize(elt_ty, size)
-
-                # outer dimensions
-                for arg in arg_rev[1:]:
+                ty: ArraySizeBound = elt_ty
+                for arg in arg_rev:
                     size_v = self._get_eval(arg)
                     size = (
                         int(INTEGER.round(size_v))
                         if isinstance(size_v, Float | Fraction)
                         else None
                     )
-
                     ty = ListSize(ty, size)
-
                 return ty
 
             case _:
@@ -458,43 +429,32 @@ class _ArraySizeInferInstance(DefaultVisitor):
     def _visit_list_expr(self, e: ListExpr, ctx: None):
         elt_sizes = [self._visit_expr(elt, ctx) for elt in e.elts]
         if elt_sizes:
-            # Unify across all elements so heterogeneous inner sizes
-            # widen correctly (e.g., ``[[1.0], [1.0, 2.0]]`` collapses
-            # the inner size to ``None`` rather than retaining the
-            # first element's size).
+            # Unify so conflicting inner sizes widen (``[[1.0], [1.0, 2.0]]``
+            # collapses the inner size to ``None``).
             elt_size = reduce(self._unify, elt_sizes)
         else:
-            # Empty list literal: derive the structural top of the
-            # element type from the type checker's verdict.  This
-            # avoids an IndexError on ``[]`` annotated as
-            # ``list[list[...]]`` and gives the right shape for any
-            # nested type (lists, tuples).
+            # Empty literal: shape the element bound from its declared type
+            # (avoids indexing ``elt_sizes[0]`` and handles nested ``[]``).
             list_ty = self.type_info.by_expr[e]
             assert isinstance(list_ty, ListType)
             elt_size = self._cvt_type(list_ty.elt)
         return ListSize(elt_size, len(e.elts))
 
     def _visit_list_comp(self, e: ListComp, ctx: None):
-        # process iterables and bindings
         iter_tys: list[ListSize] = []
         for target, iterable in zip(e.targets, e.iterables, strict=True):
             ty = self._visit_expr(iterable, ctx)
             assert isinstance(ty, ListSize)
             self._visit_binding(e, target, ty.elt)
             iter_tys.append(ty)
-
-        # process element expression
         elt_ty = self._visit_expr(e.elt, ctx)
 
-        # A single-iterable comprehension has exactly the iterable's
-        # length — propagate its size verbatim, so a *symbolic* size flows
-        # through (``[f(x) for x in xs]`` stays length-linked to ``xs``).
+        # One iterable: same length (propagates a symbolic size, so
+        # ``[f(x) for x in xs]`` stays length-linked to ``xs``).
         if len(iter_tys) == 1:
             return ListSize(elt_ty, iter_tys[0].size)
 
-        # Multiple iterables form a cartesian product; the size is the
-        # product of the lengths, known only when every one is a concrete
-        # ``int`` (symbolic sizes don't multiply).
+        # Several iterables: cartesian product, known only if all concrete.
         size = 1
         for ty in iter_tys:
             if not isinstance(ty.size, int):
@@ -522,15 +482,10 @@ class _ArraySizeInferInstance(DefaultVisitor):
         if e.start is None and e.stop is None:
             return ListSize(ty.elt, ty.size)
 
-        # The slice size is ``stop - start``, which we can pin whenever
-        # that difference is a compile-time constant.  Decomposing each
-        # bound into ``base + offset`` (see ``_affine``) covers two cases
-        # with one rule:
-        #   * both bounds concrete (base ``None``): ``x[1:3]`` -> 2;
-        #   * both bounds share a symbolic base that cancels:
-        #     ``x[i : i + 16]`` -> 16.
-        # Omitted bounds: ``start`` defaults to 0; ``stop`` defaults to
-        # the list's own size — usable as an offset only if it's concrete.
+        # Size is ``stop - start`` when that difference is a compile-time
+        # constant (``x[1:3]`` -> 2, or ``x[i:i+16]`` where the base
+        # cancels; see ``_affine``).  An omitted ``stop`` is the list's own
+        # size, usable only when concrete.
         start = (None, 0) if e.start is None else self._affine(e.start)
         if e.stop is None:
             stop = (None, ty.size) if isinstance(ty.size, int) else None
@@ -540,10 +495,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
         slice_size: int | None = None
         if stop is not None:
             diff = self._affine_diff(start, stop)
-            # FPy slicing is *strict*: ``xs[a:b]`` is valid only when
-            # ``0 <= a <= b <= len(xs)`` — out-of-range / inverted bounds
-            # raise rather than clamp.  So a negative difference is an
-            # always-raising slice: report unknown, never a bogus size.
+            # Slicing is strict: an inverted/out-of-range slice raises, so a
+            # negative difference stays unknown rather than a bogus size.
             if diff is not None and diff >= 0:
                 slice_size = diff
 
@@ -633,14 +586,11 @@ class _ArraySizeInferInstance(DefaultVisitor):
     def _visit_call(self, e: Call, ctx: None):
         for arg in e.args:
             self._visit_expr(arg, ctx)
-        # Start from the call's type shapeeton (correct shape, all-``None``
-        # sizes), then overlay any statically-known sizes the callee's own
-        # return-size analysis proved.  A concrete size in a callee's
-        # ``ret_size`` is independent of the call's arguments (arg-derived
-        # sizes resolve to ``None``), so it's a constant property of the
-        # callee and sound to propagate to every call site.
-        shapeeton = self._cvt_type(self.type_info.by_expr[e])
-        return self._refine_sizes(shapeeton, self._callee_ret_size(e))
+        # Take the call's type shape, then overlay any concrete size the
+        # callee's own return-size analysis proved — a concrete callee
+        # ``ret_size`` is arg-independent, so it holds at every call site.
+        shape = self._cvt_type(self.type_info.by_expr[e])
+        return self._refine_sizes(shape, self._callee_ret_size(e))
 
     def _callee_ret_size(self, e: Call) -> ArraySizeBound:
         """The callee's inferred return-size bound, or ``None`` when the
@@ -665,9 +615,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
         element shape.  Where shapes agree, prefer *src*'s concrete size;
         on any mismatch, keep *shape* unchanged.
 
-        Only *concrete* ``int`` sizes are adopted: a :class:`SymbolicSize`
-        in *src* belongs to the callee's own analysis run and is
-        meaningless in ours, so it must not leak across the call.
+        Only *concrete* ``int`` sizes are adopted: a *src* size variable
+        belongs to the callee's own run and must not leak across the call.
         """
         match shape, src:
             case ListSize(), ListSize():
@@ -688,12 +637,9 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self._visit_binding(stmt, stmt.target, ty)
 
     def _visit_indexed_assign(self, stmt: IndexedAssign, ctx: None):
-        # ``xs[i1]…[iN] = expr`` is treated as a functional update:
-        # ``xs = update(xs, [i1, …, iN], expr)``.  The use of ``xs`` reads
-        # the pre-mutation bound; the fresh def at this site (introduced
-        # by ``reaching_defs``) receives the widened bound — the inserted
-        # value's bound joined into the element bound at depth
-        # ``len(indices)``.
+        # ``xs[i1]…[iN] = expr`` is a functional update: read the
+        # pre-mutation bound off the use, then write the fresh def with the
+        # inserted value joined into the element bound at depth N.
         d_use = self.def_use.find_def_from_use(stmt)
         target_ty = self.by_def[d_use]
 
@@ -735,19 +681,12 @@ class _ArraySizeInferInstance(DefaultVisitor):
 
     def _iterate_to_fixpoint(self, phis, run_body):
         """
-        Drive a loop's phi-bound fixpoint to convergence.
-
-        Initialises each phi from its pre-loop (lhs) definition, then
-        repeatedly runs *run_body* and unifies the post-body (rhs) into
-        each phi until no phi changes *and* the union-find is stable.  The
-        height is finite (sizes are ``int``/symbol/``None``; the structural
-        lattice is shape-preserving; UF merges are monotone), so this
-        terminates.
-
-        The UF-stability check matters because a merge inside the body
-        (e.g. a ``zip``) can change which sizes are *equivalent* without
-        changing any stored phi value; without it the loop could stop one
-        iteration before that equivalence propagates.
+        Drive a loop's phi-bound fixpoint to convergence: seed each phi
+        from its pre-loop value, then run the body and unify the post-body
+        value into each phi until both the phis and the union-find are
+        stable.  The UF check is needed because a body merge (e.g. a
+        ``zip``) can change equivalences without moving any stored phi.
+        Terminates: finite-height lattice and monotone UF merges.
         """
         for phi in phis:
             self.by_def[phi] = self.by_def[self.def_use.defs[phi.lhs]]
@@ -771,7 +710,7 @@ class _ArraySizeInferInstance(DefaultVisitor):
         self._iterate_to_fixpoint(self.def_use.phis[stmt], body)
 
     def _visit_for(self, stmt, ctx):
-        # process iterable and binding (once, before the fixpoint)
+        # iterable + target bound once, before the fixpoint
         iter_ty = self._visit_expr(stmt.iterable, ctx)
         assert isinstance(iter_ty, ListSize)
         self._visit_binding(stmt, stmt.target, iter_ty.elt)
@@ -791,10 +730,7 @@ class _ArraySizeInferInstance(DefaultVisitor):
         ret_size = self._visit_expr(stmt.expr, ctx)
         if not isinstance(ret_size, ListSize):
             return
-        # Multiple returns: unify the list-size bound across paths.
-        # First-seen seeds; subsequent unify against the running
-        # value (taking the meet on the size — concrete iff all paths
-        # agree, else ``None``).
+        # Across multiple returns, unify: concrete iff all paths agree.
         if self.ret_size is None:
             self.ret_size = ret_size
         else:
@@ -806,19 +742,16 @@ class _ArraySizeInferInstance(DefaultVisitor):
         return ty
 
     def _visit_function(self, func: FuncDef, ctx: None):
-        # process arguments — list parameters get a fresh size variable
+        # arguments and free variables: list params get a fresh size var
         for arg, ty in zip(func.args, self.type_info.arg_types):
             if isinstance(arg.name, NamedId):
                 d = self.def_use.find_def_from_site(arg.name, arg)
                 self.by_def[d] = self._arg_bound(ty)
-
-        # process free variables — same treatment as arguments
         for fv in func.free_vars:
             d = self.def_use.find_def_from_site(fv, func)
             ty = self.type_info.by_def[d]
             self.by_def[d] = self._arg_bound(ty)
 
-        # visit body
         self._visit_block(func.body, ctx)
 
 

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -244,16 +244,27 @@ class _ArraySizeInferInstance(DefaultVisitor):
             case Zip():
                 if len(e.args) == 0:
                     return ListSize(None, 0)
-                else:
-                    assert isinstance(tys[0], ListSize)
-                    elt_tys: list[ArraySizeBound] = [tys[0].elt]
-                    size = tys[0].size
-                    for ty in tys[1:]:
-                        assert isinstance(ty, ListSize)
-                        elt_tys.append(ty.elt)
-                        size = _join_size(size, ty.size)
 
-                    return ListSize(TupleSize(tuple(elt_tys)), size)
+                # FPy's ``zip`` is *strict*: it raises unless every input
+                # has the same length (no truncation to the shortest), so
+                # the result length is that common length — known only
+                # when all inputs are known and agree.  Conflicting known
+                # sizes always raise (result unreachable) => unknown.
+                elt_tys: list[ArraySizeBound] = []
+                sizes: list[ArraySize] = []
+                for ty in tys:
+                    assert isinstance(ty, ListSize)
+                    elt_tys.append(ty.elt)
+                    sizes.append(ty.size)
+
+                if any(s is None for s in sizes):
+                    size: ArraySize = None
+                elif len(set(sizes)) == 1:
+                    size = sizes[0]
+                else:
+                    size = None
+
+                return ListSize(TupleSize(tuple(elt_tys)), size)
 
             case Empty():
                 # iterate from the inner dimension outwards to compute size

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -26,7 +26,7 @@ from ..function import Function
 from ..number import Float, INTEGER, REAL
 from ..types import ListType, TupleType, Type
 from ..utils import Gensym, NamedId, Unionfind
-from .context_use import ContextUse, ContextUseAnalysis
+from .context_use import ContextUse, ContextUseAnalysis, ContextUseSite
 from .define_use import Definition, DefSite, DefineUseAnalysis
 from .partial_eval import PartialEval, PartialEvalInfo, Value
 from .type_infer import TypeInfer, TypeAnalysis
@@ -96,21 +96,6 @@ def _size_eq(a: ArraySize, b: ArraySize) -> bool:
     return a is not None and a == b
 
 
-def is_size_eq(b1: ArraySizeBound, b2: ArraySizeBound) -> bool:
-    """Structurally compare two (resolved) bounds, treating equal sizes
-    at each level as equal."""
-    match b1, b2:
-        case ListSize(), ListSize():
-            return _size_eq(b1.size, b2.size) and is_size_eq(b1.elt, b2.elt)
-        case TupleSize(), TupleSize():
-            return (len(b1.elts) == len(b2.elts)
-                    and all(is_size_eq(a, b) for a, b in zip(b1.elts, b2.elts)))
-        case None, None:
-            return True
-        case _:
-            return False
-
-
 @dataclass(frozen=True)
 class ListSize:
     """Array-size info for a list-valued expression."""
@@ -133,6 +118,20 @@ Inferred array-size info for an expression or variable definition.
   an :class:`ArraySize`.
 - :class:`TupleSize` — heterogeneous tuple, per-element bounds preserved.
 """
+
+def is_size_eq(b1: ArraySizeBound, b2: ArraySizeBound) -> bool:
+    """Structurally compare two (resolved) bounds, treating equal sizes
+    at each level as equal."""
+    match b1, b2:
+        case ListSize(), ListSize():
+            return _size_eq(b1.size, b2.size) and is_size_eq(b1.elt, b2.elt)
+        case TupleSize(), TupleSize():
+            return (len(b1.elts) == len(b2.elts)
+                    and all(is_size_eq(a, b) for a, b in zip(b1.elts, b2.elts)))
+        case None, None:
+            return True
+        case _:
+            return False
 
 
 #####################################################################
@@ -426,7 +425,7 @@ class _ArraySizeInferInstance(DefaultVisitor):
                     assert isinstance(elt_ty, ListSize)
                     elt_ty = elt_ty.elt
 
-                ty: ArraySizeBound = elt_ty
+                acc: ArraySizeBound = elt_ty
                 for arg in arg_rev:
                     size_v = self._get_eval(arg)
                     size = (
@@ -434,8 +433,8 @@ class _ArraySizeInferInstance(DefaultVisitor):
                         if isinstance(size_v, Float | Fraction)
                         else None
                     )
-                    ty = ListSize(ty, size)
-                return ty
+                    acc = ListSize(acc, size)
+                return acc
 
             case _:
                 return None
@@ -500,7 +499,9 @@ class _ArraySizeInferInstance(DefaultVisitor):
         # constant (``x[1:3]`` -> 2, or ``x[i:i+16]`` where the base
         # cancels; see ``_affine``).  An omitted ``stop`` is the list's own
         # size, usable only when concrete.
+        start: tuple[Expr | None, int]
         start = (None, 0) if e.start is None else self._affine(e.start)
+        stop: tuple[Expr | None, int] | None
         if e.stop is None:
             stop = (None, ty.size) if isinstance(ty.size, int) else None
         else:
@@ -608,9 +609,11 @@ class _ArraySizeInferInstance(DefaultVisitor):
             bound = bound.elt
         return depth
 
-    def _is_exact(self, e: Expr) -> bool:
+    def _is_exact(self, e: ContextUseSite) -> bool:
         """True iff *e* is evaluated under the exact (``REAL``) rounding
-        context, so its arithmetic introduces no rounding."""
+        context, so its arithmetic introduces no rounding.  Only called on
+        arithmetic nodes (always context-use sites), so the lookup is safe
+        even though ``e`` is typed wider than the map's key."""
         scope = self._ctx_use.use_to_scope.get(e)
         return scope is not None and scope.ctx == REAL
 

--- a/fpy2/analysis/context_use.py
+++ b/fpy2/analysis/context_use.py
@@ -214,7 +214,12 @@ class ContextUse:
     """
 
     @staticmethod
-    def analyze(func: FuncDef, *, def_use: DefineUseAnalysis | None = None) -> ContextUseAnalysis:
+    def analyze(
+        func: FuncDef,
+        *,
+        def_use: DefineUseAnalysis | None = None,
+        partial_eval: PartialEvalInfo | None = None,
+    ) -> ContextUseAnalysis:
         """
         Runs context-use analysis on a function.
 
@@ -224,11 +229,17 @@ class ContextUse:
             The function to analyze.
         def_use:
             Optional pre-computed definition-use analysis.  If ``None``,
-            it is computed automatically.
+            it is computed automatically.  Ignored when *partial_eval*
+            is supplied (the partial-eval info already carries its own).
+        partial_eval:
+            Optional pre-computed partial-evaluation info.  If ``None``,
+            it is computed from *def_use*.  Supply it to avoid recomputing
+            partial evaluation when the caller already has it.
         """
         if not isinstance(func, FuncDef):
             raise TypeError(f'Expected `FuncDef`, got {type(func)} for {func}')
-        if def_use is None:
-            def_use = DefineUse.analyze(func)
-        eval_info = PartialEval.apply(func, def_use=def_use)
-        return _ContextUseInstance(func, eval_info).analyze()
+        if partial_eval is None:
+            if def_use is None:
+                def_use = DefineUse.analyze(func)
+            partial_eval = PartialEval.apply(func, def_use=def_use)
+        return _ContextUseInstance(func, partial_eval).analyze()

--- a/fpy2/utils/unionfind.py
+++ b/fpy2/utils/unionfind.py
@@ -64,7 +64,7 @@ class Unionfind(Generic[_T]):
             raise KeyError(x)
         return self._find(x)
 
-    def get(self, x: _T, default=None):
+    def get(self, x: _T, default: _T | None = None):
         """
         Finds the representative of the set containing `x`,
         or `default` if a representative is not found.

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -618,6 +618,94 @@ class TestArraySizeInfer:
         assert self._slice_bound(f).size is None
 
     # ------------------------------------------------------------------
+    # range() with symbolic-offset bounds (shares the slice affine logic)
+
+    def _range_bound(self, f, tyname):
+        info = self._run(f)
+        bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == tyname
+        ]
+        assert len(bounds) == 1
+        assert isinstance(bounds[0], ListSize)
+        return bounds[0]
+
+    def test_range2_symbolic_offset_under_real(self):
+        """``range(i, i + 16)`` -> 16: the symbolic base cancels, and the
+        ``+`` runs under the exact ``REAL`` context."""
+
+        @fp.fpy
+        def f(i: fp.Real) -> list[fp.Real]:
+            with fp.REAL:
+                ys = [0.0 for _ in range(i, i + 16)]
+            return ys
+
+        assert self._range_bound(f, 'Range2').size == 16
+
+    def test_range2_symbolic_offset_not_under_real_is_unknown(self):
+        """Without an exact context, ``i + 16`` may round, so the span
+        isn't provably constant -> unknown."""
+
+        @fp.fpy
+        def f(i: fp.Real) -> list[fp.Real]:
+            return [0.0 for _ in range(i, i + 16)]
+
+        assert self._range_bound(f, 'Range2').size is None
+
+    def test_range2_symbolic_offset_inverted_is_empty(self):
+        """``range(i + 16, i)`` is empty (start > stop) for any ``i`` —
+        range clamps to 0 (unlike slicing, which raises)."""
+
+        @fp.fpy
+        def f(i: fp.Real) -> list[fp.Real]:
+            with fp.REAL:
+                ys = [0.0 for _ in range(i + 16, i)]
+            return ys
+
+        assert self._range_bound(f, 'Range2').size == 0
+
+    def test_range3_symbolic_offset_with_step(self):
+        """``range(i, i + 16, 2)`` -> 8: span 16 stepped by 2."""
+
+        @fp.fpy
+        def f(i: fp.Real) -> list[fp.Real]:
+            with fp.REAL:
+                ys = [0.0 for _ in range(i, i + 16, 2)]
+            return ys
+
+        assert self._range_bound(f, 'Range3').size == 8
+
+    def test_range1_len_of_known_list(self):
+        """``range(len(xs))`` -> size of ``xs`` when statically known."""
+
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            xs = [1.0, 2.0, 3.0, 4.0]
+            return [0.0 for _ in range(len(xs))]
+
+        # the inner range has the size; the comprehension echoes it
+        assert self._range_bound(f, 'Range1').size == 4
+
+    def test_slice_len_of_known_list(self):
+        """``xs[0:len(xs)]`` -> full size via ``len`` of a known list."""
+
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            xs = [1.0, 2.0, 3.0, 4.0, 5.0]
+            return xs[0:len(xs)]
+
+        assert self._slice_bound(f).size == 5
+
+    def test_range1_len_of_unknown_list_is_unknown(self):
+        """``range(len(xs))`` for an unknown-size ``xs`` stays unknown."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            return [0.0 for _ in range(len(xs))]
+
+        assert self._range_bound(f, 'Range1').size is None
+
+    # ------------------------------------------------------------------
     # IndexedAssign as a fresh SSA def
 
     def test_indexed_assign_creates_fresh_def(self):

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -12,9 +12,8 @@ from fpy2.analysis import (
     ArraySizeInfer,
     ListSize,
     TupleSize,
-    concrete_size,
-    is_size_eq,
 )
+from fpy2.analysis.array_size import concrete_size, is_size_eq
 from fpy2.utils import NamedId
 
 
@@ -64,7 +63,6 @@ class TestArraySizeInfer:
     def test_list_argument_has_listsize(self):
         """A list-of-real argument has a ListSize whose size is a fresh
         size variable (its length is fixed per call, just unknown)."""
-        from fpy2.utils import NamedId
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:
@@ -387,7 +385,6 @@ class TestArraySizeInfer:
         """``zip`` is strict, so an unknown-size input zipped with a
         known-size one must equal it (or the zip raises): the result size
         is the known length, and the symbolic input is pinned to it."""
-        from fpy2.analysis.array_size import concrete_size
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> list[tuple[fp.Real, fp.Real]]:
@@ -1111,7 +1108,6 @@ class TestArraySizeInfer:
 
     def test_rebind_preserves_symbol(self):
         """``ys = xs`` gives ``ys`` the same symbolic length as ``xs``."""
-        from fpy2.analysis.array_size import is_size_eq
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> list[fp.Real]:
@@ -1125,7 +1121,6 @@ class TestArraySizeInfer:
     def test_comprehension_over_argument_is_equivalent(self):
         """``[f(x) for x in xs]`` has the same length as ``xs``."""
         from fpy2.utils import NamedId
-        from fpy2.analysis.array_size import is_size_eq
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> list[fp.Real]:
@@ -1140,7 +1135,6 @@ class TestArraySizeInfer:
 
     def test_enumerate_over_argument_is_equivalent(self):
         """``enumerate(xs)`` preserves ``xs``'s symbolic length."""
-        from fpy2.analysis.array_size import is_size_eq
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> list[fp.Real]:
@@ -1152,7 +1146,6 @@ class TestArraySizeInfer:
 
     def test_full_slice_preserves_symbol(self):
         """``xs[:]`` spans the whole list, keeping its symbolic length."""
-        from fpy2.analysis.array_size import is_size_eq
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> list[fp.Real]:
@@ -1180,7 +1173,6 @@ class TestArraySizeInfer:
     def test_distinct_arguments_are_not_equivalent(self):
         """Two independent list arguments get distinct, non-equivalent
         symbols (no false equality)."""
-        from fpy2.analysis.array_size import is_size_eq
 
         @fp.fpy
         def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
@@ -1193,7 +1185,6 @@ class TestArraySizeInfer:
     def test_loop_rebind_keeps_symbol(self):
         """A loop that re-binds a list via a size-preserving op keeps the
         symbolic length across the fixpoint."""
-        from fpy2.analysis.array_size import is_size_eq
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> list[fp.Real]:
@@ -1207,7 +1198,6 @@ class TestArraySizeInfer:
 
     def test_concrete_size_helper(self):
         """``concrete_size`` resolves ints directly and pinned symbols."""
-        from fpy2.analysis.array_size import concrete_size
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -57,7 +57,9 @@ class TestArraySizeInfer:
         assert x_bounds == [None]
 
     def test_list_argument_has_listsize(self):
-        """A list-of-real argument has a ListSize with empty size set."""
+        """A list-of-real argument has a ListSize whose size is a fresh
+        size variable (its length is fixed per call, just unknown)."""
+        from fpy2.utils import NamedId
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:
@@ -69,7 +71,7 @@ class TestArraySizeInfer:
         bound = xs_bounds[0]
         assert isinstance(bound, ListSize)
         assert bound.elt is None
-        assert bound.size is None
+        assert isinstance(bound.size, NamedId)
 
     def test_tuple_argument_has_tuplesize(self):
         """A tuple argument is a TupleSize with one entry per element."""
@@ -376,9 +378,11 @@ class TestArraySizeInfer:
         # NOT 2 (the min) — strict zip raises on mismatch.
         assert bound.size is None
 
-    def test_zip_with_unknown_size_is_unknown(self):
-        """If any input length is statically unknown, the zip size is
-        unknown (flat lattice doesn't yet track equal-but-unknown)."""
+    def test_zip_unknown_with_known_pins_to_known(self):
+        """``zip`` is strict, so an unknown-size input zipped with a
+        known-size one must equal it (or the zip raises): the result size
+        is the known length, and the symbolic input is pinned to it."""
+        from fpy2.analysis.array_size import concrete_size
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> list[tuple[fp.Real, fp.Real]]:
@@ -392,7 +396,10 @@ class TestArraySizeInfer:
         assert len(zip_bounds) == 1
         bound = zip_bounds[0]
         assert isinstance(bound, ListSize)
-        assert bound.size is None
+        assert bound.size == 3
+        # the strict zip also pins `xs` to length 3
+        xs_bound = [b for d, b in info.by_def.items() if d.name.base == 'xs'][0]
+        assert concrete_size(xs_bound.size, info.size_uf) == 3
 
     def test_zip_single_arg_preserves_size(self):
         """A 1-argument ``zip`` preserves the input's known size."""
@@ -1087,3 +1094,126 @@ class TestArraySizeInfer:
 
         info = self._run(f)
         assert info.ret_size is None
+
+    # ------------------------------------------------------------------
+    # Symbolic sizes (union-find): equal-but-unknown lengths
+
+    @staticmethod
+    def _def_size(info, name):
+        bounds = [b for d, b in info.by_def.items() if d.name.base == name]
+        assert bounds, f'no def found for {name}'
+        return bounds[0]
+
+    def test_rebind_preserves_symbol(self):
+        """``ys = xs`` gives ``ys`` the same symbolic length as ``xs``."""
+        from fpy2.analysis.array_size import is_size_eq
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            ys = xs
+            return ys
+
+        info = self._run(f)
+        xs_b, ys_b = self._def_size(info, 'xs'), self._def_size(info, 'ys')
+        assert is_size_eq(xs_b, ys_b, info.size_uf)
+
+    def test_comprehension_over_argument_is_equivalent(self):
+        """``[f(x) for x in xs]`` has the same length as ``xs``."""
+        from fpy2.utils import NamedId
+        from fpy2.analysis.array_size import is_size_eq
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                ys = [x for x in xs]
+            return ys
+
+        info = self._run(f)
+        assert isinstance(info.ret_size, ListSize)
+        assert isinstance(info.ret_size.size, NamedId)
+        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'), info.size_uf)
+
+    def test_enumerate_over_argument_is_equivalent(self):
+        """``enumerate(xs)`` preserves ``xs``'s symbolic length."""
+        from fpy2.analysis.array_size import is_size_eq
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            ys = [x for _, x in enumerate(xs)]
+            return ys
+
+        info = self._run(f)
+        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'), info.size_uf)
+
+    def test_full_slice_preserves_symbol(self):
+        """``xs[:]`` spans the whole list, keeping its symbolic length."""
+        from fpy2.analysis.array_size import is_size_eq
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[:]
+
+        info = self._run(f)
+        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'), info.size_uf)
+
+    def test_zip_two_unknowns_merges_classes(self):
+        """``zip(xs, ys)`` is strict, so on the non-raising path
+        ``len(xs) == len(ys)``: their symbolic classes are merged."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            acc = 0.0
+            for a, b in zip(xs, ys):
+                with fp.FP64:
+                    acc = acc + a
+            return acc
+
+        info = self._run(f)
+        xs_b, ys_b = self._def_size(info, 'xs'), self._def_size(info, 'ys')
+        assert info.size_uf.find(xs_b.size) == info.size_uf.find(ys_b.size)
+
+    def test_distinct_arguments_are_not_equivalent(self):
+        """Two independent list arguments get distinct, non-equivalent
+        symbols (no false equality)."""
+        from fpy2.analysis.array_size import is_size_eq
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            return xs[0]
+
+        info = self._run(f)
+        xs_b, ys_b = self._def_size(info, 'xs'), self._def_size(info, 'ys')
+        assert not is_size_eq(xs_b, ys_b, info.size_uf)
+
+    def test_loop_rebind_keeps_symbol(self):
+        """A loop that re-binds a list via a size-preserving op keeps the
+        symbolic length across the fixpoint."""
+        from fpy2.analysis.array_size import is_size_eq
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            ys = xs
+            for _ in range(3):
+                ys = ys
+            return ys
+
+        info = self._run(f)
+        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'), info.size_uf)
+
+    def test_concrete_size_helper(self):
+        """``concrete_size`` resolves ints directly and pinned symbols."""
+        from fpy2.analysis.array_size import concrete_size
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            acc = 0.0
+            for t in zip(xs, [1.0, 2.0]):   # pins xs to 2
+                with fp.FP64:
+                    acc = acc + 1.0
+            return acc
+
+        info = self._run(f)
+        xs_b = self._def_size(info, 'xs')
+        assert concrete_size(xs_b.size, info.size_uf) == 2
+        assert concrete_size(7, info.size_uf) == 7
+        assert concrete_size(None, info.size_uf) is None

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -1213,6 +1213,87 @@ class TestArraySizeInfer:
         assert concrete_size(7) == 7
         assert concrete_size(None) is None
 
+    # ------------------------------------------------------------------
+    # Assertion-seeded size equalities
+
+    def test_assert_len_eq_merges(self):
+        """``assert len(xs) == len(ys)`` makes their sizes equivalent."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            assert len(xs) == len(ys)
+            return xs[0]
+
+        info = self._run(f)
+        assert is_size_eq(self._def_size(info, 'xs'),
+                          self._def_size(info, 'ys'))
+
+    def test_assert_len_eq_constant_pins(self):
+        """``assert len(xs) == 16`` pins ``xs`` to a concrete size."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            assert len(xs) == 16
+            return xs[0]
+
+        info = self._run(f)
+        assert concrete_size(self._def_size(info, 'xs').size) == 16
+
+    def test_assert_len_eq_transitive(self):
+        """Two asserts chain: ``xs`` and ``zs`` become equivalent."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real], zs: list[fp.Real]) -> fp.Real:
+            assert len(xs) == len(ys)
+            assert len(ys) == len(zs)
+            return xs[0]
+
+        info = self._run(f)
+        assert is_size_eq(self._def_size(info, 'xs'),
+                          self._def_size(info, 'zs'))
+
+    def test_conditional_assert_does_not_merge(self):
+        """An assert inside an ``if`` need not hold on every execution, so
+        it must NOT constrain sizes globally (soundness)."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real], c: bool) -> fp.Real:
+            if c:
+                assert len(xs) == len(ys)
+            return xs[0]
+
+        info = self._run(f)
+        assert not is_size_eq(self._def_size(info, 'xs'),
+                              self._def_size(info, 'ys'))
+
+    def test_loop_assert_does_not_merge(self):
+        """An assert inside a loop body is conditional (the loop may run
+        zero times), so it must not constrain sizes globally."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            for _ in range(0):
+                assert len(xs) == len(ys)
+            return xs[0]
+
+        info = self._run(f)
+        assert not is_size_eq(self._def_size(info, 'xs'),
+                              self._def_size(info, 'ys'))
+
+    def test_assert_under_context_still_merges(self):
+        """A ``with`` block executes unconditionally, so an assert inside
+        one still seeds the equality."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                assert len(xs) == len(ys)
+            return xs[0]
+
+        info = self._run(f)
+        assert is_size_eq(self._def_size(info, 'xs'),
+                          self._def_size(info, 'ys'))
+
 
 # ----------------------------------------------------------------------
 # Differential soundness: inferred sizes vs. actual runtime lengths.
@@ -1391,6 +1472,12 @@ def _d_call_known() -> list[fp.Real]:
     return _d_callee_known()
 
 
+@fp.fpy
+def _d_assert_eq(xs: list[fp.Real], ys: list[fp.Real]) -> list[fp.Real]:
+    assert len(xs) == len(ys)   # merges xs ~ ys; only equal-length inputs return
+    return ys
+
+
 def _floats(n):
     return [float(k) for k in range(n)]
 
@@ -1422,6 +1509,8 @@ _DIFFERENTIAL_SPECS = [
     (_d_loop_preserve, [(_floats(0),), (_floats(4),)]),
     (_d_indexed_assign, [(_floats(0),), (_floats(1),), (_floats(6),)]),
     (_d_call_known, [()]),
+    # equal-length inputs (unequal would raise the assert and be skipped)
+    (_d_assert_eq, [(_floats(0), _floats(0)), (_floats(3), _floats(3)), (_floats(8), _floats(8))]),
 ]
 
 

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -714,6 +714,45 @@ class TestArraySizeInfer:
 
         assert self._range_bound(f, 'Range1').size is None
 
+    def test_range1_dim_is_known_structurally(self):
+        """``dim(xs)`` is the nesting depth — known even when sizes aren't,
+        so ``range(dim(xs))`` is a known size."""
+
+        @fp.fpy
+        def f(xs: list[list[fp.Real]]) -> list[fp.Real]:
+            return [0.0 for _ in range(fp.dim(xs))]
+
+        assert self._range_bound(f, 'Range1').size == 2
+
+    def test_range1_size_of_known_dimension(self):
+        """``size(xs, d)`` folds to the length of dimension ``d`` when
+        statically known."""
+
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            xs = fp.empty(4, 3)
+            return [0.0 for _ in range(fp.size(xs, 1))]
+
+        assert self._range_bound(f, 'Range1').size == 3
+
+    def test_range1_size_of_unknown_dimension_is_unknown(self):
+        """``size(xs, d)`` of an unknown-size dimension stays unknown."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            return [0.0 for _ in range(fp.size(xs, 0))]
+
+        assert self._range_bound(f, 'Range1').size is None
+
+    def test_slice_dim_of_known_list(self):
+        """``dim`` folds inside a slice bound too."""
+
+        @fp.fpy
+        def f(xs: list[list[fp.Real]]) -> list[list[fp.Real]]:
+            return xs[0:fp.dim(xs)]
+
+        assert self._slice_bound(f).size == 2
+
     # ------------------------------------------------------------------
     # IndexedAssign as a fresh SSA def
 

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -335,6 +335,82 @@ class TestArraySizeInfer:
         ]
         assert comp_bounds
 
+    def test_zip_equal_known_sizes(self):
+        """``zip`` of equal-length known lists has that size, with a
+        per-input tuple element bound."""
+
+        @fp.fpy
+        def f() -> list[tuple[fp.Real, fp.Real]]:
+            return [t for t in zip([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])]
+
+        info = self._run(f)
+        zip_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'Zip'
+        ]
+        assert len(zip_bounds) == 1
+        bound = zip_bounds[0]
+        assert isinstance(bound, ListSize)
+        assert bound.size == 3
+        # element is a 2-tuple (one slot per input list)
+        assert isinstance(bound.elt, TupleSize)
+        assert len(bound.elt.elts) == 2
+
+    def test_zip_unequal_known_sizes_is_unknown(self):
+        """``zip`` is strict (raises on length mismatch), so it must NOT
+        report the *min* of conflicting known sizes — the result is
+        unreachable, hence unknown."""
+
+        @fp.fpy
+        def f() -> list[tuple[fp.Real, fp.Real]]:
+            return [t for t in zip([1.0, 2.0, 3.0], [4.0, 5.0])]
+
+        info = self._run(f)
+        zip_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'Zip'
+        ]
+        assert len(zip_bounds) == 1
+        bound = zip_bounds[0]
+        assert isinstance(bound, ListSize)
+        # NOT 2 (the min) — strict zip raises on mismatch.
+        assert bound.size is None
+
+    def test_zip_with_unknown_size_is_unknown(self):
+        """If any input length is statically unknown, the zip size is
+        unknown (flat lattice doesn't yet track equal-but-unknown)."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[tuple[fp.Real, fp.Real]]:
+            return [t for t in zip(xs, [1.0, 2.0, 3.0])]
+
+        info = self._run(f)
+        zip_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'Zip'
+        ]
+        assert len(zip_bounds) == 1
+        bound = zip_bounds[0]
+        assert isinstance(bound, ListSize)
+        assert bound.size is None
+
+    def test_zip_single_arg_preserves_size(self):
+        """A 1-argument ``zip`` preserves the input's known size."""
+
+        @fp.fpy
+        def f() -> list[tuple[fp.Real]]:
+            return [t for t in zip([1.0, 2.0, 3.0, 4.0])]
+
+        info = self._run(f)
+        zip_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'Zip'
+        ]
+        assert len(zip_bounds) == 1
+        bound = zip_bounds[0]
+        assert isinstance(bound, ListSize)
+        assert bound.size == 4
+
     def test_list_ref_returns_element_bound(self):
         """``xs[i]`` exposes the list's element bound."""
 

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -5,12 +5,17 @@ Unit tests for :class:`ArraySizeInfer`.
 import fpy2 as fp
 import pytest
 
+from hypothesis import given, settings, strategies as st
+
 from fpy2.analysis import (
     ArraySizeAnalysis,
     ArraySizeInfer,
     ListSize,
     TupleSize,
+    concrete_size,
+    is_size_eq,
 )
+from fpy2.utils import NamedId
 
 
 class TestArraySizeInfer:
@@ -399,7 +404,7 @@ class TestArraySizeInfer:
         assert bound.size == 3
         # the strict zip also pins `xs` to length 3
         xs_bound = [b for d, b in info.by_def.items() if d.name.base == 'xs'][0]
-        assert concrete_size(xs_bound.size, info.size_uf) == 3
+        assert concrete_size(xs_bound.size) == 3
 
     def test_zip_single_arg_preserves_size(self):
         """A 1-argument ``zip`` preserves the input's known size."""
@@ -1115,7 +1120,7 @@ class TestArraySizeInfer:
 
         info = self._run(f)
         xs_b, ys_b = self._def_size(info, 'xs'), self._def_size(info, 'ys')
-        assert is_size_eq(xs_b, ys_b, info.size_uf)
+        assert is_size_eq(xs_b, ys_b)
 
     def test_comprehension_over_argument_is_equivalent(self):
         """``[f(x) for x in xs]`` has the same length as ``xs``."""
@@ -1131,7 +1136,7 @@ class TestArraySizeInfer:
         info = self._run(f)
         assert isinstance(info.ret_size, ListSize)
         assert isinstance(info.ret_size.size, NamedId)
-        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'), info.size_uf)
+        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'))
 
     def test_enumerate_over_argument_is_equivalent(self):
         """``enumerate(xs)`` preserves ``xs``'s symbolic length."""
@@ -1143,7 +1148,7 @@ class TestArraySizeInfer:
             return ys
 
         info = self._run(f)
-        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'), info.size_uf)
+        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'))
 
     def test_full_slice_preserves_symbol(self):
         """``xs[:]`` spans the whole list, keeping its symbolic length."""
@@ -1154,7 +1159,7 @@ class TestArraySizeInfer:
             return xs[:]
 
         info = self._run(f)
-        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'), info.size_uf)
+        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'))
 
     def test_zip_two_unknowns_merges_classes(self):
         """``zip(xs, ys)`` is strict, so on the non-raising path
@@ -1170,7 +1175,7 @@ class TestArraySizeInfer:
 
         info = self._run(f)
         xs_b, ys_b = self._def_size(info, 'xs'), self._def_size(info, 'ys')
-        assert info.size_uf.find(xs_b.size) == info.size_uf.find(ys_b.size)
+        assert xs_b.size == ys_b.size
 
     def test_distinct_arguments_are_not_equivalent(self):
         """Two independent list arguments get distinct, non-equivalent
@@ -1183,7 +1188,7 @@ class TestArraySizeInfer:
 
         info = self._run(f)
         xs_b, ys_b = self._def_size(info, 'xs'), self._def_size(info, 'ys')
-        assert not is_size_eq(xs_b, ys_b, info.size_uf)
+        assert not is_size_eq(xs_b, ys_b)
 
     def test_loop_rebind_keeps_symbol(self):
         """A loop that re-binds a list via a size-preserving op keeps the
@@ -1198,7 +1203,7 @@ class TestArraySizeInfer:
             return ys
 
         info = self._run(f)
-        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'), info.size_uf)
+        assert is_size_eq(info.ret_size, self._def_size(info, 'xs'))
 
     def test_concrete_size_helper(self):
         """``concrete_size`` resolves ints directly and pinned symbols."""
@@ -1214,6 +1219,337 @@ class TestArraySizeInfer:
 
         info = self._run(f)
         xs_b = self._def_size(info, 'xs')
-        assert concrete_size(xs_b.size, info.size_uf) == 2
-        assert concrete_size(7, info.size_uf) == 7
-        assert concrete_size(None, info.size_uf) is None
+        assert concrete_size(xs_b.size) == 2
+        assert concrete_size(7) == 7
+        assert concrete_size(None) is None
+
+
+# ----------------------------------------------------------------------
+# Differential soundness: inferred sizes vs. actual runtime lengths.
+#
+# Each function is analyzed statically, then *run* through the
+# interpreter on concrete inputs; the inferred sizes are checked against
+# the real runtime list lengths.  Two invariants must hold for **every**
+# input (a single counterexample is a soundness bug):
+#
+#   1. concrete-size soundness — a static concrete ``int`` size (directly
+#      or via a pinned size variable) equals the runtime list length;
+#   2. equivalence soundness — ``is_size_eq`` bounds have equal runtime
+#      lengths.
+#
+# Only the ``static-fact => runtime-fact`` direction is checked (the
+# analysis is conservative, so the converse may legitimately fail).
+# Observables are the list-typed arguments and the return value.  Inputs
+# that raise at runtime (strict-``zip`` mismatch, out-of-range slice) are
+# skipped — the static claim about them is vacuous.
+
+@fp.fpy
+def _d_literal() -> list[fp.Real]:
+    return [1.0, 2.0, 3.0]
+
+
+@fp.fpy
+def _d_empty_literal() -> list[fp.Real]:
+    return []
+
+
+@fp.fpy
+def _d_nested_literal() -> list[list[fp.Real]]:
+    return [[1.0, 2.0], [3.0, 4.0]]
+
+
+@fp.fpy
+def _d_range1() -> list[fp.Real]:
+    return [0.0 for _ in range(5)]
+
+
+@fp.fpy
+def _d_range1_negative() -> list[fp.Real]:
+    return [0.0 for _ in range(-5)]
+
+
+@fp.fpy
+def _d_range2() -> list[fp.Real]:
+    return [0.0 for _ in range(2, 7)]
+
+
+@fp.fpy
+def _d_range2_flipped() -> list[fp.Real]:
+    return [0.0 for _ in range(7, 2)]
+
+
+@fp.fpy
+def _d_range3() -> list[fp.Real]:
+    return [0.0 for _ in range(0, 10, 3)]
+
+
+@fp.fpy
+def _d_range_len_literal() -> list[fp.Real]:
+    xs = [1.0, 2.0, 3.0, 4.0]
+    return [0.0 for _ in range(len(xs))]
+
+
+@fp.fpy
+def _d_comp_over_arg(xs: list[fp.Real]) -> list[fp.Real]:
+    return [x for x in xs]
+
+
+@fp.fpy
+def _d_comp_product() -> list[fp.Real]:
+    return [0.0 for _ in range(3) for _ in range(4)]
+
+
+@fp.fpy
+def _d_enumerate(xs: list[fp.Real]) -> list[fp.Real]:
+    return [x for _, x in enumerate(xs)]
+
+
+@fp.fpy
+def _d_zip_args(xs: list[fp.Real], ys: list[fp.Real]) -> list[tuple[fp.Real, fp.Real]]:
+    return [t for t in zip(xs, ys)]
+
+
+@fp.fpy
+def _d_zip_literal(xs: list[fp.Real]) -> fp.Real:
+    acc = 0.0
+    for _ in zip(xs, [1.0, 2.0, 3.0]):
+        with fp.FP64:
+            acc = acc + 1.0
+    return acc
+
+
+@fp.fpy
+def _d_slice_concrete() -> list[fp.Real]:
+    xs = [1.0, 2.0, 3.0, 4.0, 5.0]
+    return xs[1:4]
+
+
+@fp.fpy
+def _d_slice_full(xs: list[fp.Real]) -> list[fp.Real]:
+    return xs[:]
+
+
+@fp.fpy
+def _d_slice_prefix(xs: list[fp.Real]) -> list[fp.Real]:
+    return xs[0:2]
+
+
+@fp.fpy
+def _d_slice_sym_offset(xs: list[fp.Real], i: fp.Real) -> list[fp.Real]:
+    with fp.REAL:
+        ys = xs[i:i + 2]
+    return ys
+
+
+@fp.fpy
+def _d_range_sym_offset(i: fp.Real) -> list[fp.Real]:
+    with fp.REAL:
+        ys = [0.0 for _ in range(i, i + 4)]
+    return ys
+
+
+@fp.fpy
+def _d_empty_2d() -> list[list[fp.Real]]:
+    return fp.empty(2, 3)
+
+
+@fp.fpy
+def _d_cond_equal(b: bool) -> list[fp.Real]:
+    if b:
+        return [1.0, 2.0]
+    else:
+        return [3.0, 4.0]
+
+
+@fp.fpy
+def _d_cond_unequal(b: bool) -> list[fp.Real]:
+    if b:
+        return [1.0]
+    else:
+        return [2.0, 3.0]
+
+
+@fp.fpy
+def _d_rebind(xs: list[fp.Real]) -> list[fp.Real]:
+    ys = xs
+    return ys
+
+
+@fp.fpy
+def _d_loop_preserve(xs: list[fp.Real]) -> list[fp.Real]:
+    ys = xs
+    for _ in range(3):
+        ys = ys
+    return ys
+
+
+@fp.fpy
+def _d_indexed_assign(xs: list[fp.Real]) -> list[fp.Real]:
+    ys = [0.0 for _ in xs]
+    for i, x in enumerate(xs):
+        ys[i] = x
+    return ys
+
+
+@fp.fpy
+def _d_callee_known() -> list[fp.Real]:
+    return [1.0, 2.0, 3.0, 4.0, 5.0]
+
+
+@fp.fpy
+def _d_call_known() -> list[fp.Real]:
+    return _d_callee_known()
+
+
+def _floats(n):
+    return [float(k) for k in range(n)]
+
+
+_DIFFERENTIAL_SPECS = [
+    (_d_literal, [()]),
+    (_d_empty_literal, [()]),
+    (_d_nested_literal, [()]),
+    (_d_range1, [()]),
+    (_d_range1_negative, [()]),
+    (_d_range2, [()]),
+    (_d_range2_flipped, [()]),
+    (_d_range3, [()]),
+    (_d_range_len_literal, [()]),
+    (_d_comp_over_arg, [(_floats(0),), (_floats(1),), (_floats(3),), (_floats(10),)]),
+    (_d_comp_product, [()]),
+    (_d_enumerate, [(_floats(0),), (_floats(1),), (_floats(7),)]),
+    (_d_zip_args, [(_floats(0), _floats(0)), (_floats(4), _floats(4)), (_floats(9), _floats(9))]),
+    (_d_zip_literal, [(_floats(3),)]),
+    (_d_slice_concrete, [()]),
+    (_d_slice_full, [(_floats(0),), (_floats(1),), (_floats(6),)]),
+    (_d_slice_prefix, [(_floats(2),), (_floats(5),)]),
+    (_d_slice_sym_offset, [(_floats(5), 1), (_floats(10), 3), (_floats(2), 0)]),
+    (_d_range_sym_offset, [(0,), (5,), (-3,)]),
+    (_d_empty_2d, [()]),
+    (_d_cond_equal, [(True,), (False,)]),
+    (_d_cond_unequal, [(True,), (False,)]),
+    (_d_rebind, [(_floats(0),), (_floats(1),), (_floats(8),)]),
+    (_d_loop_preserve, [(_floats(0),), (_floats(4),)]),
+    (_d_indexed_assign, [(_floats(0),), (_floats(1),), (_floats(6),)]),
+    (_d_call_known, [()]),
+]
+
+
+class TestArraySizeDifferential:
+    """Compare inferred sizes against runtime list lengths."""
+
+    @classmethod
+    def _runtime_tree(cls, v):
+        """Nested-length shape of a runtime value: ``('list', n,
+        inner|None)`` / ``('tuple', (sub, ...))`` / ``('scalar',)``."""
+        if isinstance(v, list):
+            return ('list', len(v), cls._runtime_tree(v[0]) if v else None)
+        if isinstance(v, tuple):
+            return ('tuple', tuple(cls._runtime_tree(e) for e in v))
+        return ('scalar',)
+
+    def _check_concrete(self, bound, tree, path):
+        """Every concrete static size must match the runtime length."""
+        if bound is None:
+            return
+        if isinstance(bound, ListSize):
+            assert tree[0] == 'list', f'{path}: static list vs runtime {tree[0]}'
+            c = concrete_size(bound.size)
+            if c is not None:
+                assert c == tree[1], (
+                    f'{path}: static size {c} != runtime length {tree[1]}'
+                )
+            if tree[2] is not None:
+                self._check_concrete(bound.elt, tree[2], path + '[0]')
+        elif isinstance(bound, TupleSize):
+            assert tree[0] == 'tuple', f'{path}: static tuple vs runtime {tree[0]}'
+            assert len(bound.elts) == len(tree[1]), f'{path}: tuple arity'
+            for k, (b, t) in enumerate(zip(bound.elts, tree[1])):
+                self._check_concrete(b, t, f'{path}.{k}')
+
+    @staticmethod
+    def _observables(func, info, inputs, result):
+        obs = []
+        for arg, val in zip(func.ast.args, inputs):
+            if isinstance(arg.name, NamedId):
+                d = info.def_use.find_def_from_site(arg.name, arg)
+                obs.append((str(arg.name), info.by_def[d], val))
+        obs.append(('<ret>', info.ret_size, result))
+        return obs
+
+    def _assert_sound(self, func, input_sets):
+        info = ArraySizeInfer.analyze(func.ast)
+        ran_any = False
+        for inputs in input_sets:
+            try:
+                result = func(*inputs)
+            except Exception:
+                continue  # invalid input -> static claim is vacuous
+            ran_any = True
+            obs = self._observables(func, info, inputs, result)
+
+            # (1) concrete-size soundness on every observable
+            for label, bound, val in obs:
+                self._check_concrete(bound, self._runtime_tree(val), label)
+
+            # (2) equivalence soundness: equal bounds => equal runtime lengths
+            for i in range(len(obs)):
+                for j in range(i + 1, len(obs)):
+                    _, bi, vi = obs[i]
+                    _, bj, vj = obs[j]
+                    if (isinstance(vi, list) and isinstance(vj, list)
+                            and is_size_eq(bi, bj)):
+                        assert len(vi) == len(vj), (
+                            f'{obs[i][0]} ~ {obs[j][0]} are is_size_eq but '
+                            f'runtime lengths differ: {len(vi)} != {len(vj)}'
+                        )
+        assert ran_any, f'no input set ran without raising for {func.name}'
+
+    @pytest.mark.parametrize(
+        'func,input_sets', _DIFFERENTIAL_SPECS,
+        ids=[f.name for f, _ in _DIFFERENTIAL_SPECS],
+    )
+    def test_sound(self, func, input_sets):
+        self._assert_sound(func, input_sets)
+
+    # -- hypothesis: fuzz argument lengths for size-linked functions ----
+
+    @settings(max_examples=60)
+    @given(n=st.integers(min_value=0, max_value=64))
+    def test_fuzz_comp_over_arg(self, n):
+        self._assert_sound(_d_comp_over_arg, [(_floats(n),)])
+
+    @settings(max_examples=60)
+    @given(n=st.integers(min_value=0, max_value=64))
+    def test_fuzz_enumerate(self, n):
+        self._assert_sound(_d_enumerate, [(_floats(n),)])
+
+    @settings(max_examples=60)
+    @given(n=st.integers(min_value=0, max_value=64))
+    def test_fuzz_rebind(self, n):
+        self._assert_sound(_d_rebind, [(_floats(n),)])
+
+    @settings(max_examples=60)
+    @given(n=st.integers(min_value=0, max_value=64))
+    def test_fuzz_full_slice(self, n):
+        self._assert_sound(_d_slice_full, [(_floats(n),)])
+
+    @settings(max_examples=60)
+    @given(n=st.integers(min_value=0, max_value=64))
+    def test_fuzz_indexed_assign(self, n):
+        self._assert_sound(_d_indexed_assign, [(_floats(n),)])
+
+    @settings(max_examples=60)
+    @given(n=st.integers(min_value=0, max_value=64))
+    def test_fuzz_zip_args_equal(self, n):
+        self._assert_sound(_d_zip_args, [(_floats(n), _floats(n))])
+
+    @settings(max_examples=60)
+    @given(i=st.integers(min_value=0, max_value=32))
+    def test_fuzz_slice_sym_offset(self, i):
+        self._assert_sound(_d_slice_sym_offset, [(_floats(i + 2), i)])
+
+    @settings(max_examples=60)
+    @given(i=st.integers(min_value=-8, max_value=32))
+    def test_fuzz_range_sym_offset(self, i):
+        self._assert_sound(_d_range_sym_offset, [(i,)])

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -823,3 +823,101 @@ class TestArraySizeInfer:
         info = self._run(f)
         assert isinstance(info.ret_size, ListSize)
         assert info.ret_size.size == 2
+
+    # ------------------------------------------------------------------
+    # Call-result size propagation
+
+    def test_call_propagates_known_return_size(self):
+        """A call to a callee whose return size is statically known
+        adopts that size at the call site (and onto a binding of it)."""
+
+        @fp.fpy
+        def callee() -> list[fp.Real]:
+            return [1.0, 2.0, 3.0]
+
+        @fp.fpy
+        def caller() -> list[fp.Real]:
+            ys = callee()
+            return ys
+
+        info = self._run(caller)
+        call_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'Call'
+        ]
+        assert len(call_bounds) == 1
+        assert isinstance(call_bounds[0], ListSize)
+        assert call_bounds[0].size == 3
+        # ...and it survives onto the binding / return.
+        assert isinstance(info.ret_size, ListSize)
+        assert info.ret_size.size == 3
+
+    def test_call_with_arg_dependent_size_stays_unknown(self):
+        """A callee whose return size depends on its arguments has no
+        statically-known size; the call site must not invent one."""
+
+        @fp.fpy
+        def callee(xs: list[fp.Real]) -> list[fp.Real]:
+            return [x for x in xs]
+
+        @fp.fpy
+        def caller(xs: list[fp.Real]) -> list[fp.Real]:
+            return callee(xs)
+
+        info = self._run(caller)
+        call_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'Call'
+        ]
+        assert len(call_bounds) == 1
+        assert isinstance(call_bounds[0], ListSize)
+        assert call_bounds[0].size is None
+
+    def test_call_propagates_transitively(self):
+        """A known size flows through a chain of calls."""
+
+        @fp.fpy
+        def leaf() -> list[fp.Real]:
+            return [1.0, 2.0, 3.0, 4.0, 5.0]
+
+        @fp.fpy
+        def mid() -> list[fp.Real]:
+            return leaf()
+
+        @fp.fpy
+        def top() -> list[fp.Real]:
+            return mid()
+
+        info = self._run(top)
+        assert isinstance(info.ret_size, ListSize)
+        assert info.ret_size.size == 5
+
+    def test_call_propagates_nested_sizes(self):
+        """Nested known sizes (``empty(2, 3)``) propagate per-dimension
+        through a call via the structural overlay."""
+
+        @fp.fpy
+        def grid() -> list[list[fp.Real]]:
+            return fp.empty(2, 3)
+
+        @fp.fpy
+        def use_grid() -> list[list[fp.Real]]:
+            return grid()
+
+        info = self._run(use_grid)
+        outer = info.ret_size
+        assert isinstance(outer, ListSize)
+        assert outer.size == 2
+        assert isinstance(outer.elt, ListSize)
+        assert outer.elt.size == 3
+
+    def test_primitive_call_has_no_size(self):
+        """Calling a primitive (non-FPy-function) doesn't crash and
+        yields no list-size info."""
+
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            return fp.sqrt(x)
+
+        info = self._run(f)
+        assert info.ret_size is None

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -539,6 +539,84 @@ class TestArraySizeInfer:
         ]
         assert len(slice_bounds) == 1 and slice_bounds[0].size == 2
 
+    def _slice_bound(self, f):
+        info = self._run(f)
+        slice_bounds = [
+            b for e, b in info.by_expr.items()
+            if type(e).__name__ == 'ListSlice'
+        ]
+        assert len(slice_bounds) == 1
+        assert isinstance(slice_bounds[0], ListSize)
+        return slice_bounds[0]
+
+    def test_list_slice_symbolic_offset_under_real(self):
+        """``x[i : i + 16]`` on an unknown-size list has size 16: the
+        symbolic base ``i`` cancels in ``(i + 16) - i``.  Sound only
+        because the ``+`` runs under the exact ``REAL`` context."""
+
+        @fp.fpy
+        def f(x: list[fp.Real], i: fp.Real) -> list[fp.Real]:
+            with fp.REAL:
+                y = x[i:i + 16]
+            return y
+
+        assert self._slice_bound(f).size == 16
+
+    def test_list_slice_symbolic_offset_subtraction_under_real(self):
+        """Both endpoints offset from the same base: ``x[i-4 : i+4]`` -> 8."""
+
+        @fp.fpy
+        def f(x: list[fp.Real], i: fp.Real) -> list[fp.Real]:
+            with fp.REAL:
+                y = x[i - 4:i + 4]
+            return y
+
+        assert self._slice_bound(f).size == 8
+
+    def test_list_slice_symbolic_offset_constant_on_left(self):
+        """``x[i : 16 + i]`` -> 16 (constant operand on either side)."""
+
+        @fp.fpy
+        def f(x: list[fp.Real], i: fp.Real) -> list[fp.Real]:
+            with fp.REAL:
+                y = x[i:16 + i]
+            return y
+
+        assert self._slice_bound(f).size == 16
+
+    def test_list_slice_symbolic_offset_not_under_real_is_unknown(self):
+        """Without an exact context, rounding could perturb ``i + 16``,
+        so the difference is not provably constant -> unknown."""
+
+        @fp.fpy
+        def f(x: list[fp.Real], i: fp.Real) -> list[fp.Real]:
+            return x[i:i + 16]
+
+        assert self._slice_bound(f).size is None
+
+    def test_list_slice_symbolic_offset_inverted_is_unknown(self):
+        """``x[i+16 : i]`` has start > stop: strict slicing always raises,
+        so report unknown rather than a negative size."""
+
+        @fp.fpy
+        def f(x: list[fp.Real], i: fp.Real) -> list[fp.Real]:
+            with fp.REAL:
+                y = x[i + 16:i]
+            return y
+
+        assert self._slice_bound(f).size is None
+
+    def test_list_slice_symbolic_offset_nonconstant_is_unknown(self):
+        """``x[i : i + k]`` with symbolic ``k`` can't be pinned."""
+
+        @fp.fpy
+        def f(x: list[fp.Real], i: fp.Real, k: fp.Real) -> list[fp.Real]:
+            with fp.REAL:
+                y = x[i:i + k]
+            return y
+
+        assert self._slice_bound(f).size is None
+
     # ------------------------------------------------------------------
     # IndexedAssign as a fresh SSA def
 


### PR DESCRIPTION
Extends `ArraySizeInfer` to infer list lengths in many more cases, and tracks equal-but-unknown lengths via a unionfind.

  - zip is strict — models FPy's length-strict zip: equal known lengths survive; conflicting ones are unreachable (not min).
  - Concrete sizes through calls — a callee whose ret_size is statically known propagates that size to call sites.
  - Slicing — xs[a:b] with constant bounds → b − a; xs[:] preserves the source length.
  - Affine range/slice offsets — range(i, i+16) / xs[i:i+16] fold to a constant length when the offset arithmetic is exact (under REAL).
  - len / size / dim folding — range(len(xs)), range(size(xs, d)), range(dim(xs)) fold when the queried size is known (dim is always known — it's the nesting depth).
  - Symbolic equality (union-find) — list arguments get a tracked size variable; ys = xs, comprehensions, enumerate, full slices, and zip propagate/merge it, so len(ys) == 
  len(xs) survives.
  - Assertion-seeded equalities — assert len(xs) == len(ys) merges their sizes; assert len(xs) == N pins. Only unconditional asserts seed (sound w.r.t. reachability).