### PR TITLE
List type (annotations) carry optional size parameter

### DIFF
--- a/fpy2/__init__.py
+++ b/fpy2/__init__.py
@@ -52,32 +52,3 @@ from .backend import (
 
 # runner
 from .runner import Runner, RunnerWorkerTask
-
-###########################################################
-# typing hints
-# TODO: remove these hints
-
-import typing as _typing
-
-from typing import Literal as Dim
-
-_Dims = _typing.TypeVarTuple('_Dims')
-_DType = _typing.TypeVar('_DType')
-
-class Tensor(tuple, _typing.Generic[*_Dims, _DType]):
-    """
-    FPy type hint for a homogenous tensor object::
-
-        from fpy2 import Tensor, Real
-        from typing import TypeAlias
-
-        MatrixN: TypeAlias = Tensor[Literal['N', 'N'], Real]
-        Matrix3: TypeAlias = Tensor[Literal[3, 3], Real]
-
-    Tensors have fixed or symbolic sizes and a uniform scalar data type.
-
-    Values of this type should not be constructed directly.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -260,11 +260,20 @@ class _ArraySizeInferInstance(DefaultVisitor):
             case _:
                 return None
 
+    def _annotated_size(self, length: int | NamedId | None) -> ArraySize:
+        """The array-size seeded by a :class:`ListType`'s optional length:
+        a concrete ``int``; a symbolic ``NamedId`` (registered in the
+        union-find, so equal dim names share a class); or ``None`` when the
+        annotation gives no size."""
+        if isinstance(length, NamedId):
+            self.uf.add(length)
+        return length
+
     def _cvt_type(self, ty: Type) -> ArraySizeBound:
         match ty:
             case ListType():
                 elt = self._cvt_type(ty.elt)
-                return ListSize(elt, None)
+                return ListSize(elt, self._annotated_size(ty.length))
             case TupleType():
                 elts = tuple(self._cvt_type(e) for e in ty.elts)
                 return TupleSize(elts)
@@ -272,13 +281,16 @@ class _ArraySizeInferInstance(DefaultVisitor):
                 return None
 
     def _arg_bound(self, ty: Type) -> ArraySizeBound:
-        """Like :meth:`_cvt_type`, but a list parameter's *outer* length
-        gets a fresh size variable (its length is fixed per call, just
-        unknown), so equalities such as ``ys = xs`` are tracked.  Inner
-        dimensions stay ``None`` (one size variable per argument)."""
+        """Like :meth:`_cvt_type`, but a list parameter's *outer* length,
+        when the annotation gives none, gets a fresh size variable (its
+        length is fixed per call, just unknown), so equalities such as
+        ``ys = xs`` are tracked."""
         match ty:
             case ListType():
-                return ListSize(self._cvt_type(ty.elt), self._fresh_size())
+                size = self._annotated_size(ty.length)
+                if size is None:
+                    size = self._fresh_size()
+                return ListSize(self._cvt_type(ty.elt), size)
             case TupleType():
                 return TupleSize(tuple(self._arg_bound(e) for e in ty.elts))
             case _:

--- a/fpy2/analysis/array_size.py
+++ b/fpy2/analysis/array_size.py
@@ -805,11 +805,16 @@ class _ArraySizeInferInstance(DefaultVisitor):
     def _seed_from_assert(self, test: Expr):
         """Learn size equalities from ``len(a) == len(b)`` / ``len(a) == N``
         (and chained ``==``) — pins or merges the size variables."""
-        if not isinstance(test, Compare):
-            return
-        for op, lhs, rhs in zip(test.ops, test.args, test.args[1:]):
-            if op == CompareOp.EQ:
-                self._relate_sizes(self._len_size(lhs), self._len_size(rhs))
+        match test:
+            case And():
+                for arg in test.args:
+                    self._seed_from_assert(arg)
+            case Compare():
+                for op, lhs, rhs in zip(test.ops, test.args, test.args[1:]):
+                    if op == CompareOp.EQ:
+                        self._relate_sizes(self._len_size(lhs), self._len_size(rhs))
+            case _:
+                pass
 
     def _len_size(self, e: Expr) -> ArraySize:
         """The size ``e`` constrains: the list's size for ``len(xs)``, the

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -105,6 +105,37 @@ _ternary_table: dict[type[TernaryOp], FunctionType] = {
 }
 
 
+def _merge_length(a: int | NamedId | None, b: int | NamedId | None) -> int | NamedId | None:
+    """Keep the more specific of two list lengths: ``concrete > symbolic >
+    None``.  Used when unifying two list types; never fails (length is
+    metadata)."""
+    if isinstance(a, int):
+        return a
+    if isinstance(b, int):
+        return b
+    return a if a is not None else b
+
+
+def _drop_symbolic_lengths(ty: Type) -> Type:
+    """Replace every *symbolic* (``NamedId``) list length with ``None``,
+    keeping concrete ``int`` lengths.  Applied when instantiating a callee's
+    type so its dimension variables don't leak across the call boundary."""
+    match ty:
+        case ListType():
+            length = ty.length if isinstance(ty.length, int) else None
+            return ListType(_drop_symbolic_lengths(ty.elt), length)
+        case TupleType():
+            return TupleType(*[_drop_symbolic_lengths(e) for e in ty.elts])
+        case FunctionType():
+            return FunctionType(
+                ty.ctx,
+                [_drop_symbolic_lengths(a) for a in ty.arg_types],
+                _drop_symbolic_lengths(ty.return_type),
+            )
+        case _:
+            return ty
+
+
 def _ann_to_type(ty: TypeAnn | None, fresh_var: Callable[[], VarType]) -> Type:
     match ty:
         case AnyTypeAnn():
@@ -122,8 +153,8 @@ def _ann_to_type(ty: TypeAnn | None, fresh_var: Callable[[], VarType]) -> Type:
             elt_tys = [_ann_to_type(elt, fresh_var) for elt in ty.elts]
             return TupleType(*elt_tys)
         case ListTypeAnn():
-            # list type
-            return ListType(_ann_to_type(ty.elt, fresh_var))
+            # list type — carry the optional size annotation onto the type
+            return ListType(_ann_to_type(ty.elt, fresh_var), ty.length)
         case SizedTensorTypeAnn():
             if len(ty.dims) == 0:
                 return ListType(fresh_var())
@@ -214,7 +245,7 @@ class _TypeInferInstance(Visitor):
                 return self.tvars.add(TupleType(*elts))
             case ListType():
                 elt_ty = self._resolve_type(ty.elt)
-                return self.tvars.add(ListType(elt_ty))
+                return self.tvars.add(ListType(elt_ty, ty.length))
             case _:
                 raise NotImplementedError(f'cannot resolve type {ty}')
 
@@ -235,7 +266,9 @@ class _TypeInferInstance(Visitor):
                 elt_ty = self.tvars.add(elt_ty)
                 elt_ty = self.tvars.union(elt_ty, self.tvars.add(a_ty.elt))
                 elt_ty = self.tvars.union(elt_ty, self.tvars.add(b_ty.elt))
-                return self.tvars.add(ListType(elt_ty))
+                # length is metadata: keep the more specific, never fail
+                length = _merge_length(a_ty.length, b_ty.length)
+                return self.tvars.add(ListType(elt_ty, length))
             case TupleType(), TupleType():
                 # TODO: what if the length doesn't match
                 if len(a_ty.elts) != len(b_ty.elts):
@@ -252,7 +285,10 @@ class _TypeInferInstance(Visitor):
         subst: dict[NamedId, Type] = {}
         for fv in sorted(ty.free_type_vars()):
             subst[fv] = self._fresh_type_var()
-        return ty.subst_type(subst)
+        # a callee's *symbolic* list lengths name the callee's own
+        # dimensions and are meaningless at the call site — drop them
+        # (concrete lengths stay; they hold regardless of caller).
+        return _drop_symbolic_lengths(ty.subst_type(subst))
 
     def _generalize(self, ty: Type) -> tuple[Type, dict[NamedId, Type]]:
         subst: dict[NamedId, Type] = {}

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -155,14 +155,6 @@ def _ann_to_type(ty: TypeAnn | None, fresh_var: Callable[[], VarType]) -> Type:
         case ListTypeAnn():
             # list type — carry the optional size annotation onto the type
             return ListType(_ann_to_type(ty.elt, fresh_var), ty.length)
-        case SizedTensorTypeAnn():
-            if len(ty.dims) == 0:
-                return ListType(fresh_var())
-            else:
-                arr_ty = ListType(_ann_to_type(ty.elt, fresh_var))
-                for _ in ty.dims[1:]:
-                    arr_ty = ListType(arr_ty)
-                return arr_ty
         case _:
             raise RuntimeError(f'unreachable: {ty}')
 

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -327,15 +327,25 @@ class TupleTypeAnn(TypeAnn):
 
 class ListTypeAnn(TypeAnn):
     """FPy AST: native list type annotation"""
-    __slots__ = ('elt',)
+    __slots__ = ('elt', 'length')
     elt: TypeAnn
+    length: int | NamedId | None
+    """optional list size: a known ``int``, a symbolic ``NamedId``, or
+    ``None`` (unknown)"""
 
-    def __init__(self, elt: TypeAnn, loc: Location | None):
+    def __init__(self, elt: TypeAnn, length: int | NamedId | None, loc: Location | None):
         super().__init__(loc)
         self.elt = elt
+        self.length = length
 
     def is_equiv(self, other) -> bool:
-        return isinstance(other, ListTypeAnn) and self.elt.is_equiv(other.elt)
+        # annotation equivalence is syntactic, so the size is compared
+        # (unlike the semantic ``ListType``, where length is metadata)
+        return (
+            isinstance(other, ListTypeAnn)
+            and self.elt.is_equiv(other.elt)
+            and self.length == other.length
+        )
 
 class SizedTensorTypeAnn(TypeAnn):
     """FPy AST: sized, homogenous tensor type annotation"""

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -43,7 +43,6 @@ __all__ = [
     'ContextTypeAnn',
     'TupleTypeAnn',
     'ListTypeAnn',
-    'SizedTensorTypeAnn',
 
     # Value expressions
     'Var',
@@ -346,25 +345,6 @@ class ListTypeAnn(TypeAnn):
             and self.elt.is_equiv(other.elt)
             and self.length == other.length
         )
-
-class SizedTensorTypeAnn(TypeAnn):
-    """FPy AST: sized, homogenous tensor type annotation"""
-    __slots__ = ('dims', 'elt')
-    dims: tuple[int | NamedId, ...]
-    elt: TypeAnn
-
-    def __init__(self, dims: list[int | NamedId], elt: TypeAnn, loc: Location | None):
-        super().__init__(loc)
-        self.dims = tuple(dims)
-        self.elt = elt
-
-    def is_equiv(self, other) -> bool:
-        return (
-            isinstance(other, SizedTensorTypeAnn)
-            and self.dims == other.dims
-            and self.elt.is_equiv(other.elt)
-        )
-
 
 class Expr(Ast):
     """FPy AST: expression"""

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -191,16 +191,6 @@ class _FPCoreCompileInstance(Visitor):
                                 'FPCore-compilable', arg)
                     ann = ann.elt
                 return str(arg.name), {}, dims
-            case SizedTensorTypeAnn():
-                dims = []
-                for dim in arg.type.dims:
-                    if isinstance(dim, int):
-                        dims.append(dim)
-                    elif isinstance(dim, NamedId):
-                        dims.append(str(dim))
-                    else:
-                        raise FPCoreCompileError('unexpected dimension type', dim)
-                return str(arg.name), {}, dims
             case _:
                 raise FPCoreCompileError('unsupported argument type', arg)
 

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -173,8 +173,26 @@ class _FPCoreCompileInstance(Visitor):
                 return str(arg.name), {}, None
             case RealTypeAnn():
                 return str(arg.name), {}, None
-            case SizedTensorTypeAnn():
+            case ListTypeAnn():
+                # nested sized list -> FPCore tensor dims (outermost first).
+                # Every dimension must have a known size (int) or symbolic
+                # name (NamedId); an unsized list isn't FPCore-compilable.
                 dims: list[int | str] = []
+                ann: TypeAnn = arg.type
+                while isinstance(ann, ListTypeAnn):
+                    match ann.length:
+                        case int():
+                            dims.append(ann.length)
+                        case NamedId():
+                            dims.append(str(ann.length))
+                        case _:
+                            raise FPCoreCompileError(
+                                'list argument without a known size is not '
+                                'FPCore-compilable', arg)
+                    ann = ann.elt
+                return str(arg.name), {}, dims
+            case SizedTensorTypeAnn():
+                dims = []
                 for dim in arg.type.dims:
                     if isinstance(dim, int):
                         dims.append(dim)

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -767,7 +767,17 @@ class _FPCore2FPy:
                             case _:
                                 raise RuntimeError(f'unsupported shape {shape} for argument {name}')
 
-                    arg = Argument(t, SizedTensorTypeAnn(dims, AnyTypeAnn(None), None), None)
+                    # nested sized list type: outermost dimension first, so
+                    # ``(d0, d1)`` -> ``list[list[any][d1]][d0]``.  Each
+                    # ``length`` is the dim's size (``int``) or the gensym'd
+                    # name shared with the body's ``size(t, i)`` binding.
+                    if dims:
+                        ann: TypeAnn = AnyTypeAnn(None)
+                        for dim in reversed(dims):
+                            ann = ListTypeAnn(ann, dim, None)
+                    else:
+                        ann = ListTypeAnn(AnyTypeAnn(None), None, None)
+                    arg = Argument(t, ann, None)
                     args.append(arg)
                     ctx.env[name] = t
                 case None:

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -199,7 +199,7 @@ class Parser:
             return TupleTypeAnn(elts, loc)
         elif isinstance(ty, list):
             elt = self._convert_type(ty[0], loc)
-            return ListTypeAnn(elt, loc)
+            return ListTypeAnn(elt, None, loc)
         else:
             # TODO: implement
             return AnyTypeAnn(loc)

--- a/fpy2/transform/monomorphize.py
+++ b/fpy2/transform/monomorphize.py
@@ -43,7 +43,7 @@ class _MonomorphizeVisitor(DefaultTransformVisitor):
                 return TupleTypeAnn(elts, None)
             case ListType():
                 elt = self._cvt_arg_type(ty.elt)
-                return ListTypeAnn(elt, None)
+                return ListTypeAnn(elt, None, None)
             case _:
                 raise RuntimeError(f'Unsupported argument type `{ty}`')
 
@@ -85,7 +85,7 @@ class _MonomorphizeVisitor(DefaultTransformVisitor):
                 return TupleTypeAnn(elts, None)
             case ListTypeAnn(), ListTypeAnn():
                 elt = self._merge_annotation(a.elt, b.elt)
-                return ListTypeAnn(elt, None)
+                return ListTypeAnn(elt, None, None)
             case _:
                 raise RuntimeError(f'Cannot merge different types `{a}` and `{b}`')
 

--- a/fpy2/transform/monomorphize.py
+++ b/fpy2/transform/monomorphize.py
@@ -13,6 +13,25 @@ from ..fpc_context import FPCoreContext
 from ..types import *
 
 
+def _merge_length(a: int | NamedId | None, b: int | NamedId | None) -> int | NamedId | None:
+    """Merge two list-size annotations, preferring the more specific
+    (``concrete > symbolic > None``).  Two *different* concrete sizes are a
+    genuine contradiction and raise."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    if isinstance(a, int) and isinstance(b, int):
+        if a != b:
+            raise RuntimeError(f'Cannot merge list sizes {a} and {b}')
+        return a
+    if isinstance(a, int):
+        return a
+    if isinstance(b, int):
+        return b
+    return a  # both symbolic — keep the existing one
+
+
 class _MonomorphizeVisitor(DefaultTransformVisitor):
     """Monomorphize visitor."""
 
@@ -43,7 +62,7 @@ class _MonomorphizeVisitor(DefaultTransformVisitor):
                 return TupleTypeAnn(elts, None)
             case ListType():
                 elt = self._cvt_arg_type(ty.elt)
-                return ListTypeAnn(elt, None, None)
+                return ListTypeAnn(elt, ty.length, None)
             case _:
                 raise RuntimeError(f'Unsupported argument type `{ty}`')
 
@@ -85,7 +104,7 @@ class _MonomorphizeVisitor(DefaultTransformVisitor):
                 return TupleTypeAnn(elts, None)
             case ListTypeAnn(), ListTypeAnn():
                 elt = self._merge_annotation(a.elt, b.elt)
-                return ListTypeAnn(elt, None, None)
+                return ListTypeAnn(elt, _merge_length(a.length, b.length), None)
             case _:
                 raise RuntimeError(f'Cannot merge different types `{a}` and `{b}`')
 
@@ -189,6 +208,9 @@ class Monomorphize:
                     for a_elt, b_elt in zip(a_ty.elts, b_ty.elts):
                         _check_merge(curr_ty, new_ty, a_elt, b_elt)
                 case ListType(), ListType():
+                    if (isinstance(a_ty.length, int) and isinstance(b_ty.length, int)
+                            and a_ty.length != b_ty.length):
+                        _raise_conflict(curr_ty, new_ty)
                     _check_merge(curr_ty, new_ty, a_ty.elt, b_ty.elt)
                 case _:
                     _raise_conflict(curr_ty, new_ty)

--- a/fpy2/types.py
+++ b/fpy2/types.py
@@ -279,10 +279,19 @@ class ListType(Type):
     elt: Type
     """element type"""
 
-    def __init__(self, elt: Type):
+    length: int | NamedId | None
+    """optional list size: a known ``int``, a symbolic ``NamedId``, or
+    ``None`` (unknown).  This is *metadata* — like :attr:`RealType.ctx` it
+    is ignored by ``__eq__`` / ``__hash__`` (and hence by unification), and
+    is read only by array-size inference, monomorphization, and the FPCore
+    backend."""
+
+    def __init__(self, elt: Type, length: int | NamedId | None = None):
         self.elt = elt
+        self.length = length
 
     def __eq__(self, other):
+        # ``length`` is metadata and deliberately excluded from equality.
         return isinstance(other, ListType) and self.elt == other.elt
 
     def __hash__(self):
@@ -292,7 +301,9 @@ class ListType(Type):
         return self.elt.is_context_type()
 
     def format(self) -> str:
-        return f'list[{self.elt.format()}]'
+        if self.length is None:
+            return f'list[{self.elt.format()}]'
+        return f'list[{self.elt.format()}][{self.length}]'
 
     def free_type_vars(self) -> set[NamedId]:
         return self.elt.free_type_vars()
@@ -301,10 +312,10 @@ class ListType(Type):
         return self.elt.free_context_vars()
 
     def subst_type(self, subst: dict[NamedId, Type]) -> Type:
-        return ListType(self.elt.subst_type(subst))
+        return ListType(self.elt.subst_type(subst), self.length)
 
     def subst_context(self, subst: dict[NamedId, ContextParam]) -> Type:
-        return ListType(self.elt.subst_context(subst))
+        return ListType(self.elt.subst_context(subst), self.length)
 
 
 class FunctionType(Type):

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -76,6 +76,38 @@ class TestArraySizeInfer:
         assert bound.elt is None
         assert isinstance(bound.size, NamedId)
 
+    def test_arg_concrete_length_annotation_seeds_size(self):
+        """A ``list[Real]`` argument annotated with a concrete length
+        (e.g. an FPCore fixed dimension) seeds a concrete array-size."""
+        from fpy2.ast.fpyast import ListTypeAnn, RealTypeAnn
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            return xs[0]
+
+        f.ast.args[0].type = ListTypeAnn(RealTypeAnn(None, None), 16, None)
+        info = self._run(f)
+        xs_bound = [b for d, b in info.by_def.items() if d.name.base == 'xs'][0]
+        assert concrete_size(xs_bound.size) == 16
+
+    def test_shared_symbolic_length_annotation_unifies(self):
+        """Two list args annotated with the *same* symbolic length share a
+        size class (provably-equal lengths)."""
+        from fpy2.ast.fpyast import ListTypeAnn, RealTypeAnn
+
+        n = NamedId('N')
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            return xs[0]
+
+        f.ast.args[0].type = ListTypeAnn(RealTypeAnn(None, None), n, None)
+        f.ast.args[1].type = ListTypeAnn(RealTypeAnn(None, None), n, None)
+        info = self._run(f)
+        xs_b = [b for d, b in info.by_def.items() if d.name.base == 'xs'][0]
+        ys_b = [b for d, b in info.by_def.items() if d.name.base == 'ys'][0]
+        assert is_size_eq(xs_b, ys_b)
+
     def test_tuple_argument_has_tuplesize(self):
         """A tuple argument is a TupleSize with one entry per element."""
 

--- a/tests/unit/backend/test_fpc_tensor.py
+++ b/tests/unit/backend/test_fpc_tensor.py
@@ -12,6 +12,7 @@ from fpy2 import Function, FPCoreCompiler
 from fpy2.ast.fpyast import ListTypeAnn
 from fpy2.analysis import DefineUse
 from fpy2.backend.fpc import _FPCoreCompileInstance
+from fpy2.utils import NamedId
 
 
 def _parse(src: str) -> Function:
@@ -30,8 +31,10 @@ class TestFPCoreTensorSizes:
         """Named dims become symbolic lengths on the nested list."""
         fun = _parse('(FPCore foo ((B m n)) :precision binary64 1.0)')
         ann = fun.ast.args[0].type
-        assert isinstance(ann, ListTypeAnn) and ann.length.base == 'm'
-        assert isinstance(ann.elt, ListTypeAnn) and ann.elt.length.base == 'n'
+        assert isinstance(ann, ListTypeAnn) and isinstance(ann.length, NamedId)
+        assert ann.length.base == 'm'
+        assert isinstance(ann.elt, ListTypeAnn) and isinstance(ann.elt.length, NamedId)
+        assert ann.elt.length.base == 'n'
 
     def test_fixed_dims_round_trip(self):
         """FPCore -> FPy -> FPCore preserves fixed tensor dimensions."""

--- a/tests/unit/backend/test_fpc_tensor.py
+++ b/tests/unit/backend/test_fpc_tensor.py
@@ -1,0 +1,51 @@
+"""
+Tensor-argument size annotations round-tripping through FPCore.
+
+The FPCore parser maps a dimensioned argument to a nested, sized
+``ListTypeAnn`` (outermost dimension first), and the FPCore compiler reads
+those sizes back out as tensor dimensions.
+"""
+
+import titanfp.fpbench.fpcparser as fpcparser
+
+from fpy2 import Function, FPCoreCompiler
+from fpy2.ast.fpyast import ListTypeAnn
+from fpy2.analysis import DefineUse
+from fpy2.backend.fpc import _FPCoreCompileInstance
+
+
+def _parse(src: str) -> Function:
+    return Function.from_fpcore(fpcparser.compile1(src), ignore_unknown=True)
+
+
+class TestFPCoreTensorSizes:
+    def test_fixed_dims_parse_to_nested_sized_list(self):
+        """``(A 3 4)`` -> ``list[list[any][4]][3]`` (outermost dim first)."""
+        fun = _parse('(FPCore foo ((A 3 4)) :precision binary64 1.0)')
+        ann = fun.ast.args[0].type
+        assert isinstance(ann, ListTypeAnn) and ann.length == 3
+        assert isinstance(ann.elt, ListTypeAnn) and ann.elt.length == 4
+
+    def test_named_dims_parse_to_symbolic_lengths(self):
+        """Named dims become symbolic lengths on the nested list."""
+        fun = _parse('(FPCore foo ((B m n)) :precision binary64 1.0)')
+        ann = fun.ast.args[0].type
+        assert isinstance(ann, ListTypeAnn) and ann.length.base == 'm'
+        assert isinstance(ann.elt, ListTypeAnn) and ann.elt.length.base == 'n'
+
+    def test_fixed_dims_round_trip(self):
+        """FPCore -> FPy -> FPCore preserves fixed tensor dimensions."""
+        fun = _parse('(FPCore foo ((A 3 4)) :precision binary64 1.0)')
+        core = FPCoreCompiler().compile(fun)
+        assert core.inputs == [('A', {}, [3, 4])]
+
+    def test_named_dims_compile_to_dim_names(self):
+        """The compiler emits named dimensions back as FPCore dim names.
+
+        (The full named-dim body round-trip is blocked by an unrelated
+        FPCore-backend limitation, so the argument compilation is checked
+        directly.)"""
+        fun = _parse('(FPCore foo ((A 3 4) (B m n)) :precision binary64 1.0)')
+        inst = _FPCoreCompileInstance(fun.ast, DefineUse.analyze(fun.ast))
+        name, _, dims = inst._compile_arg(fun.ast.args[1])
+        assert name == 'B' and dims == ['m', 'n']

--- a/tests/unit/generators/fpy_program.py
+++ b/tests/unit/generators/fpy_program.py
@@ -1252,7 +1252,7 @@ def _type_to_typeann(t: Type) -> TypeAnn:
     if isinstance(t, TupleType):
         return TupleTypeAnn([_type_to_typeann(e) for e in t.elts], None)
     if isinstance(t, ListType):
-        return ListTypeAnn(_type_to_typeann(t.elt), None)
+        return ListTypeAnn(_type_to_typeann(t.elt), t.length, None)
     if isinstance(t, ContextType):
         return ContextTypeAnn(None)
     raise NotImplementedError(f'no TypeAnn for type {t.format()}')


### PR DESCRIPTION
The list type and list type annotation now carries an optional size parameter. This may be used to override array size analysis or carry static length information to analyses that need it. This change helps remove some awful legacy code that was hacked in to support FPCore parsing and compilation.