### PR TITLE
Tuple accessor follow-ons

### DIFF
--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -32,6 +32,8 @@ Anything else raises :class:`CppEmitError`, which the public
 ``CppCompiler`` re-wraps as :class:`CppCompileError`.
 """
 
+import dataclasses
+
 from contextlib import contextmanager
 from fractions import Fraction
 
@@ -88,6 +90,24 @@ def _list_depth(ty: CppType) -> int:
         depth += 1
         ty = ty.elt
     return depth
+
+
+@dataclasses.dataclass(frozen=True)
+class _TupleAccess:
+    """Resolved form of a folded ``fst``/``snd`` chain over a tuple.
+
+    - ``off is None`` — a finished value: ``s`` is its C++ expression and
+      ``ty`` its type (one ``std::get`` for an element, or a non-accessor
+      base).
+    - ``off`` an ``int`` — the not-yet-materialized suffix ``base[off:]`` of
+      a tuple: ``s`` is the base expression and ``ty`` the base
+      :class:`CppTuple`.  Materialized into a ``std::make_tuple`` only if the
+      suffix is actually used (it never is when a ``fst`` reads one element
+      out of it).
+    """
+    s: str
+    ty: CppType
+    off: int | None
 
 
 class _IndentedWriter:
@@ -1055,6 +1075,11 @@ class CppEmitter(Visitor):
         return None
 
     def _visit_unaryop(self, e: UnaryOp, ctx) -> str:
+        if isinstance(e, (Fst, Snd)):
+            # Tuple accessors fold as a chain (e.g. ``fst(snd(e))``) into a
+            # single ``std::get``, so they bypass the eager operand visit
+            # below — see ``_emit_tuple_accessor``.
+            return self._emit_tuple_accessor(e, ctx)
         arg = self._visit_expr(e.arg, ctx)
         match e:
             case Cast():
@@ -1087,24 +1112,6 @@ class CppEmitter(Visitor):
                 # differs from ``int64_t``.
                 result_ty = self._storage_for_expr(e)
                 return f'static_cast<{result_ty.format()}>({arg}.size())'
-            case Fst():
-                # tuple head — element 0 of the ``std::tuple``.
-                return f'std::get<0>({arg})'
-            case Snd():
-                # tuple tail. For a pair this is the bare second element;
-                # for a longer tuple it is a new tuple of the remaining
-                # elements (bind the operand to a temp so it is evaluated
-                # once across the several ``std::get``s).
-                storage = self._storage_for_expr(e.arg)
-                if not isinstance(storage, CppTuple):
-                    raise CppEmitError(f'snd expects a tuple, got {storage.format()}', at=e)
-                n = len(storage.elts)
-                if n == 2:
-                    return f'std::get<1>({arg})'
-                tmp = self._fresh_temp()
-                self.writer.add_line(f'auto {tmp} = {arg};')
-                gets = ', '.join(f'std::get<{i}>({tmp})' for i in range(1, n))
-                return f'std::make_tuple({gets})'
             case Sum():
                 # ``sum(xs)`` → ``std::accumulate(begin, end, T(0))``
                 # with ``T`` taken from format inference.
@@ -1124,6 +1131,59 @@ class CppEmitter(Visitor):
                 raise CppEmitError(
                     f'unsupported unary op: {type(e).__name__}', at=e,
                 )
+
+    def _emit_tuple_accessor(self, e: UnaryOp, ctx) -> str:
+        """Emit a (possibly nested) ``fst``/``snd`` chain.
+
+        The chain is folded to a single ``std::get`` whenever it reads one
+        element of a tuple — e.g. ``fst(snd(e))`` over a 3+-tuple is
+        ``std::get<1>(e)`` rather than ``std::get<0>`` of a freshly built
+        tail tuple.  Only a chain that genuinely yields a shorter tuple (a
+        ``snd`` whose result is still multi-element and is *not* consumed by
+        an outer ``fst``) materializes a ``std::make_tuple``.
+        """
+        acc = self._tuple_access(e, ctx)
+        if acc.off is None:
+            return acc.s
+        # Unconsumed tail: materialize the remaining elements as a new tuple,
+        # binding the base to a temp so it is evaluated once across the gets.
+        assert isinstance(acc.ty, CppTuple)
+        tmp = self._fresh_temp()
+        self.writer.add_line(f'auto {tmp} = {acc.s};')
+        gets = ', '.join(
+            f'std::get<{i}>({tmp})' for i in range(acc.off, len(acc.ty.elts))
+        )
+        return f'std::make_tuple({gets})'
+
+    def _tuple_access(self, e: Expr, ctx) -> _TupleAccess:
+        """Resolve a ``fst``/``snd`` chain over a tuple into a
+        :class:`_TupleAccess`, peeling the nesting and tracking the net
+        offset into the underlying base tuple."""
+        match e:
+            case Fst():
+                inner = self._tuple_access(e.arg, ctx)
+                base_s, base_ty = self._as_tuple(inner, e)
+                off = 0 if inner.off is None else inner.off
+                return _TupleAccess(f'std::get<{off}>({base_s})', base_ty.elts[off], None)
+            case Snd():
+                inner = self._tuple_access(e.arg, ctx)
+                base_s, base_ty = self._as_tuple(inner, e)
+                off = (0 if inner.off is None else inner.off) + 1
+                if len(base_ty.elts) - off == 1:
+                    # the tail is a single (bare) element
+                    return _TupleAccess(f'std::get<{off}>({base_s})', base_ty.elts[off], None)
+                return _TupleAccess(base_s, base_ty, off)
+            case _:
+                # opaque base: emit it once, treat as a finished value
+                return _TupleAccess(self._visit_expr(e, ctx), self._storage_for_expr(e), None)
+
+    def _as_tuple(self, acc: _TupleAccess, e: Expr) -> tuple[str, CppTuple]:
+        """The (base string, tuple type) of *acc*, which must be a tuple."""
+        if not isinstance(acc.ty, CppTuple):
+            raise CppEmitError(
+                f'tuple accessor expects a tuple, got {acc.ty.format()}', at=e,
+            )
+        return acc.s, acc.ty
 
     def _emit_enumerate(self, e: Enumerate, src_str: str) -> str:
         """``enumerate(xs)`` builds a ``std::vector<std::tuple<I, T>>``

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -1,5 +1,7 @@
 """Compilation from FPy to FPCore."""
 
+import dataclasses
+
 from typing import Callable
 
 import titanfp.fpbench.fpcast as fpc
@@ -11,10 +13,29 @@ from ..function import Function
 from ..module import Module, ModuleEntry
 from ..number import Context
 from ..transform import ConstFold, ForBundling, ForUnpack, IfBundling, WhileBundling
-from ..types import TupleType
+from ..types import TupleType, Type
 from ..utils import Gensym
 
 from .backend import Backend, CompileError
+
+
+@dataclasses.dataclass(frozen=True)
+class _TupleAccess:
+    """Resolved form of a folded ``fst``/``snd`` chain over a tuple.
+
+    - ``off is None`` — a finished value: ``e`` is its FPCore expression
+      (one ``ref`` for an element, or a non-accessor base) and ``ty`` its
+      type.
+    - ``off`` an ``int`` — the not-yet-materialized suffix ``base[off:]`` of
+      a tuple: ``e`` is the base expression and ``ty`` the base
+      :class:`TupleType`.  Built into a ``(let … (array …))`` only if the
+      suffix is actually used (never when an outer ``fst`` reads one element
+      out of it).
+    """
+    e: fpc.Expr
+    ty: Type
+    off: int | None
+
 
 # Cached table storage
 _nullary_table_cache: dict[type[NullaryOp], fpc.Expr] | None = None
@@ -370,34 +391,66 @@ class _FPCoreCompileInstance(Visitor):
         tup = self._visit_expr(arr, ctx)
         return fpc.Dim(tup)
 
-    def _tuple_arity(self, e: Expr) -> int:
-        # Type inference runs lazily here: only ``snd`` needs the operand's
-        # arity, and FPCore-sourced functions never contain tuple accessors,
-        # so the common case skips type checking entirely (and avoids
-        # imposing FPy's type system on round-tripped FPCore).
+    def _expr_type(self, e: Expr) -> Type:
+        # Type inference runs lazily: tuple accessors are the only consumer,
+        # and FPCore-sourced functions never contain them, so the common
+        # case skips type checking entirely (and avoids imposing FPy's type
+        # system on round-tripped FPCore).
         if self._type_info is None:
             self._type_info = TypeInfer.check(self.func)
         ty = self._type_info.by_expr.get(e)
-        if not isinstance(ty, TupleType):
-            raise FPCoreCompileError('expected a tuple operand', e)
-        return len(ty.elts)
+        if ty is None:
+            raise FPCoreCompileError('missing type for tuple accessor operand', e)
+        return ty
 
-    def _visit_fst(self, arr: Expr, ctx) -> fpc.Expr:
-        # tuple head — element 0 of the (array-encoded) tuple.
-        tup = self._visit_expr(arr, ctx)
-        return fpc.Ref(tup, fpc.Integer(0))
+    def _emit_tuple_accessor(self, e: UnaryOp, ctx) -> fpc.Expr:
+        """Emit a (possibly nested) ``fst``/``snd`` chain.
 
-    def _visit_snd(self, arr: Expr, ctx) -> fpc.Expr:
-        # tuple tail. For a pair this is the bare second element; for a
-        # longer tuple it is a new array of the remaining elements, binding
-        # the operand to a `let` so it is evaluated once.
-        n = self._tuple_arity(arr)
-        tup = self._visit_expr(arr, ctx)
-        if n == 2:
-            return fpc.Ref(tup, fpc.Integer(1))
+        A chain that reads one element folds to a single ``ref`` — e.g.
+        ``fst(snd(t))`` over a 3+-tuple is ``(ref t 1)`` rather than a
+        ``ref`` into a freshly built tail array.  Only an unconsumed
+        multi-element tail materializes a ``(let … (array …))``.
+        """
+        acc = self._tuple_access(e, ctx)
+        if acc.off is None:
+            return acc.e
+        # Unconsumed tail: build a new array of the remaining elements,
+        # binding the base to a `let` so it is evaluated once.
+        assert isinstance(acc.ty, TupleType)
         tuple_id = str(self.gensym.fresh('t'))
-        refs = [fpc.Ref(fpc.Var(tuple_id), fpc.Integer(i)) for i in range(1, n)]
-        return fpc.Let([(tuple_id, tup)], fpc.Array(*refs))
+        refs = [
+            fpc.Ref(fpc.Var(tuple_id), fpc.Integer(i))
+            for i in range(acc.off, len(acc.ty.elts))
+        ]
+        return fpc.Let([(tuple_id, acc.e)], fpc.Array(*refs))
+
+    def _tuple_access(self, e: Expr, ctx) -> _TupleAccess:
+        """Resolve a ``fst``/``snd`` chain over a tuple into a
+        :class:`_TupleAccess`, peeling the nesting and tracking the net
+        offset into the underlying base tuple."""
+        match e:
+            case Fst():
+                inner = self._tuple_access(e.arg, ctx)
+                base, base_ty = self._as_tuple(inner, e)
+                off = 0 if inner.off is None else inner.off
+                return _TupleAccess(fpc.Ref(base, fpc.Integer(off)), base_ty.elts[off], None)
+            case Snd():
+                inner = self._tuple_access(e.arg, ctx)
+                base, base_ty = self._as_tuple(inner, e)
+                off = (0 if inner.off is None else inner.off) + 1
+                if len(base_ty.elts) - off == 1:
+                    # the tail is a single (bare) element
+                    return _TupleAccess(fpc.Ref(base, fpc.Integer(off)), base_ty.elts[off], None)
+                return _TupleAccess(base, base_ty, off)
+            case _:
+                # opaque base: emit it once, treat as a finished value
+                return _TupleAccess(self._visit_expr(e, ctx), self._expr_type(e), None)
+
+    def _as_tuple(self, acc: _TupleAccess, e: Expr) -> tuple[fpc.Expr, TupleType]:
+        """The (base expr, tuple type) of *acc*, which must be a tuple."""
+        if not isinstance(acc.ty, TupleType):
+            raise FPCoreCompileError('expected a tuple operand', e)
+        return acc.e, acc.ty
 
     def _visit_enumerate(self, arr: Expr, ctx: None) -> fpc.Expr:
         # (let ([t <tuple>])
@@ -577,12 +630,10 @@ class _FPCoreCompileInstance(Visitor):
                 case Dim():
                     # dim expression
                     return self._visit_dim(e.arg, ctx)
-                case Fst():
-                    # tuple head accessor
-                    return self._visit_fst(e.arg, ctx)
-                case Snd():
-                    # tuple tail accessor
-                    return self._visit_snd(e.arg, ctx)
+                case Fst() | Snd():
+                    # tuple accessors — fold a chain (e.g. ``fst(snd(e))``)
+                    # into a single ``ref``.
+                    return self._emit_tuple_accessor(e, ctx)
                 case Enumerate():
                     # enumerate expression
                     return self._visit_enumerate(e.arg, ctx)

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -48,9 +48,15 @@ Two patterns are recognized:
    The transform leaves non-``Var``-argument zip comps alone; the
    cpp backend's emit-time fast path still optimizes them.
 
+A binding slot may itself be a nested ``TupleBinding`` (e.g.
+``for (a, b), c in zip(pairs, xs)``).  In the for-loop path the nested
+slot lowers to a destructuring assignment ``(a, b) = _srcK[_i]``; in the
+comp path — which has no statement context — each leaf name is reached by
+an ``fst``/``snd`` chain over ``argK[_i]`` (element ``i`` of a ``k``-tuple
+``t`` is ``fst(snd^i(t))``, or ``snd^(k-1)(t)`` for the last element).
+
 Patterns that don't match the guards (range iterables, mismatched
-arity, nested ``TupleBinding`` elements, non-``Var`` list-comp zip
-args) are left unchanged.
+arity, non-``Var`` list-comp zip args) are left unchanged.
 
 Ordering note: run :class:`ZipElim` *before*
 :class:`fpy2.transform.ForUnpack`.  ``ForUnpack`` rewrites
@@ -61,12 +67,12 @@ defeats this transform's guard.
 
 import dataclasses
 
-from typing import Any
+from typing import Any, Callable
 
 from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
 from ..ast.fpyast import (
-    Assign, Expr, ForStmt, FuncDef, Len, ListComp, ListRef, NamedId,
-    Range1, Stmt, StmtBlock, TupleBinding, UnderscoreId, Var, Zip,
+    Assign, Attribute, Expr, ForStmt, Fst, FuncDef, Len, ListComp, ListRef, NamedId,
+    Range1, Snd, Stmt, StmtBlock, TupleBinding, UnderscoreId, Var, Zip,
 )
 from ..ast.visitor import DefaultTransformVisitor
 from ..utils import Gensym, Id
@@ -89,12 +95,12 @@ class _Ctx:
 def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
     """Predicate for the for-loop / comp fast path.
 
-    Fires iff *iterable* is a :class:`Zip`, *target* is a
-    :class:`TupleBinding` of matching arity, and every element of
-    the binding is a :class:`NamedId` or :class:`UnderscoreId`.
-    Nested tuple bindings are out of scope — they'd require
-    recursive destructuring of each per-iteration element, which
-    isn't worth the complication.
+    Fires iff *iterable* is a :class:`Zip` and *target* is a
+    :class:`TupleBinding` of matching arity.  Each binding slot may be a
+    :class:`NamedId`, an :class:`UnderscoreId`, or a nested
+    :class:`TupleBinding` (the per-iteration element of a nested slot is
+    itself a tuple, destructured via the ``fst``/``snd`` accessors in the
+    comp path and via a destructuring assignment in the for-loop path).
     """
     if not isinstance(iterable, Zip):
         return False
@@ -103,9 +109,71 @@ def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
     if len(iterable.args) != len(target.elts):
         return False
     return all(
-        isinstance(e, (NamedId, UnderscoreId))
+        isinstance(e, (NamedId, UnderscoreId, TupleBinding))
         for e in target.elts
     )
+
+
+def _index_access(arg_name: NamedId, idx: NamedId) -> Callable[[], Expr]:
+    """A thunk building ``arg_name[idx]`` fresh on each call."""
+    return lambda: ListRef(Var(arg_name, None), Var(idx, None), None)
+
+
+def _fst(arg: Expr) -> Expr:
+    """Build ``fst(arg)``."""
+    name = Attribute(Var(NamedId('fp'), None), 'fst', None)
+    return Fst(name, arg, None)
+
+
+def _snd(arg: Expr) -> Expr:
+    """Build ``snd(arg)``."""
+    name = Attribute(Var(NamedId('fp'), None), 'snd', None)
+    return Snd(name, arg, None)
+
+
+def _snd_n(arg: Expr, n: int) -> Expr:
+    """Apply ``snd`` ``n`` times (``n == 0`` returns ``arg`` unchanged)."""
+    for _ in range(n):
+        arg = _snd(arg)
+    return arg
+
+
+def _elt_access(
+    make_access: Callable[[], Expr], i: int, k: int,
+) -> Callable[[], Expr]:
+    """A thunk for element ``i`` of the ``k``-tuple built by *make_access*.
+
+    Viewing a tuple as a binary pair, element ``i`` is ``fst(snd^i(t))`` for
+    ``i < k - 1`` and ``snd^(k-1)(t)`` for the last element (``snd`` of a
+    pair is the bare element).
+    """
+    if i < k - 1:
+        return lambda: _fst(_snd_n(make_access(), i))
+    return lambda: _snd_n(make_access(), k - 1)
+
+
+def _destructure_subst(
+    binding: Id | TupleBinding,
+    make_access: Callable[[], Expr],
+    subst: dict[NamedId, Expr],
+) -> None:
+    """Map every :class:`NamedId` in *binding* to an accessor expression.
+
+    *make_access* builds a *fresh* expression for the value bound to
+    *binding* (the per-iteration source element).  It is invoked once per
+    leaf, so no AST node is shared between substitutions.
+    """
+    match binding:
+        case NamedId():
+            subst[binding] = make_access()
+        case UnderscoreId():
+            pass
+        case TupleBinding():
+            k = len(binding.elts)
+            for i, elt in enumerate(binding.elts):
+                _destructure_subst(elt, _elt_access(make_access, i, k), subst)
+        case _:
+            raise RuntimeError(f'unexpected zip binding element: {binding!r}')
 
 
 class _SubstNames(DefaultTransformVisitor):
@@ -227,7 +295,11 @@ class _ZipElimInstance(DefaultTransformVisitor):
             match elt:
                 case UnderscoreId():
                     continue
-                case NamedId():
+                case NamedId() | TupleBinding():
+                    # ``NamedId`` -> ``a = src[i]``; a nested
+                    # ``TupleBinding`` -> ``(a, b) = src[i]``, whose
+                    # destructuring the backends already lower (the
+                    # statement context needs no ``fst``/``snd``).
                     per_iter.append(
                         Assign(
                             elt, None,
@@ -284,25 +356,15 @@ class _ZipElimInstance(DefaultTransformVisitor):
                 and all(isinstance(a, Var) for a in new_iter.args)
             ):
                 idx = self.gensym.fresh('_i')
-                # Build a substitution for each named binding slot:
-                # ``name -> arg[idx]``.  Underscore slots contribute
-                # no substitution.
+                # Substitute each binding slot with an accessor into its
+                # source: ``name -> arg[idx]`` for a plain slot, and the
+                # ``fst``/``snd`` chain for a nested tuple binding (whose
+                # per-iteration element is itself a tuple).
                 for binding, arg in zip(target.elts, new_iter.args):
-                    match binding:
-                        case NamedId():
-                            assert isinstance(arg, Var)
-                            subst[binding] = ListRef(
-                                Var(arg.name, None),
-                                Var(idx, None),
-                                None,
-                            )
-                        case UnderscoreId():
-                            continue
-                        case _:
-                            raise RuntimeError(
-                                f'unexpected binding element in zip '
-                                f'target: {binding!r}'
-                            )
+                    assert isinstance(arg, Var)
+                    _destructure_subst(
+                        binding, _index_access(arg.name, idx), subst,
+                    )
                 # New target/iterable: ``_i in range(len(arg0))``.
                 assert isinstance(new_iter.args[0], Var)
                 len_expr = Len(

--- a/tests/unit/backend/cpp/test_emit_tuple.py
+++ b/tests/unit/backend/cpp/test_emit_tuple.py
@@ -202,3 +202,65 @@ class TestTupleAccessors:
         assert 'std::make_tuple(' in out
         assert 'std::get<1>(' in out
         assert 'std::get<2>(' in out
+
+    def test_fst_snd_chain_folds_to_single_get(self):
+        """``fst(snd(p))`` over a 3-tuple reads element 1 directly — one
+        ``std::get<1>``, with no intermediate ``std::make_tuple``."""
+        @fp.fpy
+        def f(p: tuple[fp.Real, fp.Real, fp.Real]) -> fp.Real:
+            return fp.fst(fp.snd(p))
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64,
+            arg_types=[TupleType(RealType(fp.FP64), RealType(fp.FP64), RealType(fp.FP64))],
+        )
+        assert 'std::get<1>(p)' in out
+        assert 'make_tuple' not in out
+
+    def test_deep_chain_folds_to_single_get(self):
+        """``fst(snd(snd(p)))`` over a 4-tuple folds to ``std::get<2>``."""
+        @fp.fpy
+        def f(p: tuple[fp.Real, fp.Real, fp.Real, fp.Real]) -> fp.Real:
+            return fp.fst(fp.snd(fp.snd(p)))
+
+        R = RealType(fp.FP64)
+        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[TupleType(R, R, R, R)])
+        assert 'std::get<2>(p)' in out
+        assert 'make_tuple' not in out
+
+    def test_all_snd_chain_to_bare_element_folds(self):
+        """``snd(snd(p))`` over a 3-tuple is the bare last element —
+        ``std::get<2>``, no ``make_tuple``."""
+        @fp.fpy
+        def f(p: tuple[fp.Real, fp.Real, fp.Real]) -> fp.Real:
+            return fp.snd(fp.snd(p))
+
+        R = RealType(fp.FP64)
+        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[TupleType(R, R, R)])
+        assert 'std::get<2>(p)' in out
+        assert 'make_tuple' not in out
+
+    def test_unconsumed_tail_still_materializes(self):
+        """A ``snd`` whose multi-element tail is the actual result (not
+        consumed by an outer ``fst``) still builds a ``std::make_tuple``."""
+        @fp.fpy
+        def f(p: tuple[fp.Real, fp.Real, fp.Real, fp.Real]) -> tuple[fp.Real, fp.Real, fp.Real]:
+            return fp.snd(p)
+
+        R = RealType(fp.FP64)
+        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[TupleType(R, R, R, R)])
+        assert 'std::make_tuple(' in out
+        assert 'std::get<3>(' in out
+
+    def test_nested_element_tuple_rebases(self):
+        """When ``snd`` yields a bare element that is itself a tuple, an
+        outer ``fst`` indexes into it (a fresh base)."""
+        @fp.fpy
+        def f(p: tuple[fp.Real, tuple[fp.Real, fp.Real]]) -> fp.Real:
+            return fp.fst(fp.snd(p))
+
+        R = RealType(fp.FP64)
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[TupleType(R, TupleType(R, R))],
+        )
+        assert 'std::get<0>(std::get<1>(p))' in out

--- a/tests/unit/backend/test_fpc_tuple.py
+++ b/tests/unit/backend/test_fpc_tuple.py
@@ -41,3 +41,47 @@ class TestTupleAccessors:
 
         # tail of a 3-tuple -> an array of the last two elements
         assert '(array (ref' in _compile(f)
+
+    def test_fst_snd_chain_folds_to_single_ref(self):
+        """``fst(snd(t))`` over a 3-tuple folds to ``(ref t 1)`` — no
+        intermediate tail array."""
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
+            t = (a, b, c)
+            return fp.fst(fp.snd(t))
+
+        s = _compile(f)
+        assert '(ref t 1)' in s
+        assert 'array (ref' not in s
+
+    def test_deep_chain_folds_to_single_ref(self):
+        """``fst(snd(snd(t)))`` over a 4-tuple folds to ``(ref t 2)``."""
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real, c: fp.Real, d: fp.Real) -> fp.Real:
+            t = (a, b, c, d)
+            return fp.fst(fp.snd(fp.snd(t)))
+
+        s = _compile(f)
+        assert '(ref t 2)' in s
+        assert 'array (ref' not in s
+
+    def test_all_snd_chain_to_bare_element_folds(self):
+        """``snd(snd(t))`` over a 3-tuple is the bare last element ``(ref t 2)``."""
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
+            t = (a, b, c)
+            return fp.snd(fp.snd(t))
+
+        s = _compile(f)
+        assert '(ref t 2)' in s
+        assert 'array (ref' not in s
+
+    def test_unconsumed_tail_still_materializes(self):
+        """A multi-element tail that is the result still builds an array."""
+        @fp.fpy
+        def f(a: fp.Real, b: fp.Real, c: fp.Real, d: fp.Real):
+            t = (a, b, c, d)
+            return fp.snd(t)
+
+        s = _compile(f)
+        assert '(array (ref' in s

--- a/tests/unit/transform/test_zip_elim.py
+++ b/tests/unit/transform/test_zip_elim.py
@@ -21,7 +21,8 @@ the original AST is sufficient and stable.
 import fpy2 as fp
 
 from fpy2.ast.fpyast import (
-    Assign, ForStmt, Len, ListComp, ListRef, NamedId, Range1, Var, Zip,
+    Assign, ForStmt, Fst, Len, ListComp, ListRef, NamedId, Range1, Snd,
+    TupleBinding, Var, Zip,
 )
 from fpy2.transform import ZipElim
 
@@ -267,3 +268,93 @@ class TestProperties:
 
         # Should not raise.
         ZipElim.apply(f.ast)
+
+
+def _contains(ast: fp.ast.FuncDef, types) -> bool:
+    """True iff any sub-expression of *ast* is an instance of *types*."""
+    from fpy2.ast.visitor import DefaultVisitor
+
+    hits: list = []
+
+    class _C(DefaultVisitor):
+        def _visit_expr(self, e, ctx):
+            if isinstance(e, types):
+                hits.append(e)
+            return super()._visit_expr(e, ctx)
+
+    _C()._visit_function(ast, None)
+    return bool(hits)
+
+
+class TestNestedTupleBinding:
+    """Zip targets with a nested ``TupleBinding`` slot — newly supported
+    via the ``fst``/``snd`` accessors (comp path) and a destructuring
+    assignment (for-loop path)."""
+
+    def test_for_loop_nested_binding(self):
+        @fp.fpy
+        def f(pairs: list[tuple[fp.Real, fp.Real]], xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for (a, b), c in zip(pairs, xs):
+                    acc = acc + a + b + c
+                return acc
+
+        new_ast = ZipElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        assert isinstance(loop.iterable, Range1)
+        # The nested slot lowers to a destructuring assign (TupleBinding
+        # target); the plain ``c`` slot to a ListRef assign.
+        body = loop.body.stmts
+        assert any(
+            isinstance(s, Assign) and isinstance(s.target, TupleBinding)
+            for s in body
+        )
+        assert not _contains(new_ast, Zip)
+        pairs = [(1.0, 2.0), (3.0, 4.0)]
+        xs = [10.0, 20.0]
+        assert _eval(new_ast, f, pairs, xs) == f(pairs, xs)
+
+    def test_list_comp_nested_binding(self):
+        @fp.fpy
+        def f(pairs: list[tuple[fp.Real, fp.Real]], xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [a + b + c for (a, b), c in zip(pairs, xs)]
+
+        new_ast = ZipElim.apply(f.ast)
+        comp = _find_listcomp(new_ast)
+        # Rewritten to a range-indexed comp; the nested slot's elements are
+        # reached by fst/snd accessors in the elt.
+        assert isinstance(comp.iterables[0], Range1)
+        assert isinstance(comp.targets[0], NamedId)
+        assert not _contains(new_ast, Zip)
+        assert _contains(new_ast, (Fst, Snd))
+        pairs = [(1.0, 2.0), (3.0, 4.0)]
+        xs = [10.0, 20.0]
+        assert list(_eval(new_ast, f, pairs, xs)) == list(f(pairs, xs))
+
+    def test_list_comp_deeply_nested_binding(self):
+        @fp.fpy
+        def f(
+            ps: list[tuple[tuple[fp.Real, fp.Real], fp.Real]], xs: list[fp.Real]
+        ) -> list[fp.Real]:
+            with fp.FP64:
+                return [a + b + c + d for ((a, b), c), d in zip(ps, xs)]
+
+        new_ast = ZipElim.apply(f.ast)
+        assert not _contains(new_ast, Zip)
+        ps = [((1.0, 2.0), 3.0), ((4.0, 5.0), 6.0)]
+        xs = [10.0, 20.0]
+        assert list(_eval(new_ast, f, ps, xs)) == list(f(ps, xs))
+
+    def test_underscore_inside_nested_binding(self):
+        @fp.fpy
+        def f(pairs: list[tuple[fp.Real, fp.Real]], xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [b + c for (_, b), c in zip(pairs, xs)]
+
+        new_ast = ZipElim.apply(f.ast)
+        assert not _contains(new_ast, Zip)
+        pairs = [(99.0, 2.0), (99.0, 4.0)]
+        xs = [10.0, 20.0]
+        assert list(_eval(new_ast, f, pairs, xs)) == list(f(pairs, xs))


### PR DESCRIPTION
Follow on PR to #212 .
- expands zip elimination to list comprehensions with tuple destructuring
- optimizes C++ compilation for nested accessors: `fst(snd(e)) => std::get<1>(e)`
- optimizes FPCore compilation for nested accessors