### PR TITLE
Release v0.1.11

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # Version History
 
+## [0.1.11] - 2026-06-30
+### Features:
+ - Analyses:
+   - extend `ZipElim` to list comprehensions with tuple destructuring
+ - Language:
+   - add tuple accessors `fst` and `snd`
+ - Misc:
+   - list type (annotations) carry an optional size parameter for static sizing
+
 ## [0.1.10] - 2026-06-29
 ### Features:
  - Analyses:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpy2"
-version = "0.1.10"
+version = "0.1.11"
 authors = [ 
   { name="Brett Saiki", email="bsaiki@cs.washington.edu" }
 ]


### PR DESCRIPTION
Changes for release 0.1.11.

> ## [0.1.11] - 2026-06-30
> ### Features:
>  - Analyses:
>    - extend `ZipElim` to list comprehensions with tuple destructuring
>  - Language:
>    - add tuple accessors `fst` and `snd`
>  - Misc:
>    - list type (annotations) carry an optional size parameter for static sizing