### PR TITLE
Various fixes

### DIFF
--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -186,6 +186,26 @@ class SetFormat:
         return SetFormat(frozenset((x,)))
 
 
+def _free_var_set_format(val: object) -> 'SetFormat | None':
+    """Singleton :class:`SetFormat` for a captured numeric free variable, or
+    ``None`` if *val* has no exact finite rational form (non-numeric, or a
+    non-finite ``Float``/``float``)."""
+    match val:
+        case Fraction():
+            return SetFormat.from_value(val)
+        case Float():
+            return SetFormat.from_value(val.as_rational()) if val.is_finite() else None
+        case RealFloat():
+            return SetFormat.from_value(Fraction(val))
+        case int() | float():
+            try:
+                return SetFormat.from_value(Fraction(val))
+            except (ValueError, OverflowError):
+                return None  # non-finite float
+        case _:
+            return None
+
+
 @dataclass(frozen=True)
 class TupleFormat:
     """Format for a tuple-valued expression."""
@@ -1636,26 +1656,14 @@ class _FormatInferInstance(Visitor):
                 self._set_def_bound(d, params[i])
             else:
                 self._set_def_bound(d, param_from_type(self.type_info.by_def[d]))
-        # Free-variable defs (captured from an outer scope)
+        # Free-variable defs (captured from an outer scope).  A finite numeric
+        # capture pins the def to the singleton set {value}; anything else
+        # falls back to the type-derived bound.
         for v in func.free_vars:
             d = self.def_use.find_def_from_site(v, func)
-            val = self.func.env[str(d.name)]
-            match val:
-                case Fraction():
-                    # map to SetFormat(v)
-                    fmt: FormatBound = SetFormat.from_value(val)
-                case int() | float() | RealFloat():
-                    # map to SetFormat(v)
-                    fmt = SetFormat.from_value(Fraction(val))
-                case Float():
-                    # map to SetFormat
-                    if val.is_finite():
-                        fmt = SetFormat.from_value(val.as_rational())
-                    else:
-                        fmt = SetFormat.from_value(Fraction(0))
-                case _:
-                    fmt = param_from_type(self.type_info.by_def[d])
-
+            fmt = _free_var_set_format(self.func.env[str(v)])
+            if fmt is None:
+                fmt = param_from_type(self.type_info.by_def[d])
             self._set_def_bound(d, fmt)
 
         # Walk the body — populates ``by_def`` / ``by_expr`` / ``by_call``.

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -132,11 +132,8 @@ from typing import Any, Callable, Iterable, TypeAlias
 from ...ast.fpyast import *
 from ...ast.visitor import Visitor
 from ...function import Function
-from ...number import Context, INTEGER
-from ...number.context.format import Format
-from ...number import REAL
-from ...number.context.real import REAL_FORMAT
-from ...number.number.reals import RealFloat
+from ...number import Context, Float, RealFloat, INTEGER, REAL
+from ...number.format import Format, REAL_FORMAT
 from ...utils import is_dyadic
 from ...types import (
     Type,
@@ -183,6 +180,10 @@ class SetFormat:
     widens to ``REAL_FORMAT``).
     """
     values: frozenset[Fraction]
+
+    @staticmethod
+    def from_value(x: Fraction):
+        return SetFormat(frozenset((x,)))
 
 
 @dataclass(frozen=True)
@@ -404,7 +405,7 @@ def _to_abstract(f: AbstractableFormatBound | SetFormat) -> AbstractFormat | Non
     else:
         return _setformat_to_abstract(f)
 
-_ZERO_SET: 'SetFormat' = SetFormat(frozenset((Fraction(0),)))
+_ZERO_SET: 'SetFormat' = SetFormat.from_value(Fraction(0))
 
 
 def _is_zero_set(f: 'FormatBound') -> bool:
@@ -1039,19 +1040,19 @@ class _FormatInferInstance(Visitor):
 
     # Numeric literals: exact real values bounded by the singleton set {v}
     def _visit_decnum(self, e: Decnum, ctx: None) -> FormatBound:
-        return SetFormat(frozenset((e.as_rational(),)))
+        return SetFormat.from_value(e.as_rational())
 
     def _visit_hexnum(self, e: Hexnum, ctx: None) -> FormatBound:
-        return SetFormat(frozenset((e.as_rational(),)))
+        return SetFormat.from_value(e.as_rational())
 
     def _visit_integer(self, e: Integer, ctx: None) -> FormatBound:
-        return SetFormat(frozenset((e.as_rational(),)))
+        return SetFormat.from_value(e.as_rational())
 
     def _visit_rational(self, e: Rational, ctx: None) -> FormatBound:
-        return SetFormat(frozenset((e.as_rational(),)))
+        return SetFormat.from_value(e.as_rational())
 
     def _visit_digits(self, e: Digits, ctx: None) -> FormatBound:
-        return SetFormat(frozenset((e.as_rational(),)))
+        return SetFormat.from_value(e.as_rational())
 
     # Non-real-valued leaves
     def _visit_bool(self, e: BoolVal, ctx: None) -> FormatBound:
@@ -1180,7 +1181,7 @@ class _FormatInferInstance(Visitor):
 
         # ``sum([])`` is conventionally 0 — fits trivially in any scope.
         if n == 0:
-            return SetFormat(frozenset((Fraction(0),)))
+            return SetFormat.from_value(Fraction(0))
 
         elt_fmt = arg_fmt.elt
         # Single-element reduction: ``sum([x])`` evaluates to
@@ -1638,7 +1639,24 @@ class _FormatInferInstance(Visitor):
         # Free-variable defs (captured from an outer scope)
         for v in func.free_vars:
             d = self.def_use.find_def_from_site(v, func)
-            self._set_def_bound(d, param_from_type(self.type_info.by_def[d]))
+            val = self.func.env[str(d.name)]
+            match val:
+                case Fraction():
+                    # map to SetFormat(v)
+                    fmt: FormatBound = SetFormat.from_value(val)
+                case int() | float() | RealFloat():
+                    # map to SetFormat(v)
+                    fmt = SetFormat.from_value(Fraction(val))
+                case Float():
+                    # map to SetFormat
+                    if val.is_finite():
+                        fmt = SetFormat.from_value(val.as_rational())
+                    else:
+                        fmt = SetFormat.from_value(Fraction(0))
+                case _:
+                    fmt = param_from_type(self.type_info.by_def[d])
+
+            self._set_def_bound(d, fmt)
 
         # Walk the body — populates ``by_def`` / ``by_expr`` / ``by_call``.
         self._visit_block(func.body, ctx)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -1661,7 +1661,7 @@ class _FormatInferInstance(Visitor):
         # falls back to the type-derived bound.
         for v in func.free_vars:
             d = self.def_use.find_def_from_site(v, func)
-            fmt = _free_var_set_format(self.func.env[str(v)])
+            fmt: FormatBound = _free_var_set_format(self.func.env[str(v)])
             if fmt is None:
                 fmt = param_from_type(self.type_info.by_def[d])
             self._set_def_bound(d, fmt)

--- a/fpy2/analysis/partial_eval.py
+++ b/fpy2/analysis/partial_eval.py
@@ -85,9 +85,8 @@ class _PartialEvalInstance(DefaultVisitor):
 
     def _base_env(self) -> dict[NamedId, object]:
         return {
-            NamedId(d): self.func.env[d]
-            for d in self.func.env
-            if isinstance(self.func.env[d], ModuleType)
+            d: self.func.env[str(d)]
+            for d in self.func.free_vars
         }
 
     def _is_value(self, e: Expr) -> bool:

--- a/fpy2/analysis/partial_eval.py
+++ b/fpy2/analysis/partial_eval.py
@@ -138,13 +138,15 @@ class _PartialEvalInstance(DefaultVisitor):
         self.by_expr[e] = e.val
 
     def _visit_decnum(self, e: Decnum, ctx: Context | None):
-        self.by_expr[e] = e.as_rational()
+        # `as_real` (not `as_rational`) so a `-0.0` literal folds to a signed
+        # zero rather than collapsing to `+0.0`.
+        self.by_expr[e] = e.as_real()
 
     def _visit_integer(self, e: Integer, ctx: Context | None):
         self.by_expr[e] = e.as_rational()
 
     def _visit_hexnum(self, e: Hexnum, ctx: Context | None):
-        self.by_expr[e] = e.as_rational()
+        self.by_expr[e] = e.as_real()
 
     def _visit_rational(self, e: Rational, ctx: Context | None):
         self.by_expr[e] = e.as_rational()

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -352,18 +352,16 @@ class _TypeInferInstance(Visitor):
                     self._unify(arg_ty, ListType(self._fresh_type_var()))
                     return RealType(None)
                 case Fst():
-                    # tuple head accessor: `fst` is the first projection of a
-                    # pair. Unify the operand with a fresh pair `(head, tail)` and
-                    # let unification do the checking — this both constrains an
-                    # open type variable and rejects non-pairs (a `real`, a list,
-                    # or a tuple of arity != 2). See the OCaml `fst : 'a * 'b -> 'a`.
+                    # `fst : 'a * 'b -> 'a`, the first projection of a pair.
+                    # Unifying the operand with a fresh pair both constrains an
+                    # open type variable and rejects non-pairs (a real, a list,
+                    # or a tuple of arity != 2).
                     head = self._fresh_type_var()
                     tail = self._fresh_type_var()
                     self._unify(arg_ty, TupleType(head, tail))
                     return head
                 case Snd():
-                    # tuple tail accessor: `snd` is the second projection of a
-                    # pair (see `Fst`).
+                    # `snd : 'a * 'b -> 'b`, the second projection (see `Fst`).
                     head = self._fresh_type_var()
                     tail = self._fresh_type_var()
                     self._unify(arg_ty, TupleType(head, tail))

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -352,21 +352,22 @@ class _TypeInferInstance(Visitor):
                     self._unify(arg_ty, ListType(self._fresh_type_var()))
                     return RealType(None)
                 case Fst():
-                    # tuple head accessor. A tuple's arity cannot be unified
-                    # from an open type, so the operand must resolve to a
-                    # concrete tuple; the head exists for any non-empty tuple.
-                    resolved = self._resolve_type(arg_ty)
-                    if not isinstance(resolved, TupleType) or len(resolved.elts) < 1:
-                        raise TypeInferError(f'`fst` requires a non-empty tuple, got `{resolved.format()}`')
-                    return resolved.elts[0]
+                    # tuple head accessor: `fst` is the first projection of a
+                    # pair. Unify the operand with a fresh pair `(head, tail)` and
+                    # let unification do the checking — this both constrains an
+                    # open type variable and rejects non-pairs (a `real`, a list,
+                    # or a tuple of arity != 2). See the OCaml `fst : 'a * 'b -> 'a`.
+                    head = self._fresh_type_var()
+                    tail = self._fresh_type_var()
+                    self._unify(arg_ty, TupleType(head, tail))
+                    return head
                 case Snd():
-                    # tuple tail accessor. The tail exists only for arity >= 2;
-                    # it is the bare element for a pair, else the rest tuple.
-                    resolved = self._resolve_type(arg_ty)
-                    if not isinstance(resolved, TupleType) or len(resolved.elts) < 2:
-                        raise TypeInferError(f'`snd` requires a tuple of at least 2 elements, got `{resolved.format()}`')
-                    rest = resolved.elts[1:]
-                    return rest[0] if len(rest) == 1 else TupleType(*rest)
+                    # tuple tail accessor: `snd` is the second projection of a
+                    # pair (see `Fst`).
+                    head = self._fresh_type_var()
+                    tail = self._fresh_type_var()
+                    self._unify(arg_ty, TupleType(head, tail))
+                    return tail
                 case Enumerate():
                     # enumerate operator
                     ty = self._fresh_type_var()

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -9,7 +9,7 @@ from fractions import Fraction
 
 from ..env import ForeignEnv
 from ..fpc_context import FPCoreContext
-from ..number import Context
+from ..number import Context, Float
 from ..utils import (
     CompareOp,
     Id, NamedId, SourceId, UnderscoreId,
@@ -434,6 +434,17 @@ class RationalVal(RealVal):
         """Returns the represented rational value as a Fraction in simplest form."""
         ...
 
+    def as_real(self) -> 'Fraction | Float':
+        """
+        Returns the represented value as an exact real number.
+
+        Unlike `as_rational`, this preserves the sign of a zero: a `Fraction`
+        cannot represent negative zero, so a negative-zero literal is returned as
+        an exact `Float`. Prefer this over `as_rational` when the sign of a zero
+        is significant, e.g. when lowering a literal to a runtime value.
+        """
+        return self.as_rational()
+
     def is_integer(self) -> bool:
         """Returns true if the represented value is an integer."""
         return self.as_rational().denominator == 1
@@ -454,6 +465,13 @@ class Decnum(RationalVal):
     def as_rational(self) -> Fraction:
         return decnum_to_fraction(self.val)
 
+    def as_real(self) -> 'Fraction | Float':
+        r = self.as_rational()
+        if r == 0 and self.val.lstrip().startswith('-'):
+            # negative zero: not representable as a `Fraction`
+            return Float(s=True, exp=0, c=0)
+        return r
+
 class Hexnum(RationalVal):
     """FPy AST: hexadecimal number"""
     __slots__ = ('func', 'val')
@@ -470,6 +488,13 @@ class Hexnum(RationalVal):
 
     def as_rational(self) -> Fraction:
         return hexnum_to_fraction(self.val)
+
+    def as_real(self) -> 'Fraction | Float':
+        r = self.as_rational()
+        if r == 0 and self.val.lstrip().startswith('-'):
+            # negative zero: not representable as a `Fraction`
+            return Float(s=True, exp=0, c=0)
+        return r
 
 class Integer(RationalVal):
     """FPy AST: integer"""

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -435,13 +435,12 @@ class RationalVal(RealVal):
         ...
 
     def as_real(self) -> 'Fraction | Float':
-        """
-        Returns the represented value as an exact real number.
+        """Returns the represented value as an exact real number.
 
-        Unlike `as_rational`, this preserves the sign of a zero: a `Fraction`
-        cannot represent negative zero, so a negative-zero literal is returned as
-        an exact `Float`. Prefer this over `as_rational` when the sign of a zero
-        is significant, e.g. when lowering a literal to a runtime value.
+        Unlike `as_rational`, this preserves the sign of a zero: a negative-zero
+        literal is returned as an exact `Float` (a `Fraction` cannot represent
+        one). Prefer this when the sign of a zero matters, e.g. when lowering a
+        literal to a runtime value.
         """
         return self.as_rational()
 

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -52,7 +52,7 @@ from ...ast.fpyast import (
     WhileStmt, Zip,
 )
 from ...ast.visitor import Visitor
-from ...number import EFloatContext, MPFixedContext, MPBFixedContext, REAL, RM
+from ...number import EFloatContext, Float, MPFixedContext, MPBFixedContext, REAL, RM
 from ...number.context.context import Context
 
 from ...analysis.format_infer import (
@@ -779,10 +779,10 @@ class CppEmitter(Visitor):
         return self._name_for_var_use(e)
 
     def _visit_decnum(self, e: Decnum, ctx) -> str:
-        return self._emit_numeric_literal(e.as_rational())
+        return self._emit_real_literal(e.as_real())
 
     def _visit_hexnum(self, e: Hexnum, ctx) -> str:
-        return self._emit_numeric_literal(e.as_rational())
+        return self._emit_real_literal(e.as_real())
 
     def _visit_integer(self, e: Integer, ctx) -> str:
         # Integer literals print directly.
@@ -793,6 +793,14 @@ class CppEmitter(Visitor):
 
     def _visit_digits(self, e: Digits, ctx) -> str:
         return self._emit_numeric_literal(e.as_rational())
+
+    def _emit_real_literal(self, v: 'Fraction | Float') -> str:
+        """Emit an exact-real literal, preserving the sign of a negative zero
+        (which has no `Fraction` form; see `RationalVal.as_real`)."""
+        if isinstance(v, Float):
+            # negative zero is the only non-`Fraction` real `as_real` produces
+            return '-0.0'
+        return self._emit_numeric_literal(v)
 
     def _emit_numeric_literal(self, v: Fraction) -> str:
         """

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -352,10 +352,9 @@ class Parser:
             case ast.USub():
                 arg = self._parse_expr(e.operand)
                 if isinstance(arg, RationalVal) and arg.as_rational() == 0:
-                    # Negating a zero literal yields negative zero: a signed
-                    # literal, not a `Neg` operation (which is rounded under the
-                    # current context, and yields a signed zero even under an
-                    # exact context). See `RationalVal.as_real`.
+                    # Negating a zero literal yields negative zero, a signed
+                    # literal — fold it here so the sign survives regardless of
+                    # context (a `Neg` under REAL loses it). See `as_real`.
                     return Decnum('-0.0', loc)
                 elif isinstance(arg, Integer):
                     return Integer(-arg.val, loc)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -264,9 +264,7 @@ class Parser:
             case int():
                 return Integer(e.value, loc)
             case float():
-                # Do not fold `0.0` to an integer: it must stay a float so that
-                # negation (`-0.0`) yields negative zero rather than integer 0.
-                if e.value.is_integer() and e.value != 0.0:
+                if e.value.is_integer():
                     return Integer(int(e.value), loc)
                 else:
                     return Decnum(str(e.value), loc)
@@ -353,7 +351,13 @@ class Parser:
                 return self._parse_expr(e.operand)
             case ast.USub():
                 arg = self._parse_expr(e.operand)
-                if isinstance(arg, Integer):
+                if isinstance(arg, RationalVal) and arg.as_rational() == 0:
+                    # Negating a zero literal yields negative zero: a signed
+                    # literal, not a `Neg` operation (which is rounded under the
+                    # current context, and yields a signed zero even under an
+                    # exact context). See `RationalVal.as_real`.
+                    return Decnum('-0.0', loc)
+                elif isinstance(arg, Integer):
                     return Integer(-arg.val, loc)
                 else:
                     return Neg(arg, loc)

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -264,7 +264,9 @@ class Parser:
             case int():
                 return Integer(e.value, loc)
             case float():
-                if e.value.is_integer():
+                # Do not fold `0.0` to an integer: it must stay a float so that
+                # negation (`-0.0`) yields negative zero rather than integer 0.
+                if e.value.is_integer() and e.value != 0.0:
                     return Integer(int(e.value), loc)
                 else:
                     return Decnum(str(e.value), loc)

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -97,6 +97,10 @@ def _cvt_return_value(x: Value):
 def _cvt_return(x: Value):
     return x if _is_return_value(x) else _cvt_return_value(x)
 
+def _neg_zero() -> Float:
+    """Constructs an exact negative zero (not representable as a `Fraction`)."""
+    return Float(s=True, exp=0, c=0)
+
 def _cvt_float(x: Value):
     match x:
         case Float():
@@ -514,6 +518,7 @@ def make_namespace() -> dict[str, object]:
     namespace = {
         '__fpy_call': _eval_call,
         '__fpy_fraction': Fraction,
+        '__fpy_negzero': _neg_zero,
         '__fpy_int': _cvt_int,
         '__fpy_list_set': _eval_list_set,
         '__fpy_list_slice': _eval_list_slice,
@@ -602,8 +607,18 @@ class BytecodeCompiler(Visitor):
             }
 
     def _rational_to_ast(self, e: RationalVal) -> pyast.Call:
-        val = e.as_rational()
+        val = e.as_real()
         attrs = self._location_to_attributes(e.loc)
+        if isinstance(val, Float):
+            # negative zero: a signed zero cannot be constructed from a
+            # `Fraction`, so emit the exact real value directly (see
+            # `RationalVal.as_real`).
+            return pyast.Call(
+                func=pyast.Name(id='__fpy_negzero', ctx=pyast.Load(), **attrs),
+                args=[],
+                keywords=[],
+                **attrs
+            )
         return pyast.Call(
             func=pyast.Name(id='__fpy_fraction', ctx=pyast.Load(), **attrs),
             args=[

--- a/fpy2/number/__init__.py
+++ b/fpy2/number/__init__.py
@@ -1,5 +1,3 @@
-
-
 # Numbers
 from .number import Float, RealFloat, Real
 

--- a/fpy2/ops.py
+++ b/fpy2/ops.py
@@ -1081,26 +1081,19 @@ def size(x: list, dim: Real, ctx: Context = REAL):
 
 def fst(x, ctx: Context = REAL):
     """
-    Returns the first element (head) of the tuple `x`.
-
-    Viewing a tuple as a binary pair, `fst((a, b)) == a`. Defined for any
-    non-empty tuple (the head of a 1-tuple is its sole element).
+    Returns the first element `x` of a pair `(x, y)`.
     """
-    if len(x) < 1:
-        raise ValueError(f'fst requires a non-empty tuple, got `{x}`')
+    if len(x) != 2:
+        raise ValueError(f'fst requires a pair, got `{x}`')
     return x[0]
 
 def snd(x, ctx: Context = REAL):
     """
-    Returns the rest (tail) of the tuple `x`.
-
-    Viewing a tuple as a binary pair, `snd((a, b)) == b`; for a longer
-    tuple the tail is the tuple of the remaining elements. Requires a tuple
-    of at least 2 elements (a pair has no tail unless a second element exists).
+    Returns the second element `y` of a pair `(x, y)`.
     """
-    if len(x) < 2:
-        raise ValueError(f'snd requires a tuple of at least 2 elements, got `{x}`')
-    return x[1] if len(x) == 2 else tuple(x[1:])
+    if len(x) != 2:
+        raise ValueError(f'snd requires a pair, got `{x}`')
+    return x[1]
 
 #############################################################################
 # Constants

--- a/fpy2/rewrite/matcher.py
+++ b/fpy2/rewrite/matcher.py
@@ -6,10 +6,25 @@ from fractions import Fraction
 
 from ..ast import *
 from ..function import Function
+from ..number import Float
 from ..utils import default_repr, sliding_window
 
 from .pattern import Pattern, ExprPattern, StmtPattern
 from .subst import Subst
+
+
+def _real_eq(a: 'Fraction | Float', b: 'Fraction | Float') -> bool:
+    """Signed-zero-aware equality of two exact-real literal values.
+
+    `RationalVal.as_real` returns a `Float` only for negative zero, which is
+    otherwise `==` to `+0.0` under IEEE semantics. Treat a negative-zero literal
+    as equal only to another negative zero, so a rule keyed on `+0.0` does not
+    match `-0.0` (which would be unsound, e.g. `x + 0.0 -> x` at `x = -0.0`)."""
+    a_negzero = isinstance(a, Float)
+    b_negzero = isinstance(b, Float)
+    if a_negzero or b_negzero:
+        return a_negzero and b_negzero
+    return a == b
 
 class _MatchFailure(Exception):
     """
@@ -129,13 +144,14 @@ class _MatcherInst(Visitor):
             raise _MatchFailure(f'matching {pat} against {e}')
 
     def _visit_decnum(self, e: Decnum, pat: Decnum):
-        # this is a semantic match, not a syntactic match!
-        if e.as_rational() != pat.as_rational():
+        # semantic match, not syntactic — but signed-zero aware: `-0.0` and
+        # `+0.0` are distinct (see `_real_eq` / `RationalVal.as_real`).
+        if not _real_eq(e.as_real(), pat.as_real()):
             raise _MatchFailure(f'matching {pat} against {e}')
 
     def _visit_hexnum(self, e: Hexnum, pat: Hexnum):
-        # this is a semantic match, not a syntactic match!
-        if e.as_rational() != pat.as_rational():
+        # semantic match, not syntactic — signed-zero aware (see `_visit_decnum`).
+        if not _real_eq(e.as_real(), pat.as_real()):
             raise _MatchFailure(f'matching {pat} against {e}')
 
     def _visit_integer(self, e: Integer, pat: Integer):

--- a/fpy2/transform/const_fold.py
+++ b/fpy2/transform/const_fold.py
@@ -47,6 +47,9 @@ class _ConstFoldInstance(DefaultTransformVisitor):
         if isinstance(val, bool):
             return BoolVal(val, loc)
         if isinstance(val, Float):
+            if val.is_zero() and val.s:
+                # negative zero has no `Fraction` form; emit a signed literal
+                return Decnum('-0.0', loc)
             val = val.as_rational()
         elif isinstance(val, (int, float)):
             val = Fraction(val)

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -50,10 +50,14 @@ Two patterns are recognized:
 
 A binding slot may itself be a nested ``TupleBinding`` (e.g.
 ``for (a, b), c in zip(pairs, xs)``).  In the for-loop path the nested
-slot lowers to a destructuring assignment ``(a, b) = _srcK[_i]``; in the
-comp path — which has no statement context — each leaf name is reached by
-an ``fst``/``snd`` chain over ``argK[_i]`` (element ``i`` of a ``k``-tuple
-``t`` is ``fst(snd^i(t))``, or ``snd^(k-1)(t)`` for the last element).
+slot lowers to a destructuring assignment ``(a, b) = _srcK[_i]`` (any arity;
+no ``fst``/``snd``).  In the comp path — which has no statement context —
+each leaf name is reached by an ``fst``/``snd`` chain over ``argK[_i]``
+(for a pair ``t``, ``fst(t)`` / ``snd(t)``).  Because ``fst``/``snd`` are
+pair-only, the comp path rewrites a nested slot only when it (and any
+binding nested within it) is a pair; a comp with a nested slot of arity != 2
+is left unchanged for the backend to materialize (see
+:func:`_comp_nesting_is_pairs`).
 
 Patterns that don't match the guards (range iterables, mismatched
 arity, non-``Var`` list-comp zip args) are left unchanged.
@@ -131,25 +135,25 @@ def _snd(arg: Expr) -> Expr:
     return Snd(name, arg, None)
 
 
-def _snd_n(arg: Expr, n: int) -> Expr:
-    """Apply ``snd`` ``n`` times (``n == 0`` returns ``arg`` unchanged)."""
-    for _ in range(n):
-        arg = _snd(arg)
-    return arg
+def _comp_nesting_is_pairs(target: TupleBinding) -> bool:
+    """Whether *target* can be lowered by the comp path under pair-only
+    ``fst``/``snd``.
 
-
-def _elt_access(
-    make_access: Callable[[], Expr], i: int, k: int,
-) -> Callable[[], Expr]:
-    """A thunk for element ``i`` of the ``k``-tuple built by *make_access*.
-
-    Viewing a tuple as a binary pair, element ``i`` is ``fst(snd^i(t))`` for
-    ``i < k - 1`` and ``snd^(k-1)(t)`` for the last element (``snd`` of a
-    pair is the bare element).
+    The comp path reaches the leaves of a nested ``TupleBinding`` slot with
+    ``fst``/``snd`` (see :func:`_destructure_subst`), which are pair-only: a
+    nested slot of arity != 2 would emit ``snd`` of a non-pair.  The top-level
+    zip target is exempt — its slots are reached by direct ``argK[_i]``
+    indexing, not ``fst``/``snd`` — so only *nested* bindings must be pairs.
     """
-    if i < k - 1:
-        return lambda: _fst(_snd_n(make_access(), i))
-    return lambda: _snd_n(make_access(), k - 1)
+    def check(binding: Id | TupleBinding, *, top: bool) -> bool:
+        match binding:
+            case TupleBinding():
+                if not top and len(binding.elts) != 2:
+                    return False
+                return all(check(e, top=False) for e in binding.elts)
+            case _:
+                return True
+    return check(target, top=True)
 
 
 def _destructure_subst(
@@ -169,9 +173,13 @@ def _destructure_subst(
         case UnderscoreId():
             pass
         case TupleBinding():
-            k = len(binding.elts)
-            for i, elt in enumerate(binding.elts):
-                _destructure_subst(elt, _elt_access(make_access, i, k), subst)
+            # The comp path only reaches a nested slot that is a pair
+            # (guaranteed by `_comp_nesting_is_pairs`); `fst`/`snd` are its two
+            # projections.
+            assert len(binding.elts) == 2, 'comp-path nested slot must be a pair'
+            head, tail = binding.elts
+            _destructure_subst(head, lambda: _fst(make_access()), subst)
+            _destructure_subst(tail, lambda: _snd(make_access()), subst)
         case _:
             raise RuntimeError(f'unexpected zip binding element: {binding!r}')
 
@@ -354,6 +362,11 @@ class _ZipElimInstance(DefaultTransformVisitor):
                 and isinstance(new_iter, Zip)
                 and isinstance(target, TupleBinding)
                 and all(isinstance(a, Var) for a in new_iter.args)
+                # `fst`/`snd` are pair-only, so a nested slot of arity != 2 can't
+                # be reached by the comp path's accessor chains; leave such a
+                # `zip` in place (the backends materialize it) rather than emit
+                # ill-typed `snd`-of-non-pair.
+                and _comp_nesting_is_pairs(target)
             ):
                 idx = self.gensym.fresh('_i')
                 # Substitute each binding slot with an accessor into its

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -119,18 +119,13 @@ def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
 
 
 def _is_access_path(e: Expr) -> bool:
-    """Whether *e* may be substituted into the comp body — i.e. re-evaluated
-    once per iteration in place of a ``_srcK = ...`` preamble binding (which a
-    comprehension, being an expression, cannot host).
+    """Whether *e* is safe to inline into the comp body (re-evaluated once per
+    iteration, since a comp has no preamble to bind it once).
 
-    True for a ``Var`` or a *pure, O(1), deterministic* projection/index chain
-    rooted at one: ``fst``/``snd``/``arg[i]``.  Such an access path has no side
-    effects and yields the same value each time, so inlining it preserves
-    ``zip``'s "evaluate each argument once" semantics.
-
-    Deliberately excludes allocating/expensive args (e.g. ``xs[1:]`` slices,
-    calls): re-evaluating those per iteration would turn O(n) into O(n^2), so
-    they are left for the backend to materialize.
+    True for a ``Var`` or a pure, O(1) projection/index chain rooted at one
+    (``fst``/``snd``/``arg[i]``): no side effects, same value each time.
+    Excludes allocating/expensive args (slices, calls) whose re-evaluation
+    would turn O(n) into O(n^2); those are left for the backend to materialize.
     """
     match e:
         case Var():
@@ -171,14 +166,12 @@ def _snd(arg: Expr) -> Expr:
 
 
 def _comp_nesting_is_pairs(target: TupleBinding) -> bool:
-    """Whether *target* can be lowered by the comp path under pair-only
-    ``fst``/``snd``.
+    """Whether *target*'s nested bindings can be lowered by the comp path.
 
-    The comp path reaches the leaves of a nested ``TupleBinding`` slot with
-    ``fst``/``snd`` (see :func:`_destructure_subst`), which are pair-only: a
-    nested slot of arity != 2 would emit ``snd`` of a non-pair.  The top-level
-    zip target is exempt — its slots are reached by direct ``argK[_i]``
-    indexing, not ``fst``/``snd`` — so only *nested* bindings must be pairs.
+    The comp path reaches a nested ``TupleBinding``'s leaves with ``fst``/``snd``
+    (see :func:`_destructure_subst`), which are pair-only, so every nested slot
+    must have arity 2.  The top-level target is exempt — its slots are reached
+    by direct ``argK[_i]`` indexing, not ``fst``/``snd``.
     """
     def check(binding: Id | TupleBinding, *, top: bool) -> bool:
         match binding:
@@ -229,18 +222,12 @@ class _SubstNames(DefaultTransformVisitor):
 
     def __init__(self, subst: dict[NamedId, Expr]):
         super().__init__()
-        # Active substitutions, shadowed lexically.  We mutate in
-        # place via push/pop because ``DefaultTransformVisitor`` is
-        # purely top-down and gives us no return-trip hook for
-        # popping; the surrounding ``_visit_list_comp`` override
-        # restores after recursing.
+        # Active substitutions; `_visit_list_comp` shadows/restores entries
+        # around a nested comp that rebinds a substituted name.
         self._subst = dict(subst)
 
     def _visit_var(self, e: Var, ctx: Any):
-        # The substitution targets are ``NamedId``s; FPy's parser
-        # synthesizes a ``Var`` whose ``.name`` is the same
-        # ``NamedId`` object.  Equality is structural (``NamedId``
-        # implements ``__eq__`` over (base, count)).
+        # Substitution targets are ``NamedId``s, keyed by structural equality.
         replacement = self._subst.get(e.name)
         if replacement is not None:
             return replacement

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -75,8 +75,8 @@ from typing import Any, Callable
 
 from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
 from ..ast.fpyast import (
-    Assign, Attribute, Expr, ForStmt, Fst, FuncDef, Len, ListComp, ListRef, NamedId,
-    Range1, Snd, Stmt, StmtBlock, TupleBinding, UnderscoreId, Var, Zip,
+    Assign, Attribute, Expr, ForStmt, Fst, FuncDef, Integer, Len, ListComp, ListRef,
+    NamedId, Range1, Snd, Stmt, StmtBlock, TupleBinding, UnderscoreId, Var, Zip,
 )
 from ..ast.visitor import DefaultTransformVisitor
 from ..utils import Gensym, Id
@@ -118,9 +118,44 @@ def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
     )
 
 
-def _index_access(arg_name: NamedId, idx: NamedId) -> Callable[[], Expr]:
-    """A thunk building ``arg_name[idx]`` fresh on each call."""
-    return lambda: ListRef(Var(arg_name, None), Var(idx, None), None)
+def _is_access_path(e: Expr) -> bool:
+    """Whether *e* may be substituted into the comp body — i.e. re-evaluated
+    once per iteration in place of a ``_srcK = ...`` preamble binding (which a
+    comprehension, being an expression, cannot host).
+
+    True for a ``Var`` or a *pure, O(1), deterministic* projection/index chain
+    rooted at one: ``fst``/``snd``/``arg[i]``.  Such an access path has no side
+    effects and yields the same value each time, so inlining it preserves
+    ``zip``'s "evaluate each argument once" semantics.
+
+    Deliberately excludes allocating/expensive args (e.g. ``xs[1:]`` slices,
+    calls): re-evaluating those per iteration would turn O(n) into O(n^2), so
+    they are left for the backend to materialize.
+    """
+    match e:
+        case Var():
+            return True
+        case Fst() | Snd():
+            return _is_access_path(e.arg)
+        case ListRef():
+            return _is_access_path(e.value) and _is_access_path(e.index)
+        case Integer():                       # a constant index in ``arg[i]``
+            return True
+        case _:
+            return False
+
+
+def _clone(e: Expr) -> Expr:
+    """A structurally fresh copy of *e* (no AST shared between substituted
+    occurrences); ``DefaultTransformVisitor`` rebuilds every node."""
+    return DefaultTransformVisitor()._visit_expr(e, None)
+
+
+def _index_access(arg: Expr, idx: NamedId) -> Callable[[], Expr]:
+    """A thunk building ``arg[idx]`` with a fresh copy of ``arg`` each call.
+
+    *arg* must be an :func:`_is_access_path` (safe to re-evaluate per call)."""
+    return lambda: ListRef(_clone(arg), Var(idx, None), None)
 
 
 def _fst(arg: Expr) -> Expr:
@@ -361,7 +396,10 @@ class _ZipElimInstance(DefaultTransformVisitor):
                 _is_zip_tuple_binding(target, new_iter)
                 and isinstance(new_iter, Zip)
                 and isinstance(target, TupleBinding)
-                and all(isinstance(a, Var) for a in new_iter.args)
+                # Each arg is inlined into the comp body (re-evaluated per
+                # iteration, since a comp has no preamble to bind it once), so it
+                # must be a pure, re-evaluable access path.
+                and all(_is_access_path(a) for a in new_iter.args)
                 # `fst`/`snd` are pair-only, so a nested slot of arity != 2 can't
                 # be reached by the comp path's accessor chains; leave such a
                 # `zip` in place (the backends materialize it) rather than emit
@@ -374,15 +412,13 @@ class _ZipElimInstance(DefaultTransformVisitor):
                 # ``fst``/``snd`` chain for a nested tuple binding (whose
                 # per-iteration element is itself a tuple).
                 for binding, arg in zip(target.elts, new_iter.args):
-                    assert isinstance(arg, Var)
                     _destructure_subst(
-                        binding, _index_access(arg.name, idx), subst,
+                        binding, _index_access(arg, idx), subst,
                     )
                 # New target/iterable: ``_i in range(len(arg0))``.
-                assert isinstance(new_iter.args[0], Var)
                 len_expr = Len(
                     Var(NamedId('len'), None),
-                    Var(new_iter.args[0].name, None),
+                    _clone(new_iter.args[0]),
                     None,
                 )
                 new_targets.append(idx)

--- a/infra/mpfx/mx_dot_prod.py
+++ b/infra/mpfx/mx_dot_prod.py
@@ -3,7 +3,7 @@ import gzip
 import pickle
 import fpy2 as fp
 import random
-import multiprocessing as mp
+from concurrent.futures import ProcessPoolExecutor, as_completed
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -32,22 +32,6 @@ def sample_block():
         elt_bits = (bits >> (8 * i)) & 0xFF
         elt = fp.MX_E5M2.decode(elt_bits)
         elts.append(elt)
-    return bits, scale, elts
-
-
-
-    # sample a scale
-    scale_bits = random.randint(MIN_E8M0_BITS, MAX_E8M0_BITS)
-    scale = fp.MX_E8M0.decode(scale_bits)
-    # sample 32 elements
-    bits = scale_bits
-    elts = []
-    for i in range(32):
-        elt_bits = random.randint(0, 255)
-        elt = fp.MX_E5M2.decode(elt_bits)
-        bits |= elt_bits << (8 * i)  # pack the element bits into the block
-        elts.append(elt)
-    # return the scale and elements
     return bits, scale, elts
 
 
@@ -91,40 +75,47 @@ def plot_mismatches(mismatch_x, mismatch_y):
 
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("num_inputs", type=int, help="number of trials")
-parser.add_argument("-t", "--threads", type=int, default=1, help="number of worker threads (default: all CPUs)")
-parser.add_argument("-s", "--seed", type=int, default=1, help="base random seed")
-parser.add_argument("-o", "--output", type=str, default="mismatches.pkl", help="file to dump mismatches (default: mismatches.pkl)")
-parser.add_argument("--replot", action="store_true", help="replot from existing mismatch file instead of running new trials")
-args = parser.parse_args()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("num_inputs", type=int, help="number of trials")
+    parser.add_argument("-t", "--threads", type=int, default=1, help="number of worker threads (default: 1)")
+    parser.add_argument("-s", "--seed", type=int, default=1, help="base random seed")
+    parser.add_argument("-o", "--output", type=str, default="mismatches.pkl", help="file to dump mismatches (default: mismatches.pkl)")
+    parser.add_argument("--replot", action="store_true", help="replot from existing mismatch file instead of running new trials")
+    args = parser.parse_args()
 
-num_inputs: int = args.num_inputs
-seed: int = args.seed
-num_threads: int = args.threads
-output: str = args.output
-replot: bool = args.replot
+    num_inputs: int = args.num_inputs
+    seed: int = args.seed
+    num_threads: int = args.threads
+    output: str = args.output
+    replot: bool = args.replot
 
-if replot:
-    with gzip.open(output, "rb") as f:
-        data = pickle.load(f)
-    mismatch_x = data["x"]
-    mismatch_y = data["y"]
-    print(len(mismatch_x), "mismatches loaded from", output)
-else:
-    mismatch_x = []
-    mismatch_y = []
-    with mp.Pool(processes=num_threads) as pool:
-        for xbits, ybits, is_mismatch in pool.map(run_trial, range(seed, seed + num_inputs)):
-            if is_mismatch:
-                mismatch_x.append(xbits)
-                mismatch_y.append(ybits)
+    if replot:
+        with gzip.open(output, "rb") as f:
+            data = pickle.load(f)
+        mismatch_x = data["x"]
+        mismatch_y = data["y"]
+        print(len(mismatch_x), "mismatches loaded from", output)
+    else:
+        mismatch_x = []
+        mismatch_y = []
+        with ProcessPoolExecutor(max_workers=num_threads) as executor:
+            futures = [executor.submit(run_trial, s) for s in range(seed, seed + num_inputs)]
+            for future in as_completed(futures):
+                xbits, ybits, is_mismatch = future.result()
+                if is_mismatch:
+                    mismatch_x.append(xbits)
+                    mismatch_y.append(ybits)
 
-    print(len(mismatch_x), "mismatches found out of", num_inputs)
+        print(len(mismatch_x), "mismatches found out of", num_inputs)
 
-    # dump mismatches to file
-    with gzip.open(args.output, "wb") as f:
-        pickle.dump({"x": mismatch_x, "y": mismatch_y, "N": num_inputs, "seed": seed}, f)
-    print("mismatches saved to", args.output)
+        # dump mismatches to file
+        with gzip.open(args.output, "wb") as f:
+            pickle.dump({"x": mismatch_x, "y": mismatch_y, "N": num_inputs, "seed": seed}, f)
+        print("mismatches saved to", args.output)
 
-plot_mismatches(mismatch_x, mismatch_y)
+    plot_mismatches(mismatch_x, mismatch_y)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest",
+  "pytest-xdist",
   "hypothesis==6.135",
   "mypy",
   "ruff",
@@ -42,6 +43,7 @@ dev = [
 [dependency-groups]
 dev = [
   "pytest",
+  "pytest-xdist",
   "hypothesis==6.135",
   "mypy",
   "ruff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ Documentation = "https://fpy.readthedocs.io/"
 [tool.setuptools.packages.find]
 include = ["fpy2*"]
 
+[tool.pytest.ini_options]
+# Many test classes follow the `<Feature>TestCase` convention rather than the
+# default `Test*` prefix; collect both so those suites actually run.
+python_classes = ["Test*", "*TestCase"]
+
 [tool.mypy]
 disable_error_code = ["import-untyped"]
 check_untyped_defs = true

--- a/tests/unit/analysis/test_array_size.py
+++ b/tests/unit/analysis/test_array_size.py
@@ -1749,17 +1749,3 @@ class TestTupleAccessorSizes:
         u = self._bound(self._run(f), 'u')
         assert isinstance(u, ListSize)
         assert concrete_size(u.size) == 8
-
-    def test_snd_of_longer_projects_rest_tuple(self):
-        @fp.fpy
-        def f(xs: list[fp.Real], ys: list[fp.Real], zs: list[fp.Real]):
-            t = (xs, ys, zs)
-            u = fp.snd(t)        # arity 3 -> TupleSize of the last two
-            return u
-
-        self._pin(f, {'xs': 16, 'ys': 8, 'zs': 4})
-        u = self._bound(self._run(f), 'u')
-        assert isinstance(u, TupleSize)
-        assert len(u.elts) == 2
-        assert concrete_size(u.elts[0].size) == 8
-        assert concrete_size(u.elts[1].size) == 4

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1572,19 +1572,3 @@ class TestTupleAccessorFormats:
         mono = Monomorphize.apply(f.ast, None, [RealType(fp.FP32), RealType(fp.FP64)])
         info = FormatInfer.analyze(mono)
         assert fp.FP64.format() in self._bounds(info, 'u')
-
-    def test_snd_of_longer_projects_rest_tuple_format(self):
-        from fpy2.transform import Monomorphize
-
-        @fp.fpy
-        def f(x: fp.Real, y: fp.Real, z: fp.Real):
-            t = (x, y, z)
-            u = fp.snd(t)        # arity 3 -> TupleFormat of the last two
-            return u
-
-        mono = Monomorphize.apply(
-            f.ast, None, [RealType(fp.FP32), RealType(fp.FP64), RealType(fp.FP16)],
-        )
-        info = FormatInfer.analyze(mono)
-        u_bounds = self._bounds(info, 'u')
-        assert TupleFormat((fp.FP64.format(), fp.FP16.format())) in u_bounds

--- a/tests/unit/analysis/test_type_infer.py
+++ b/tests/unit/analysis/test_type_infer.py
@@ -255,11 +255,12 @@ class TestTypeInferOnGeneratedPrograms:
 
 
 class TestTupleAccessors:
-    """``fst`` / ``snd`` projection and the arity/non-tuple errors.
+    """``fst`` / ``snd`` projection and the non-pair errors.
 
-    ``fst`` returns the head (any non-empty tuple); ``snd`` returns the tail
-    — the bare second element for a pair, else the tuple of the rest — and
-    requires arity >= 2.
+    ``fst``/``snd`` are the two projections of a *pair* (``'a * 'b -> 'a`` /
+    ``'a * 'b -> 'b``), so they are HM-typeable even on an open operand.
+    Anything that isn't a pair — a non-tuple, a 1-tuple, or a tuple of arity
+    != 2 — is rejected by unification.
     """
 
     @staticmethod
@@ -287,12 +288,14 @@ class TestTupleAccessors:
 
         assert isinstance(self._return_type(f), RealType)
 
-    def test_fst_accepts_one_tuple(self):
+    def test_fst_of_one_tuple_errors(self):
+        # `fst` is pair-only: a 1-tuple is not a pair.
         @fp.fpy
         def f(t: tuple[fp.Real]) -> fp.Real:
             return fp.fst(t)
 
-        assert isinstance(self._return_type(f), RealType)
+        with pytest.raises(TypeInferError):
+            TypeInfer.check(f.ast)
 
     def test_snd_of_pair_is_bare_element(self):
         @fp.fpy
@@ -301,20 +304,19 @@ class TestTupleAccessors:
 
         assert isinstance(self._return_type(f), BoolType)
 
-    def test_snd_of_longer_tuple_is_rest_tuple(self):
+    def test_snd_of_longer_tuple_errors(self):
+        # `snd` is pair-only: a 3-tuple is not a pair (destructure instead).
         @fp.fpy
         def f(t: tuple[fp.Real, bool, fp.Real]):
             return fp.snd(t)
 
-        rt = self._return_type(f)
-        assert isinstance(rt, TupleType)
-        assert len(rt.elts) == 2
-        assert isinstance(rt.elts[0], BoolType)
-        assert isinstance(rt.elts[1], RealType)
+        with pytest.raises(TypeInferError):
+            TypeInfer.check(f.ast)
 
-    def test_chained_fst_snd_walks_pairs(self):
+    def test_chained_fst_snd_walks_nested_pairs(self):
+        # nesting is explicit: a 3-element value is a pair whose tail is a pair.
         @fp.fpy
-        def f(t: tuple[fp.Real, bool, fp.Real]):
+        def f(t: tuple[fp.Real, tuple[bool, fp.Real]]):
             return fp.fst(fp.snd(t))
 
         assert isinstance(self._return_type(f), BoolType)

--- a/tests/unit/backend/cpp/test_emit_tuple.py
+++ b/tests/unit/backend/cpp/test_emit_tuple.py
@@ -164,17 +164,18 @@ class TestTupleDestructure:
 
 
 class TestTupleAccessors:
-    """``fst`` / ``snd`` lower to ``std::get`` (and ``std::make_tuple`` for
-    the tail of a tuple longer than a pair)."""
+    """``fst`` / ``snd`` are pair projections; they lower to
+    ``std::get<0>`` / ``std::get<1>``.  A chain over a nested pair nests
+    the ``std::get`` calls."""
 
     def test_fst_emits_get0(self):
         @fp.fpy
-        def f(p: tuple[fp.Real, fp.Real, fp.Real]) -> fp.Real:
+        def f(p: tuple[fp.Real, fp.Real]) -> fp.Real:
             return fp.fst(p)
 
         out = CppCompiler().compile(
             f, ctx=fp.FP64,
-            arg_types=[TupleType(RealType(fp.FP64), RealType(fp.FP64), RealType(fp.FP64))],
+            arg_types=[TupleType(RealType(fp.FP64), RealType(fp.FP64))],
         )
         assert 'std::get<0>(p)' in out
 
@@ -188,69 +189,6 @@ class TestTupleAccessors:
             arg_types=[TupleType(RealType(fp.FP64), RealType(fp.FP64))],
         )
         assert 'std::get<1>(p)' in out
-
-    def test_snd_longer_emits_make_tuple(self):
-        @fp.fpy
-        def f(p: tuple[fp.Real, fp.Real, fp.Real]) -> tuple[fp.Real, fp.Real]:
-            return fp.snd(p)
-
-        out = CppCompiler().compile(
-            f, ctx=fp.FP64,
-            arg_types=[TupleType(RealType(fp.FP64), RealType(fp.FP64), RealType(fp.FP64))],
-        )
-        # tail of a 3-tuple -> a new tuple of elements 1 and 2
-        assert 'std::make_tuple(' in out
-        assert 'std::get<1>(' in out
-        assert 'std::get<2>(' in out
-
-    def test_fst_snd_chain_folds_to_single_get(self):
-        """``fst(snd(p))`` over a 3-tuple reads element 1 directly — one
-        ``std::get<1>``, with no intermediate ``std::make_tuple``."""
-        @fp.fpy
-        def f(p: tuple[fp.Real, fp.Real, fp.Real]) -> fp.Real:
-            return fp.fst(fp.snd(p))
-
-        out = CppCompiler().compile(
-            f, ctx=fp.FP64,
-            arg_types=[TupleType(RealType(fp.FP64), RealType(fp.FP64), RealType(fp.FP64))],
-        )
-        assert 'std::get<1>(p)' in out
-        assert 'make_tuple' not in out
-
-    def test_deep_chain_folds_to_single_get(self):
-        """``fst(snd(snd(p)))`` over a 4-tuple folds to ``std::get<2>``."""
-        @fp.fpy
-        def f(p: tuple[fp.Real, fp.Real, fp.Real, fp.Real]) -> fp.Real:
-            return fp.fst(fp.snd(fp.snd(p)))
-
-        R = RealType(fp.FP64)
-        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[TupleType(R, R, R, R)])
-        assert 'std::get<2>(p)' in out
-        assert 'make_tuple' not in out
-
-    def test_all_snd_chain_to_bare_element_folds(self):
-        """``snd(snd(p))`` over a 3-tuple is the bare last element —
-        ``std::get<2>``, no ``make_tuple``."""
-        @fp.fpy
-        def f(p: tuple[fp.Real, fp.Real, fp.Real]) -> fp.Real:
-            return fp.snd(fp.snd(p))
-
-        R = RealType(fp.FP64)
-        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[TupleType(R, R, R)])
-        assert 'std::get<2>(p)' in out
-        assert 'make_tuple' not in out
-
-    def test_unconsumed_tail_still_materializes(self):
-        """A ``snd`` whose multi-element tail is the actual result (not
-        consumed by an outer ``fst``) still builds a ``std::make_tuple``."""
-        @fp.fpy
-        def f(p: tuple[fp.Real, fp.Real, fp.Real, fp.Real]) -> tuple[fp.Real, fp.Real, fp.Real]:
-            return fp.snd(p)
-
-        R = RealType(fp.FP64)
-        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[TupleType(R, R, R, R)])
-        assert 'std::make_tuple(' in out
-        assert 'std::get<3>(' in out
 
     def test_nested_element_tuple_rebases(self):
         """When ``snd`` yields a bare element that is itself a tuple, an

--- a/tests/unit/backend/test_fpc_tuple.py
+++ b/tests/unit/backend/test_fpc_tuple.py
@@ -1,10 +1,10 @@
 """
 FPCore lowering of the ``fst`` / ``snd`` tuple accessors.
 
-Tuples compile to FPCore arrays, so ``fst``/``snd`` lower to ``ref`` (and,
-for the tail of a tuple longer than a pair, an ``array`` of the remaining
-refs).  The FPCore backend has no tuple-typed arguments, so the tuples here
-are built from scalar arguments inside the body.
+``fst``/``snd`` are pair projections; tuples compile to FPCore arrays, so
+they lower to ``(ref t 0)`` / ``(ref t 1)``.  A chain over a nested pair
+lowers to nested refs.  The FPCore backend has no tuple-typed arguments, so
+the tuples here are built from scalar arguments inside the body.
 """
 
 import fpy2 as fp
@@ -19,8 +19,8 @@ def _compile(f) -> str:
 class TestTupleAccessors:
     def test_fst_emits_ref0(self):
         @fp.fpy
-        def f(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
-            t = (a, b, c)
+        def f(a: fp.Real, b: fp.Real) -> fp.Real:
+            t = (a, b)
             return fp.fst(t)
 
         assert '(ref t 0)' in _compile(f)
@@ -33,55 +33,11 @@ class TestTupleAccessors:
 
         assert '(ref t 1)' in _compile(f)
 
-    def test_snd_longer_emits_array_of_refs(self):
-        @fp.fpy
-        def f(a: fp.Real, b: fp.Real, c: fp.Real):
-            t = (a, b, c)
-            return fp.snd(t)
-
-        # tail of a 3-tuple -> an array of the last two elements
-        assert '(array (ref' in _compile(f)
-
-    def test_fst_snd_chain_folds_to_single_ref(self):
-        """``fst(snd(t))`` over a 3-tuple folds to ``(ref t 1)`` — no
-        intermediate tail array."""
+    def test_chain_over_nested_pair(self):
+        """``fst(snd(t))`` over a nested pair lowers to nested refs."""
         @fp.fpy
         def f(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
-            t = (a, b, c)
+            t = (a, (b, c))
             return fp.fst(fp.snd(t))
 
-        s = _compile(f)
-        assert '(ref t 1)' in s
-        assert 'array (ref' not in s
-
-    def test_deep_chain_folds_to_single_ref(self):
-        """``fst(snd(snd(t)))`` over a 4-tuple folds to ``(ref t 2)``."""
-        @fp.fpy
-        def f(a: fp.Real, b: fp.Real, c: fp.Real, d: fp.Real) -> fp.Real:
-            t = (a, b, c, d)
-            return fp.fst(fp.snd(fp.snd(t)))
-
-        s = _compile(f)
-        assert '(ref t 2)' in s
-        assert 'array (ref' not in s
-
-    def test_all_snd_chain_to_bare_element_folds(self):
-        """``snd(snd(t))`` over a 3-tuple is the bare last element ``(ref t 2)``."""
-        @fp.fpy
-        def f(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
-            t = (a, b, c)
-            return fp.snd(fp.snd(t))
-
-        s = _compile(f)
-        assert '(ref t 2)' in s
-        assert 'array (ref' not in s
-
-    def test_unconsumed_tail_still_materializes(self):
-        """A multi-element tail that is the result still builds an array."""
-        @fp.fpy
-        def f(a: fp.Real, b: fp.Real, c: fp.Real, d: fp.Real):
-            t = (a, b, c, d)
-            return fp.snd(t)
-
-        s = _compile(f)
-        assert '(array (ref' in s
+        assert '(ref (ref t 1) 0)' in _compile(f)

--- a/tests/unit/interpret/test_tuple_accessors.py
+++ b/tests/unit/interpret/test_tuple_accessors.py
@@ -9,39 +9,17 @@ import fpy2 as fp
 
 
 class TestTupleAccessors:
-    def test_fst_head(self):
+
+    def test_fst(self):
         @fp.fpy
-        def f(t: tuple[fp.Real, fp.Real, fp.Real]) -> fp.Real:
+        def f(t: tuple[fp.Real, fp.Real]) -> fp.Real:
             return fp.fst(t)
 
-        assert float(f((1.0, 2.0, 3.0), ctx=fp.FP64)) == 1.0
+        assert float(f((1.0, 2.0), ctx=fp.FP64)) == 1.0
 
-    def test_fst_one_tuple(self):
-        @fp.fpy
-        def f(t: tuple[fp.Real]) -> fp.Real:
-            return fp.fst(t)
-
-        assert float(f((7.0,), ctx=fp.FP64)) == 7.0
-
-    def test_snd_pair_is_bare(self):
+    def test_snd(self):
         @fp.fpy
         def f(t: tuple[fp.Real, fp.Real]) -> fp.Real:
             return fp.snd(t)
 
-        assert float(f((4.0, 5.0), ctx=fp.FP64)) == 5.0
-
-    def test_snd_longer_is_tuple(self):
-        @fp.fpy
-        def f(t: tuple[fp.Real, fp.Real, fp.Real]) -> fp.Real:
-            a, b = fp.snd(t)        # snd((x, y, z)) == (y, z)
-            with fp.FP64:
-                return a + b
-
-        assert float(f((1.0, 2.0, 3.0), ctx=fp.FP64)) == 5.0
-
-    def test_chained_fst_snd(self):
-        @fp.fpy
-        def f(t: tuple[fp.Real, fp.Real, fp.Real]) -> fp.Real:
-            return fp.fst(fp.snd(t))
-
-        assert float(f((1.0, 2.0, 3.0), ctx=fp.FP64)) == 2.0
+        assert float(f((1.0, 2.0), ctx=fp.FP64)) == 2.0

--- a/tests/unit/rewrite/test_matcher.py
+++ b/tests/unit/rewrite/test_matcher.py
@@ -87,6 +87,30 @@ class MatchExprTestCase(_MatcherTestCase):
         self.assertAstEqual(m1.subst['b'], Var(NamedId('y'), None))
         self.assertAstEqual(m1.subst['c'], Var(NamedId('z'), None))
 
+    def test_signed_zero_is_distinct(self):
+        # `+0.0` and `-0.0` are distinct literals: a rule keyed on one must not
+        # match the other (e.g. `x + 0.0 -> x` is unsound at `x = -0.0`).
+        @pattern
+        def add_pos_zero(a):
+            a + 0.0
+
+        @pattern
+        def add_neg_zero(a):
+            a + -0.0
+
+        @fpy
+        def f_pos(x):
+            return x + 0.0
+
+        @fpy
+        def f_neg(x):
+            return x + -0.0
+
+        assert len(Matcher(add_pos_zero).match(f_pos)) == 1
+        assert len(Matcher(add_pos_zero).match(f_neg)) == 0
+        assert len(Matcher(add_neg_zero).match(f_neg)) == 1
+        assert len(Matcher(add_neg_zero).match(f_pos)) == 0
+
 
 @fpy
 def f2(lst):

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -75,15 +75,19 @@ class TestTupleAccessors:
     """Eager semantics of the ``fst`` / ``snd`` tuple accessors."""
 
     def test_fst(self):
-        assert fp.fst((1, 2, 3)) == 1
-        assert fp.fst((9,)) == 9          # head of a 1-tuple
+        assert fp.fst((1, 2)) == 1
 
-    def test_snd_pair_is_bare(self):
-        assert fp.snd((4, 5)) == 5
+    def test_snd(self):
+        assert fp.snd((1, 2)) == 2
 
-    def test_snd_longer_is_rest_tuple(self):
-        assert fp.snd((1, 2, 3)) == (2, 3)
+    def test_fst_requires_two_elements(self):
+        with pytest.raises(ValueError):
+            fp.fst((9,))
+        with pytest.raises(ValueError):
+            fp.fst((1, 2, 3))
 
-    def test_snd_requires_at_least_two_elements(self):
+    def test_snd_requires_two_elements(self):
         with pytest.raises(ValueError):
             fp.snd((9,))
+        with pytest.raises(ValueError):
+            fp.snd((1, 2, 3))


### PR DESCRIPTION
This PR makes many small changes:
- adds `as_real()` method to rational constants to recover signed zeros
- make `fst` and `snd` operate only on pairs (as in OCaml)
- extend zip elimination to work on list comprehensions with list/tuple accesses
- do not restrict partial evaluation's use of free variables
- fix format inference for free variables
- add `pytest-xdist` as a dependency for parallel unit tests
- ensure pytest runs all tests