### PR TITLE
Fix symbol resolution for operators

### DIFF
--- a/fpy2/analysis/syntax_check.py
+++ b/fpy2/analysis/syntax_check.py
@@ -144,34 +144,52 @@ class SyntaxCheckInstance(Visitor):
     def _visit_decnum(self, e: Decnum, ctx: _Ctx):
         pass
 
+    @staticmethod
+    def _check_op_nameable(e: Expr):
+        """A synthesized operator (`func is None`) must have a canonical
+        name, or the pretty-printer cannot render it."""
+        if getattr(e, 'func', None) is None and type(e) not in CANONICAL_OP_NAMES:
+            raise FPySyntaxError(
+                f'operator `{type(e).__name__}` has no surface reference '
+                f'and no entry in CANONICAL_OP_NAMES'
+            )
+
     def _visit_hexnum(self, e: Hexnum, ctx: _Ctx):
-        pass
+        self._check_op_nameable(e)
 
     def _visit_integer(self, e: Integer, ctx: _Ctx):
         pass
 
     def _visit_rational(self, e: Rational, ctx: _Ctx):
-        pass
+        self._check_op_nameable(e)
 
     def _visit_digits(self, e: Digits, ctx: _Ctx):
-        pass
+        self._check_op_nameable(e)
 
     def _visit_nullaryop(self, e: NullaryOp, ctx: _Ctx):
-        pass
+        self._check_op_nameable(e)
 
     def _visit_unaryop(self, e: UnaryOp, ctx: _Ctx):
+        if isinstance(e, NamedUnaryOp):
+            self._check_op_nameable(e)
         self._visit_expr(e.arg, ctx)
 
     def _visit_binaryop(self, e: BinaryOp, ctx: _Ctx):
+        if isinstance(e, NamedBinaryOp):
+            self._check_op_nameable(e)
         self._visit_expr(e.first, ctx)
         self._visit_expr(e.second, ctx)
 
     def _visit_ternaryop(self, e: TernaryOp, ctx: _Ctx):
+        if isinstance(e, NamedTernaryOp):
+            self._check_op_nameable(e)
         self._visit_expr(e.first, ctx)
         self._visit_expr(e.second, ctx)
         self._visit_expr(e.third, ctx)
 
     def _visit_naryop(self, e: NaryOp, ctx: _Ctx):
+        if isinstance(e, NamedNaryOp):
+            self._check_op_nameable(e)
         for c in e.args:
             self._visit_expr(c, ctx)
 

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -2,6 +2,7 @@
 
 from pprint import pformat
 from types import ModuleType
+from typing import Any
 
 from ..env import ForeignEnv
 from ..fpc_context import FPCoreContext

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -56,6 +56,36 @@ class _FormatterInstance(Visitor):
             case _:
                 raise RuntimeError('unreachable', func)
 
+    @staticmethod
+    def _find_fpy_alias(env: ForeignEnv | None) -> str | None:
+        """Name that the `fpy2` package is bound to in `env`, if any."""
+        if env is None:
+            return None
+        for name in env:
+            val = env.get(name)
+            if isinstance(val, ModuleType) and getattr(val, '__name__', None) == 'fpy2':
+                return name
+        return None
+
+    def _op_name(self, e: Expr, ctx: _Ctx) -> str:
+        """Render the surface name of a named-operator / literal node.
+
+        Uses the node's `func` symbol when present (the reference the user
+        wrote, preserved verbatim).  When `func` is `None` the node was
+        synthesized by a rewrite pass, so derive the canonical name for its
+        type and qualify it with the enclosing function's `fpy2` alias when
+        the operator lives in the `fpy2` namespace.
+        """
+        func = getattr(e, 'func', None)
+        if func is not None:
+            return self._visit_function_name(func, ctx)
+
+        import fpy2
+        name = CANONICAL_OP_NAMES[type(e)]
+        if self._fpy_alias is not None and hasattr(fpy2, name):
+            return f'{self._fpy_alias}.{name}'
+        return name
+
     def _visit_var(self, e: Var, ctx: _Ctx) -> str:
         return str(e.name)
 
@@ -78,29 +108,29 @@ class _FormatterInstance(Visitor):
         return e.val
 
     def _visit_hexnum(self, e: Hexnum, ctx: _Ctx):
-        name = self._visit_function_name(e.func, ctx)
+        name = self._op_name(e, ctx)
         return f'{name}(\'{e.val}\')'
 
     def _visit_integer(self, e: Integer, ctx: _Ctx):
         return str(e.val)
 
     def _visit_rational(self, e: Rational, ctx: _Ctx):
-        name = self._visit_function_name(e.func, ctx)
+        name = self._op_name(e, ctx)
         return f'{name}({e.p}, {e.q})'
 
     def _visit_digits(self, e: Digits, ctx: _Ctx):
-        name = self._visit_function_name(e.func, ctx)
+        name = self._op_name(e, ctx)
         return f'{name}({e.m}, {e.e}, {e.b})'
 
     def _visit_nullaryop(self, e: NullaryOp, ctx: _Ctx):
-        name = self._visit_function_name(e.func, ctx)
+        name = self._op_name(e, ctx)
         return f'{name}()'
 
     def _visit_unaryop(self, e: UnaryOp, ctx: _Ctx):
         arg = self._visit_expr(e.arg, ctx)
         match e:
             case NamedUnaryOp():
-                name = self._visit_function_name(e.func, ctx)
+                name = self._op_name(e, ctx)
                 return f'{name}({arg})'
             case Abs():
                 return f'abs({arg})'
@@ -116,7 +146,7 @@ class _FormatterInstance(Visitor):
         rhs = self._visit_expr(e.second, ctx)
         match e:
             case NamedBinaryOp():
-                name = self._visit_function_name(e.func, ctx)
+                name = self._op_name(e, ctx)
                 return f'{name}({lhs}, {rhs})'
             case Add():
                 return f'({lhs} + {rhs})'
@@ -137,7 +167,7 @@ class _FormatterInstance(Visitor):
         arg2 = self._visit_expr(e.third, ctx)
         match e:
             case NamedTernaryOp():
-                name = self._visit_function_name(e.func, ctx)
+                name = self._op_name(e, ctx)
                 return f'{name}({arg0}, {arg1}, {arg2})'
             case _:
                 raise RuntimeError('unreachable', e)
@@ -146,7 +176,7 @@ class _FormatterInstance(Visitor):
         args = [self._visit_expr(arg, ctx) for arg in e.args]
         match e:
             case NamedNaryOp():
-                name = self._visit_function_name(e.func, ctx)
+                name = self._op_name(e, ctx)
                 return f'{name}({", ".join(args)})'
             case And():
                 return ' and '.join(args)
@@ -360,6 +390,9 @@ class _FormatterInstance(Visitor):
             self._add_line(')', ctx)
 
     def _visit_function(self, func: FuncDef, ctx: _Ctx):
+        # record how `fpy2` is imported so synthesized operators can be named
+        self._fpy_alias = self._find_fpy_alias(func.env)
+
         # TODO: type annotation
         arg_strs = [str(arg.name) for arg in func.args]
         arg_str = ', '.join(arg_strs)

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -1,8 +1,9 @@
 """Pretty printing of FPy ASTs"""
 
 from pprint import pformat
-from typing import Any
+from types import ModuleType
 
+from ..env import ForeignEnv
 from ..fpc_context import FPCoreContext
 from .fpyast import *
 from .visitor import Visitor
@@ -13,10 +14,16 @@ class _FormatterInstance(Visitor):
     """Single-instance visitor for pretty printing FPy ASTs"""
     ast: Ast
     fmt: str
+    _fpy_alias: str | None
 
     def __init__(self, ast: Ast):
         self.ast = ast
         self.fmt = ''
+        # name the `fpy2` package is bound to in the enclosing function's
+        # namespace, if any; used to render operators synthesized by rewrite
+        # passes (whose `func` symbol is `None`).  Set when a `FuncDef` is
+        # formatted; stays `None` for a bare expression with no environment.
+        self._fpy_alias = None
 
     def apply(self) -> str:
         match self.ast:

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -19,10 +19,7 @@ class _FormatterInstance(Visitor):
     def __init__(self, ast: Ast):
         self.ast = ast
         self.fmt = ''
-        # name the `fpy2` package is bound to in the enclosing function's
-        # namespace, if any; used to render operators synthesized by rewrite
-        # passes (whose `func` symbol is `None`).  Set when a `FuncDef` is
-        # formatted; stays `None` for a bare expression with no environment.
+        # `fpy2`'s alias in the enclosing function's namespace; set per `FuncDef`
         self._fpy_alias = None
 
     def apply(self) -> str:
@@ -58,14 +55,19 @@ class _FormatterInstance(Visitor):
 
     @staticmethod
     def _find_fpy_alias(env: ForeignEnv | None) -> str | None:
-        """Name that the `fpy2` package is bound to in `env`, if any."""
+        """Name that the `fpy2` package is bound to in `env`, if any.
+
+        `env` iterates in nondeterministic (set-union) order, so pick the
+        lexicographically smallest match to keep formatting stable when
+        `fpy2` is bound under more than one name."""
         if env is None:
             return None
-        for name in env:
-            val = env.get(name)
-            if isinstance(val, ModuleType) and getattr(val, '__name__', None) == 'fpy2':
-                return name
-        return None
+        aliases = [
+            name for name in env
+            if isinstance(env.get(name), ModuleType)
+            and getattr(env.get(name), '__name__', None) == 'fpy2'
+        ]
+        return min(aliases, default=None)
 
     def _fpy_qualified(self, name: str) -> str:
         """Render an `fpy2` symbol as `<alias>.<name>` when the enclosing
@@ -76,14 +78,9 @@ class _FormatterInstance(Visitor):
         return name
 
     def _op_name(self, e: Expr, ctx: _Ctx) -> str:
-        """Render the surface name of a named-operator / literal node.
-
-        Uses the node's `func` symbol when present (the reference the user
-        wrote, preserved verbatim).  When `func` is `None` the node was
-        synthesized by a rewrite pass, so derive the canonical name for its
-        type and qualify it with the enclosing function's `fpy2` alias when
-        the operator lives in the `fpy2` namespace.
-        """
+        """Surface name of a named-operator / literal node: the user's `func`
+        symbol verbatim, or the canonical name when `func` is `None`
+        (synthesized by a rewrite pass)."""
         func = getattr(e, 'func', None)
         if func is not None:
             return self._visit_function_name(func, ctx)

--- a/fpy2/ast/formatter.py
+++ b/fpy2/ast/formatter.py
@@ -67,6 +67,14 @@ class _FormatterInstance(Visitor):
                 return name
         return None
 
+    def _fpy_qualified(self, name: str) -> str:
+        """Render an `fpy2` symbol as `<alias>.<name>` when the enclosing
+        function imports `fpy2` under a module alias, else bare `name`."""
+        import fpy2
+        if self._fpy_alias is not None and hasattr(fpy2, name):
+            return f'{self._fpy_alias}.{name}'
+        return name
+
     def _op_name(self, e: Expr, ctx: _Ctx) -> str:
         """Render the surface name of a named-operator / literal node.
 
@@ -79,12 +87,7 @@ class _FormatterInstance(Visitor):
         func = getattr(e, 'func', None)
         if func is not None:
             return self._visit_function_name(func, ctx)
-
-        import fpy2
-        name = CANONICAL_OP_NAMES[type(e)]
-        if self._fpy_alias is not None and hasattr(fpy2, name):
-            return f'{self._fpy_alias}.{name}'
-        return name
+        return self._fpy_qualified(CANONICAL_OP_NAMES[type(e)])
 
     def _visit_var(self, e: Var, ctx: _Ctx) -> str:
         return str(e.name)
@@ -370,11 +373,12 @@ class _FormatterInstance(Visitor):
         spec = fmeta.spec
         meta = fmeta.props
 
-        num_fields = sum(x is not None for x in (rctx, spec, meta))
-        if num_fields == 0:
-            self._add_line('@fpy', ctx)
+        name = self._fpy_qualified('fpy')
+        if not (rctx or spec or meta):
+            # no keyword arguments: emit the bare decorator without `(...)`
+            self._add_line(f'@{name}', ctx)
         else:
-            self._add_line('@fpy(', ctx)
+            self._add_line(f'@{name}(', ctx)
             if rctx:
                 v = self._format_data(rctx, arg_str)
                 self._add_line(f'ctx={v},', ctx + 1)

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -25,6 +25,7 @@ from ..utils import (
 )
 
 __all__ = [
+    'CANONICAL_OP_NAMES',
     'AMax',
     'AMin',
     'Abs',
@@ -455,10 +456,10 @@ class Decnum(RationalVal):
 class Hexnum(RationalVal):
     """FPy AST: hexadecimal number"""
     __slots__ = ('func', 'val')
-    func: 'FuncSymbol'
+    func: 'FuncSymbol | None'
     val: str
 
-    def __init__(self, func: 'FuncSymbol', val: str, loc: Location | None):
+    def __init__(self, func: 'FuncSymbol | None', val: str, loc: Location | None):
         super().__init__(loc)
         self.func = func
         self.val = val
@@ -494,11 +495,11 @@ class Integer(RationalVal):
 class Rational(RationalVal):
     """FPy AST: rational number"""
     __slots__ = ('func', 'p', 'q')
-    func: 'FuncSymbol'
+    func: 'FuncSymbol | None'
     p: int
     q: int
 
-    def __init__(self, func: 'FuncSymbol', p: int, q: int, loc: Location | None):
+    def __init__(self, func: 'FuncSymbol | None', p: int, q: int, loc: Location | None):
         super().__init__(loc)
         self.func = func
         self.p = p
@@ -513,12 +514,12 @@ class Rational(RationalVal):
 class Digits(RationalVal):
     """FPy AST: scientific notation"""
     __slots__ = ('b', 'e', 'func', 'm')
-    func: 'FuncSymbol'
+    func: 'FuncSymbol | None'
     m: int
     e: int
     b: int
 
-    def __init__(self, func: 'FuncSymbol', m: int, e: int, b: int, loc: Location | None):
+    def __init__(self, func: 'FuncSymbol | None', m: int, e: int, b: int, loc: Location | None):
         super().__init__(loc)
         self.func = func
         self.m = m
@@ -557,10 +558,10 @@ class NullaryOp(NaryExpr):
 
     __slots__ = ('func',)
 
-    func: 'FuncSymbol'
+    func: 'FuncSymbol | None'
     args: tuple[Expr, ...] = ()
 
-    def __init__(self, func: 'FuncSymbol', loc: Location | None):
+    def __init__(self, func: 'FuncSymbol | None', loc: Location | None):
         super().__init__(loc)
         self.func = func
 
@@ -602,7 +603,7 @@ class NamedUnaryOp(UnaryOp):
 
     def __init__(
         self,
-        func: 'FuncSymbol',
+        func: 'FuncSymbol | None',
         arg: Expr,
         loc: Location | None
     ):
@@ -650,7 +651,7 @@ class NamedBinaryOp(BinaryOp):
 
     def __init__(
         self,
-        func: 'FuncSymbol',
+        func: 'FuncSymbol | None',
         first: Expr,
         second: Expr,
         loc: Location | None
@@ -703,7 +704,7 @@ class NamedTernaryOp(TernaryOp):
 
     def __init__(
         self,
-        func: 'FuncSymbol',
+        func: 'FuncSymbol | None',
         first: Expr,
         second: Expr,
         third: Expr,
@@ -737,7 +738,7 @@ class NamedNaryOp(NaryOp):
 
     def __init__(
         self,
-        func: 'FuncSymbol',
+        func: 'FuncSymbol | None',
         args: Iterable[Expr],
         loc: Location | None
     ):
@@ -1822,6 +1823,108 @@ symbol ::= Var ( symbol )
          | Attribute ( symbol, _ )
 
 This type alias only shallowly checks the type
+"""
+
+
+###########################################################
+# Canonical operator names
+
+CANONICAL_OP_NAMES: dict[type, str] = {
+    # nullary constants
+    ConstNan: 'nan',
+    ConstInf: 'inf',
+    ConstPi: 'const_pi',
+    ConstE: 'const_e',
+    ConstLog2E: 'const_log2e',
+    ConstLog10E: 'const_log10e',
+    ConstLn2: 'const_ln2',
+    ConstPi_2: 'const_pi_2',
+    ConstPi_4: 'const_pi_4',
+    Const1_Pi: 'const_1_pi',
+    Const2_Pi: 'const_2_pi',
+    Const2_SqrtPi: 'const_2_sqrt_pi',
+    ConstSqrt2: 'const_sqrt2',
+    ConstSqrt1_2: 'const_sqrt1_2',
+    # unary
+    Sqrt: 'sqrt',
+    Cbrt: 'cbrt',
+    Ceil: 'ceil',
+    Floor: 'floor',
+    NearbyInt: 'nearbyint',
+    RoundInt: 'roundint',
+    Trunc: 'trunc',
+    Acos: 'acos',
+    Asin: 'asin',
+    Atan: 'atan',
+    Cos: 'cos',
+    Sin: 'sin',
+    Tan: 'tan',
+    Acosh: 'acosh',
+    Asinh: 'asinh',
+    Atanh: 'atanh',
+    Cosh: 'cosh',
+    Sinh: 'sinh',
+    Tanh: 'tanh',
+    Exp: 'exp',
+    Exp2: 'exp2',
+    Expm1: 'expm1',
+    Log: 'log',
+    Log10: 'log10',
+    Log1p: 'log1p',
+    Log2: 'log2',
+    Erf: 'erf',
+    Erfc: 'erfc',
+    Lgamma: 'lgamma',
+    Tgamma: 'tgamma',
+    IsFinite: 'isfinite',
+    IsInf: 'isinf',
+    IsNan: 'isnan',
+    IsNormal: 'isnormal',
+    Signbit: 'signbit',
+    Round: 'round',
+    Cast: 'cast',
+    Len: 'len',
+    Dim: 'dim',
+    Fst: 'fst',
+    Snd: 'snd',
+    Enumerate: 'enumerate',
+    Sum: 'sum',
+    Logb: 'logb',
+    AMin: 'min',
+    AMax: 'max',
+    Range1: 'range',
+    # binary
+    Copysign: 'copysign',
+    Fdim: 'fdim',
+    Fmod: 'fmod',
+    Remainder: 'remainder',
+    Hypot: 'hypot',
+    Atan2: 'atan2',
+    Pow: 'pow',
+    Size: 'size',
+    RoundAt: 'round_at',
+    Range2: 'range',
+    # ternary
+    Fma: 'fma',
+    Range3: 'range',
+    # n-ary
+    Zip: 'zip',
+    Max: 'max',
+    Min: 'min',
+    Empty: 'empty',
+    # literals
+    Hexnum: 'hexfloat',
+    Rational: 'rational',
+    Digits: 'digits',
+}
+"""
+Canonical FPy surface name for each named-operator / literal node type.
+
+Used by the pretty-printer to render a node whose `func` symbol is `None`
+(i.e. a node synthesized by a rewrite pass rather than parsed from user
+source). The name is the operator's public attribute name in the ``fpy2``
+package (or, for :class:`Len`/:class:`Range1` etc., the Python builtin the
+parser resolves against). See :meth:`Formatter._op_name`.
 """
 
 ###########################################################

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -599,7 +599,7 @@ class NamedUnaryOp(UnaryOp):
 
     __slots__ = ('func',)
 
-    func: 'FuncSymbol'
+    func: 'FuncSymbol | None'
 
     def __init__(
         self,
@@ -647,7 +647,7 @@ class NamedBinaryOp(BinaryOp):
 
     __slots__ = ('func',)
 
-    func: 'FuncSymbol'
+    func: 'FuncSymbol | None'
 
     def __init__(
         self,
@@ -700,7 +700,7 @@ class TernaryOp(NaryExpr):
 class NamedTernaryOp(TernaryOp):
     """FPy AST: ternary operation with a named function"""
     __slots__ = ('func',)
-    func: 'FuncSymbol'
+    func: 'FuncSymbol | None'
 
     def __init__(
         self,
@@ -734,7 +734,7 @@ class NaryOp(NaryExpr):
 class NamedNaryOp(NaryOp):
     """FPy AST: n-ary operation with a named function"""
     __slots__ = ('func',)
-    func: 'FuncSymbol'
+    func: 'FuncSymbol | None'
 
     def __init__(
         self,

--- a/fpy2/frontend/fpc.py
+++ b/fpy2/frontend/fpc.py
@@ -27,20 +27,20 @@ def _get_constants():
         _constants_cache = {
             'TRUE': BoolVal(True, None),
             'FALSE': BoolVal(False, None),
-            'NAN': ConstNan(_func_symbol('nan'), None),
-            'INFINITY': ConstInf(_func_symbol('inf'), None),
-            'PI': ConstPi(_func_symbol('const_pi'), None),
-            'E': ConstE(_func_symbol('const_e'), None),
-            'LOG2E': ConstLog2E(_func_symbol('const_log2e'), None),
-            'LOG10E': ConstLog10E(_func_symbol('const_log10e'), None),
-            'LN2': ConstLn2(_func_symbol('const_ln2'), None),
-            'PI_2': ConstPi_2(_func_symbol('const_pi_2'), None),
-            'PI_4': ConstPi_4(_func_symbol('const_pi_4'), None),
-            'M_1_PI': Const1_Pi(_func_symbol('const_1_pi'), None),
-            'M_2_PI': Const2_Pi(_func_symbol('const_2_pi'), None),
-            'M_2_SQRTPI': Const2_SqrtPi(_func_symbol('const_2_sqrtpi'), None),
-            'SQRT2': ConstSqrt2(_func_symbol('const_sqrt2'), None),
-            'SQRT1_2': ConstSqrt1_2(_func_symbol('const_sqrt1_2'), None),
+            'NAN': ConstNan(None, None),
+            'INFINITY': ConstInf(None, None),
+            'PI': ConstPi(None, None),
+            'E': ConstE(None, None),
+            'LOG2E': ConstLog2E(None, None),
+            'LOG10E': ConstLog10E(None, None),
+            'LN2': ConstLn2(None, None),
+            'PI_2': ConstPi_2(None, None),
+            'PI_4': ConstPi_4(None, None),
+            'M_1_PI': Const1_Pi(None, None),
+            'M_2_PI': Const2_Pi(None, None),
+            'M_2_SQRTPI': Const2_SqrtPi(None, None),
+            'SQRT2': ConstSqrt2(None, None),
+            'SQRT1_2': ConstSqrt1_2(None, None),
         }
     return _constants_cache
 
@@ -121,10 +121,10 @@ def _func_symbol(name: str):
     return Var(NamedId(name), None)
 
 def _empty(ns: list[Expr]) -> Expr:
-    return Empty(_func_symbol('empty'), ns, None)
+    return Empty(None, ns, None)
 
 def _round(x: Expr) -> Expr:
-    return Round(_func_symbol('round'), x, None)
+    return Round(None, x, None)
 
 # TODO: clean this up
 class _Ctx:
@@ -188,16 +188,16 @@ class _FPCore2FPy:
         return _round(Decnum(str(e.value), None))
 
     def _visit_hexnum(self, e: fpc.Hexnum, ctx: _Ctx) -> Expr:
-        return _round(Hexnum(_func_symbol('hexnum'), str(e.value), None))
+        return _round(Hexnum(None, str(e.value), None))
 
     def _visit_integer(self, e: fpc.Integer, ctx: _Ctx) -> Expr:
         return _round(Integer(int(e.value), None))
 
     def _visit_rational(self, e: fpc.Rational, ctx: _Ctx) -> Expr:
-        return _round(Rational(_func_symbol('rational'), e.p, e.q, None))
+        return _round(Rational(None, e.p, e.q, None))
 
     def _visit_digits(self, e: fpc.Digits, ctx: _Ctx) -> Expr:
-        return _round(Digits(_func_symbol('digits'), e.m, e.e, e.b, None))
+        return _round(Digits(None, e.m, e.e, e.b, None))
 
     def _visit_unary(self, e: fpc.UnaryExpr, ctx: _Ctx) -> Expr:
         unary_table = _get_unary_table()
@@ -211,7 +211,7 @@ class _FPCore2FPy:
             cls = unary_table[e.name]
             arg = self._visit(e.children[0], ctx)
             if issubclass(cls, NamedUnaryOp):
-                return cls(_func_symbol(e.name), arg, None)
+                return cls(None, arg, None)
             else:
                 return cls(arg, None)
         else:
@@ -224,7 +224,7 @@ class _FPCore2FPy:
             left = self._visit(e.children[0], ctx)
             right = self._visit(e.children[1], ctx)
             if issubclass(cls, NamedBinaryOp):
-                return cls(_func_symbol(e.name), left, right, None)
+                return cls(None, left, right, None)
             else:
                 return cls(left, right, None)
         else:
@@ -232,11 +232,11 @@ class _FPCore2FPy:
                 case 'fmin':
                     left = self._visit(e.children[0], ctx)
                     right = self._visit(e.children[1], ctx)
-                    return Min(_func_symbol('min'), (left, right), None)
+                    return Min(None, (left, right), None)
                 case 'fmax':
                     left = self._visit(e.children[0], ctx)
                     right = self._visit(e.children[1], ctx)
-                    return Max(_func_symbol('max'), (left, right), None)
+                    return Max(None, (left, right), None)
                 case _:
                     raise NotImplementedError(f'unsupported binary operation {e.name}')
 
@@ -248,7 +248,7 @@ class _FPCore2FPy:
             arg1 = self._visit(e.children[1], ctx)
             arg2 = self._visit(e.children[2], ctx)
             if issubclass(cls, NamedTernaryOp):
-                return cls(_func_symbol(e.name), arg0, arg1, arg2, None)
+                return cls(None, arg0, arg1, arg2, None)
             else:
                 return cls(arg0, arg1, arg2, None)
         else:
@@ -299,7 +299,7 @@ class _FPCore2FPy:
                     raise ValueError('size operator expects 2 arguments')
                 arg0 = self._visit(e.children[0], ctx)
                 arg1 = self._visit(e.children[1], ctx)
-                return Size(_func_symbol('size'), arg0, arg1, None)
+                return Size(None, arg0, arg1, None)
             case fpc.UnknownOperator():
                 ident = pythonize_id(e.name)
                 exprs = [self._visit(e, ctx) for e in e.children]
@@ -448,7 +448,7 @@ class _FPCore2FPy:
             t = iter_vars[0]
             n = range_vars[0]
             inner_stmts: list[Stmt] = []
-            e = Range1(_func_symbol('range'), Var(n, None), None)
+            e = Range1(None, Var(n, None), None)
             stmt = ForStmt(t, e, StmtBlock(inner_stmts), None)
             stmts.append(stmt)
             return self._make_tensor_body(iter_vars[1:], range_vars[1:], inner_stmts)
@@ -756,7 +756,7 @@ class _FPCore2FPy:
                             case str():
                                 # named dimension
                                 dim_id = self.gensym.fresh(dim)
-                                size_e = Size(_func_symbol('size'), Var(t, None), Integer(i, None), None)
+                                size_e = Size(None, Var(t, None), Integer(i, None), None)
                                 stmt = Assign(dim_id, None, size_e, None)
                                 ctx.stmts.append(stmt)
                                 # TODO: duplicate dimension names means a runtime check

--- a/fpy2/transform/const_fold.py
+++ b/fpy2/transform/const_fold.py
@@ -18,8 +18,9 @@ def _rational_literal(val: Fraction, loc):
     otherwise an ``fp.rational(p, q)`` call."""
     if val.denominator == 1:
         return Integer(int(val), loc)
-    func = Attribute(Var(NamedId('fp'), loc), 'rational', loc)
-    return Rational(func, val.numerator, val.denominator, loc)
+    # synthesized node: no surface reference; the pretty-printer names it
+    # per the target function's namespace (see CANONICAL_OP_NAMES).
+    return Rational(None, val.numerator, val.denominator, loc)
 
 
 def value_to_literal(val: object, loc):

--- a/fpy2/transform/const_fold.py
+++ b/fpy2/transform/const_fold.py
@@ -15,11 +15,9 @@ from ..number import Context, Float
 
 def _rational_literal(val: Fraction, loc):
     """AST literal for an exact rational: an ``Integer`` when integral,
-    otherwise an ``fp.rational(p, q)`` call."""
+    otherwise a ``rational`` literal."""
     if val.denominator == 1:
         return Integer(int(val), loc)
-    # synthesized node: no surface reference; the pretty-printer names it
-    # per the target function's namespace (see CANONICAL_OP_NAMES).
     return Rational(None, val.numerator, val.denominator, loc)
 
 

--- a/fpy2/transform/for_unroll.py
+++ b/fpy2/transform/for_unroll.py
@@ -69,13 +69,13 @@ def _sub(a: Expr, b: Expr) -> Sub:
     return Sub(a, b, None)
 
 def _len(xs: Expr) -> Len:
-    return Len(_var(NamedId('len')), xs, None)
+    return Len(None, xs, None)
 
 def _fmod(a: Expr, b: Expr) -> Fmod:
-    return Fmod(_var(NamedId('fmod')), a, b, None)
+    return Fmod(None, a, b, None)
 
 def _range(start: Expr, stop: Expr, step: Expr) -> Range3:
-    return Range3(_var(NamedId('range')), start, stop, step, None)
+    return Range3(None, start, stop, step, None)
 
 def _eq(a: Expr, b: Expr) -> Compare:
     return Compare([CompareOp.EQ], [a, b], None)

--- a/fpy2/transform/split_loop.py
+++ b/fpy2/transform/split_loop.py
@@ -96,12 +96,12 @@ class _SplitLoop(DefaultTransformVisitor):
                         UnderscoreId(),
                         ForeignVal(INTEGER, None),
                         StmtBlock([
-                            Assign(n, None, Len(Var(NamedId('len'), None), Var(t1, None), None), None),
+                            Assign(n, None, Len(None, Var(t1, None), None), None),
                             AssertStmt(
                                 Compare(
                                     [CompareOp.EQ], 
                                     [
-                                        Fmod(Var(NamedId('fmod'), None), Var(n, None), Var(t2, None), None),
+                                        Fmod(None, Var(n, None), Var(t2, None), None),
                                         Integer(0, None)
                                     ],
                                     None
@@ -140,7 +140,7 @@ class _SplitLoop(DefaultTransformVisitor):
             # outer loop
             stmt = ForStmt(
                 outer,
-                Range3(Var(NamedId('range'), None), Integer(0, None), Var(n, None), Var(t2, None), None),
+                Range3(None, Integer(0, None), Var(n, None), Var(t2, None), None),
                 StmtBlock([slice_ctx, inner_loop]),
                 stmt.loc
             )

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -172,14 +172,12 @@ def _index_access(arg: Expr, idx: NamedId) -> Callable[[], Expr]:
 
 def _fst(arg: Expr) -> Expr:
     """Build ``fst(arg)``."""
-    name = Attribute(Var(NamedId('fp'), None), 'fst', None)
-    return Fst(name, arg, None)
+    return Fst(None, arg, None)
 
 
 def _snd(arg: Expr) -> Expr:
     """Build ``snd(arg)``."""
-    name = Attribute(Var(NamedId('fp'), None), 'snd', None)
-    return Snd(name, arg, None)
+    return Snd(None, arg, None)
 
 
 def _comp_nesting_is_pairs(target: TupleBinding) -> bool:
@@ -365,12 +363,12 @@ class _ZipElimInstance(DefaultTransformVisitor):
         new_body_stmts: list[Stmt] = per_iter + list(new_body.stmts)
         # Iterable: ``range(len(_src0))``.
         size_expr = Len(
-            Var(NamedId('len'), None),
+            None,
             Var(src_names[0], None),
             None,
         )
         range_expr = Range1(
-            Var(NamedId('range'), None),
+            None,
             size_expr,
             None,
         )
@@ -421,13 +419,13 @@ class _ZipElimInstance(DefaultTransformVisitor):
                     )
                 # New target/iterable: ``_i in range(len(arg0))``.
                 len_expr = Len(
-                    Var(NamedId('len'), None),
+                    None,
                     _clone(new_iter.args[0]),
                     None,
                 )
                 new_targets.append(idx)
                 new_iterables.append(
-                    Range1(Var(NamedId('range'), None), len_expr, None)
+                    Range1(None, len_expr, None)
                 )
             else:
                 new_targets.append(self._visit_binding(target, ctx))

--- a/tests/unit/test_op_names.py
+++ b/tests/unit/test_op_names.py
@@ -1,0 +1,101 @@
+"""
+Tests for `CANONICAL_OP_NAMES` (fpy2/ast/fpyast.py).
+
+These tie the canonical node-type -> name registry to the parser's
+name -> node-type tables so the two cannot drift apart: the pretty-printer
+uses `CANONICAL_OP_NAMES` to render an operator synthesized by a rewrite
+pass (whose `func` symbol is `None`), and that rendered name must resolve
+back to the same operator when re-parsed.
+"""
+
+import builtins
+import inspect
+
+import fpy2
+import fpy2.frontend.parser as parser
+
+from fpy2.ast import fpyast
+from fpy2.ast.fpyast import (
+    CANONICAL_OP_NAMES,
+    NullaryOp, NamedUnaryOp, NamedBinaryOp, NamedTernaryOp, NamedNaryOp,
+    Hexnum, Rational, Digits,
+)
+
+# every node class whose `func` symbol may be `None` (and therefore must be
+# renderable from its type alone)
+_FUNC_BEARING_BASES = (
+    NullaryOp, NamedUnaryOp, NamedBinaryOp, NamedTernaryOp, NamedNaryOp,
+)
+
+_PARSER_TABLES = (
+    parser._nullary_table,
+    parser._unary_table,
+    parser._binary_table,
+    parser._ternary_table,
+    parser._nary_table,
+)
+
+
+def _concrete_func_bearing_classes() -> set[type]:
+    classes = {
+        obj
+        for obj in vars(fpyast).values()
+        if inspect.isclass(obj)
+        and issubclass(obj, _FUNC_BEARING_BASES)
+        and obj not in _FUNC_BEARING_BASES
+    }
+    classes |= {Hexnum, Rational, Digits}
+    return classes
+
+
+def _parser_class_to_callables() -> dict[type, set]:
+    m: dict[type, set] = {}
+    for table in _PARSER_TABLES:
+        for fn, cls in table.items():
+            m.setdefault(cls, set()).add(fn)
+    return m
+
+
+def _resolve(name: str):
+    """The callable a canonical name resolves to, preferring fpy2 over builtins
+    (the parser resolves `fp.<name>` before a bare builtin)."""
+    obj = getattr(fpy2, name, None)
+    if obj is None:
+        obj = getattr(builtins, name, None)
+    return obj
+
+
+def test_registry_covers_all_func_bearing_classes():
+    missing = sorted(
+        c.__name__ for c in _concrete_func_bearing_classes() - set(CANONICAL_OP_NAMES)
+    )
+    assert not missing, f'operator classes with no canonical name: {missing}'
+
+
+def test_registry_has_no_stale_entries():
+    stale = sorted(
+        c.__name__ for c in set(CANONICAL_OP_NAMES) - _concrete_func_bearing_classes()
+    )
+    assert not stale, f'canonical names for non-operator classes: {stale}'
+
+
+def test_canonical_names_resolve():
+    for cls, name in CANONICAL_OP_NAMES.items():
+        assert _resolve(name) is not None, (
+            f'{cls.__name__}: canonical name {name!r} is neither an fpy2 '
+            f'attribute nor a Python builtin'
+        )
+
+
+def test_canonical_names_map_back_to_class():
+    # for every class the parser produces from a surface name, that name must
+    # resolve to a callable the parser maps back to the same class
+    for cls, callables in _parser_class_to_callables().items():
+        if cls not in CANONICAL_OP_NAMES:
+            continue  # non-named ops (Add, Abs, ...) render without a func symbol
+        name = CANONICAL_OP_NAMES[cls]
+        resolved = _resolve(name)
+        assert resolved in callables, (
+            f'{cls.__name__}: canonical name {name!r} resolves to a callable '
+            f'the parser does not map to {cls.__name__}'
+        )


### PR DESCRIPTION
Inserting operators into the AST required manually setting the function symbol. This PR fixes that issue by automatically finding the function name for each operator