### PR TITLE
Support Python's `any` and `all`

### DIFF
--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -423,6 +423,14 @@ class _TypeInferInstance(Visitor):
                     # list-reduce operators: list[real] -> real
                     self._unify(arg_ty, ListType(RealType(None)))
                     return RealType(None)
+                case AnyOf() | AllOf():
+                    # boolean list-reduce operators: list[bool] -> bool.
+                    # Built here rather than in `_unary_table` because `_unify`
+                    # unions the `ListType` it is handed into `tvars` (and
+                    # merges its length), so a shared table entry would leak
+                    # unification state across call sites.
+                    self._unify(arg_ty, ListType(BoolType()))
+                    return BoolType()
                 case _:
                     raise ValueError(f'unknown unary operator: {cls}')
 

--- a/fpy2/analysis/type_infer.py
+++ b/fpy2/analysis/type_infer.py
@@ -424,11 +424,7 @@ class _TypeInferInstance(Visitor):
                     self._unify(arg_ty, ListType(RealType(None)))
                     return RealType(None)
                 case AnyOf() | AllOf():
-                    # boolean list-reduce operators: list[bool] -> bool.
-                    # Built here rather than in `_unary_table` because `_unify`
-                    # unions the `ListType` it is handed into `tvars` (and
-                    # merges its length), so a shared table entry would leak
-                    # unification state across call sites.
+                    # boolean list-reduce operators: list[bool] -> bool
                     self._unify(arg_ty, ListType(BoolType()))
                     return BoolType()
                 case _:

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -35,7 +35,9 @@ __all__ = [
     'Acosh',
     # IEEE 754 arithmetic
     'Add',
+    'AllOf',
     'And',
+    'AnyOf',
     # Type annotations
     'AnyTypeAnn',
     # Function definition
@@ -1096,6 +1098,21 @@ class And(NaryOp):
     """FPy node: logical conjunction"""
     __slots__ = ()
 
+class AnyOf(NamedUnaryOp):
+    """FPy node: ``any(bs)`` reduce-form over ``bs : list[bool]``.
+
+    The list-fold counterpart of :class:`Or`, as :class:`AMax` is to
+    :class:`Max`.  Named ``AnyOf`` rather than ``Any`` so the class does not
+    shadow :data:`typing.Any`, which this module and its star-importers
+    (notably :mod:`fpy2.frontend.parser`) both use in annotations.
+    """
+    __slots__ = ()
+
+class AllOf(NamedUnaryOp):
+    """FPy node: ``all(bs)`` reduce-form — the :class:`And` counterpart of
+    :class:`AnyOf`."""
+    __slots__ = ()
+
 # Rounding operator
 
 class Round(NamedUnaryOp):
@@ -1892,6 +1909,8 @@ CANONICAL_OP_NAMES: dict[type, str] = {
     Logb: 'logb',
     AMin: 'min',
     AMax: 'max',
+    AnyOf: 'any',
+    AllOf: 'all',
     Range1: 'range',
     # binary
     Copysign: 'copysign',

--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -1101,16 +1101,15 @@ class And(NaryOp):
 class AnyOf(NamedUnaryOp):
     """FPy node: ``any(bs)`` reduce-form over ``bs : list[bool]``.
 
-    The list-fold counterpart of :class:`Or`, as :class:`AMax` is to
-    :class:`Max`.  Named ``AnyOf`` rather than ``Any`` so the class does not
-    shadow :data:`typing.Any`, which this module and its star-importers
-    (notably :mod:`fpy2.frontend.parser`) both use in annotations.
+    List-fold counterpart of :class:`Or`, as :class:`AMax` is to :class:`Max`.
+    Not named ``Any``: that would shadow :data:`typing.Any`, which this module
+    and its star-importers use in annotations.
     """
     __slots__ = ()
 
 class AllOf(NamedUnaryOp):
-    """FPy node: ``all(bs)`` reduce-form — the :class:`And` counterpart of
-    :class:`AnyOf`."""
+    """FPy node: ``all(bs)`` reduce-form — :class:`And` to :class:`AnyOf`'s
+    :class:`Or`."""
     __slots__ = ()
 
 # Rounding operator

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -1759,28 +1759,10 @@ class CppEmitter(Visitor):
         return result
 
     def _emit_any_all(self, e: 'AnyOf | AllOf', arg_str: str) -> str:
-        """Reduce ``any(bs)`` / ``all(bs)`` to ``std::any_of`` / ``std::all_of``.
-
-        Unlike :meth:`_emit_amin_amax` this needs no hoisted loop and no
-        casting: the operand is ``std::vector<bool>`` and the result is
-        ``bool``, so the standard algorithm applies directly with an identity
-        predicate.  It also short-circuits, matching Python — and unlike the
-        FPCore lowering, whose ``for`` has a fixed trip count.
-
-        The empty range is well defined and agrees with FPy: ``std::all_of``
-        yields ``true`` and ``std::any_of`` yields ``false``.  No UB here, in
-        contrast to the ``xs[0]`` that ``min``/``max`` index unguarded.
-
-        As with ``Sum``, the operand is bound to ``auto&&`` first: on a prvalue
-        operand (a list literal, say) ``arg.begin()`` and ``arg.end()`` would
-        name iterators into *different* temporaries — an invalid range.
-        """
-        result_ty = self._storage_for_expr(e)
-        if result_ty is not CppScalar.BOOL:
-            raise CppEmitError(
-                f'expected bool result for {type(e).__name__}, got {result_ty!r}',
-                at=e,
-            )
+        """``any(bs)`` / ``all(bs)`` -> ``std::any_of`` / ``std::all_of`` with an
+        identity predicate.  The empty range agrees with FPy (``all_of`` is
+        ``true``, ``any_of`` is ``false``), so unlike ``min``/``max`` there is
+        no unguarded ``xs[0]``."""
         arg_storage = self._storage_for_expr(e.arg)
         if arg_storage != CppList(CppScalar.BOOL):
             raise CppEmitError(
@@ -1789,8 +1771,9 @@ class CppEmitter(Visitor):
                 at=e,
             )
         fn = 'std::any_of' if isinstance(e, AnyOf) else 'std::all_of'
+        # Bind first, as ``Sum`` does: on a prvalue operand ``begin()`` and
+        # ``end()`` would name iterators into different temporaries.
         src = self._fresh_temp()
-        # source read only (iterated) -> reference, no copy
         self.writer.add_line(f'auto&& {src} = {arg_str};')
         pred = self._fresh_temp()
         return (

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -51,9 +51,11 @@ from ...analysis.format_infer import (
     round_is_identity,
 )
 from ...ast.fpyast import (
+    AllOf,
     AMax,
     AMin,
     And,
+    AnyOf,
     Argument,
     AssertStmt,
     Assign,
@@ -1266,6 +1268,8 @@ class CppEmitter(Visitor):
                 )
             case AMin() | AMax():
                 return self._emit_amin_amax(e, arg)
+            case AnyOf() | AllOf():
+                return self._emit_any_all(e, arg)
             case Enumerate():
                 return self._emit_enumerate(e, arg)
             case UnaryOp() if type(e) in self.op_table.unary:
@@ -1753,6 +1757,46 @@ class CppEmitter(Visitor):
         for nxt in casted[1:]:
             result = f'{fn}({result}, {nxt})'
         return result
+
+    def _emit_any_all(self, e: 'AnyOf | AllOf', arg_str: str) -> str:
+        """Reduce ``any(bs)`` / ``all(bs)`` to ``std::any_of`` / ``std::all_of``.
+
+        Unlike :meth:`_emit_amin_amax` this needs no hoisted loop and no
+        casting: the operand is ``std::vector<bool>`` and the result is
+        ``bool``, so the standard algorithm applies directly with an identity
+        predicate.  It also short-circuits, matching Python — and unlike the
+        FPCore lowering, whose ``for`` has a fixed trip count.
+
+        The empty range is well defined and agrees with FPy: ``std::all_of``
+        yields ``true`` and ``std::any_of`` yields ``false``.  No UB here, in
+        contrast to the ``xs[0]`` that ``min``/``max`` index unguarded.
+
+        As with ``Sum``, the operand is bound to ``auto&&`` first: on a prvalue
+        operand (a list literal, say) ``arg.begin()`` and ``arg.end()`` would
+        name iterators into *different* temporaries — an invalid range.
+        """
+        result_ty = self._storage_for_expr(e)
+        if result_ty is not CppScalar.BOOL:
+            raise CppEmitError(
+                f'expected bool result for {type(e).__name__}, got {result_ty!r}',
+                at=e,
+            )
+        arg_storage = self._storage_for_expr(e.arg)
+        if arg_storage != CppList(CppScalar.BOOL):
+            raise CppEmitError(
+                f'expected list[bool] arg for {type(e).__name__}, '
+                f'got {arg_storage!r}',
+                at=e,
+            )
+        fn = 'std::any_of' if isinstance(e, AnyOf) else 'std::all_of'
+        src = self._fresh_temp()
+        # source read only (iterated) -> reference, no copy
+        self.writer.add_line(f'auto&& {src} = {arg_str};')
+        pred = self._fresh_temp()
+        return (
+            f'{fn}({src}.begin(), {src}.end(), '
+            f'[](bool {pred}) {{ return {pred}; }})'
+        )
 
     def _emit_amin_amax(self, e: 'AMin | AMax', arg_str: str) -> str:
         """Reduce ``min(xs)`` / ``max(xs)`` to a hoisted for-loop.

--- a/fpy2/backend/cpp/utils.py
+++ b/fpy2/backend/cpp/utils.py
@@ -10,6 +10,9 @@ explicitly and concatenate them — same shape as the legacy
 
 Header coverage tracks what the emitter actually uses:
 
+- ``<algorithm>``: ``std::any_of`` / ``std::all_of`` for ``AnyOf`` / ``AllOf``,
+  and ``std::min`` / ``std::max`` for the integer ``min``/``max`` paths (which
+  previously resolved only transitively through another header).
 - ``<cassert>``: ``assert(...)`` from ``Cast``.
 - ``<cfenv>``: ``std::fegetround`` / ``std::fesetround`` and the
   ``FE_*`` rounding-mode macros.
@@ -32,6 +35,7 @@ home.
 
 
 CPP_HEADERS: tuple[str, ...] = (
+    '#include <algorithm>',
     '#include <cassert>',
     '#include <cfenv>',
     '#include <cmath>',

--- a/fpy2/backend/cpp/utils.py
+++ b/fpy2/backend/cpp/utils.py
@@ -11,8 +11,7 @@ explicitly and concatenate them — same shape as the legacy
 Header coverage tracks what the emitter actually uses:
 
 - ``<algorithm>``: ``std::any_of`` / ``std::all_of`` for ``AnyOf`` / ``AllOf``,
-  and ``std::min`` / ``std::max`` for the integer ``min``/``max`` paths (which
-  previously resolved only transitively through another header).
+  and ``std::min`` / ``std::max`` for the integer ``min``/``max`` paths.
 - ``<cassert>``: ``assert(...)`` from ``Cast``.
 - ``<cfenv>``: ``std::fegetround`` / ``std::fesetround`` and the
   ``FE_*`` rounding-mode macros.

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -624,6 +624,62 @@ class _FPCoreCompileInstance(Visitor):
             )
         )
 
+    def _visit_any(self, arg: Expr, ctx: None) -> fpc.Expr:
+        # any(bs) → fold over the list with `or`, seeded FALSE.
+        return self._visit_bool_reduce(arg, fpc.Or, 'FALSE', ctx)
+
+    def _visit_all(self, arg: Expr, ctx: None) -> fpc.Expr:
+        # all(bs) → fold over the list with `and`, seeded TRUE.
+        return self._visit_bool_reduce(arg, fpc.And, 'TRUE', ctx)
+
+    def _visit_bool_reduce(
+        self,
+        arg: Expr,
+        combine: Callable[[fpc.Expr, fpc.Expr], fpc.Expr],
+        identity: str,
+        ctx: None,
+    ) -> fpc.Expr:
+        """Shared lowering for the boolean list reductions
+        (``any``/``all``).  Builds::
+
+            (let ([t <tuple>])
+              (for ([i (! :precision integer (size t 0))]
+                    [accum <identity> (<combine> accum (ref t i))])
+                accum))
+
+        Simpler than :meth:`_visit_list_reduce` because the accumulator is
+        seeded with the operator's *identity* (``FALSE`` for ``or``, ``TRUE``
+        for ``and``) rather than with the first element: the loop runs over
+        all ``n`` indices, so there is no ``n - 1`` bound and no ``(+ i 1)``
+        index arithmetic.  The empty list is then correct by construction —
+        the ``for`` body never runs and the identity is returned — where the
+        arithmetic reductions leave it out of contract.
+
+        The fold is eager, while Python's ``any``/``all`` short-circuit.  That
+        is unobservable here: the operand is an already-materialized list and
+        FPy is pure, so visiting every element cannot change the result.
+        (FPCore's ``for`` has a fixed trip count and could not short-circuit
+        regardless; expressing that would need a ``while``.)
+        """
+        tuple_id = str(self.gensym.fresh('t'))
+        iter_id = str(self.gensym.fresh('i'))
+        accum_id = str(self.gensym.fresh('accum'))
+        idx_ctx = { 'precision': 'integer' }
+
+        tup = self._visit_expr(arg, ctx)
+        return fpc.Let(
+            [(tuple_id, tup)],
+            fpc.For(
+                [(iter_id, fpc.Ctx(idx_ctx, _size0_expr(tuple_id)))],
+                [(
+                    accum_id,
+                    fpc.Constant(identity),
+                    combine(fpc.Var(accum_id), fpc.Ref(fpc.Var(tuple_id), fpc.Var(iter_id)))
+                )],
+                fpc.Var(accum_id)
+            )
+        )
+
 
     def _visit_nullaryop(self, e: NullaryOp, ctx: None) -> fpc.Expr:
         nullary_table = _get_nullary_table()
@@ -666,6 +722,12 @@ class _FPCoreCompileInstance(Visitor):
                 case AMax():
                     # max(xs) reduce-form
                     return self._visit_amax(e.arg, ctx)
+                case AnyOf():
+                    # any(bs) boolean reduce-form
+                    return self._visit_any(e.arg, ctx)
+                case AllOf():
+                    # all(bs) boolean reduce-form
+                    return self._visit_all(e.arg, ctx)
                 case _:
                     raise NotImplementedError('no FPCore operator for', e)
 

--- a/fpy2/backend/fpc.py
+++ b/fpy2/backend/fpc.py
@@ -624,49 +624,29 @@ class _FPCoreCompileInstance(Visitor):
             )
         )
 
-    def _visit_any(self, arg: Expr, ctx: None) -> fpc.Expr:
-        # any(bs) → fold over the list with `or`, seeded FALSE.
-        return self._visit_bool_reduce(arg, fpc.Or, 'FALSE', ctx)
-
-    def _visit_all(self, arg: Expr, ctx: None) -> fpc.Expr:
-        # all(bs) → fold over the list with `and`, seeded TRUE.
-        return self._visit_bool_reduce(arg, fpc.And, 'TRUE', ctx)
-
-    def _visit_bool_reduce(
-        self,
-        arg: Expr,
-        combine: Callable[[fpc.Expr, fpc.Expr], fpc.Expr],
-        identity: str,
-        ctx: None,
-    ) -> fpc.Expr:
-        """Shared lowering for the boolean list reductions
-        (``any``/``all``).  Builds::
+    def _visit_bool_reduce(self, e: 'AnyOf | AllOf', ctx: None) -> fpc.Expr:
+        """``any``/``all`` — fold the list with ``or``/``and``.  Builds::
 
             (let ([t <tuple>])
               (for ([i (! :precision integer (size t 0))]
                     [accum <identity> (<combine> accum (ref t i))])
                 accum))
 
-        Simpler than :meth:`_visit_list_reduce` because the accumulator is
-        seeded with the operator's *identity* (``FALSE`` for ``or``, ``TRUE``
-        for ``and``) rather than with the first element: the loop runs over
-        all ``n`` indices, so there is no ``n - 1`` bound and no ``(+ i 1)``
-        index arithmetic.  The empty list is then correct by construction —
-        the ``for`` body never runs and the identity is returned — where the
-        arithmetic reductions leave it out of contract.
-
-        The fold is eager, while Python's ``any``/``all`` short-circuit.  That
-        is unobservable here: the operand is an already-materialized list and
-        FPy is pure, so visiting every element cannot change the result.
-        (FPCore's ``for`` has a fixed trip count and could not short-circuit
-        regardless; expressing that would need a ``while``.)
+        Unlike :meth:`_visit_list_reduce` the accumulator is seeded with the
+        operator's identity rather than element 0, so the loop covers all ``n``
+        indices: no ``n - 1`` bound, no ``(+ i 1)`` arithmetic, and the empty
+        list is correct by construction rather than out of contract.
         """
+        is_any = isinstance(e, AnyOf)
+        combine = fpc.Or if is_any else fpc.And
+        identity = 'FALSE' if is_any else 'TRUE'
+
         tuple_id = str(self.gensym.fresh('t'))
         iter_id = str(self.gensym.fresh('i'))
         accum_id = str(self.gensym.fresh('accum'))
         idx_ctx = { 'precision': 'integer' }
 
-        tup = self._visit_expr(arg, ctx)
+        tup = self._visit_expr(e.arg, ctx)
         return fpc.Let(
             [(tuple_id, tup)],
             fpc.For(
@@ -679,7 +659,6 @@ class _FPCoreCompileInstance(Visitor):
                 fpc.Var(accum_id)
             )
         )
-
 
     def _visit_nullaryop(self, e: NullaryOp, ctx: None) -> fpc.Expr:
         nullary_table = _get_nullary_table()
@@ -722,12 +701,9 @@ class _FPCoreCompileInstance(Visitor):
                 case AMax():
                     # max(xs) reduce-form
                     return self._visit_amax(e.arg, ctx)
-                case AnyOf():
-                    # any(bs) boolean reduce-form
-                    return self._visit_any(e.arg, ctx)
-                case AllOf():
-                    # all(bs) boolean reduce-form
-                    return self._visit_all(e.arg, ctx)
+                case AnyOf() | AllOf():
+                    # any(bs) / all(bs) boolean reduce-forms
+                    return self._visit_bool_reduce(e, ctx)
                 case _:
                     raise NotImplementedError('no FPCore operator for', e)
 

--- a/fpy2/frontend/parser.py
+++ b/fpy2/frontend/parser.py
@@ -76,6 +76,8 @@ _unary_table: dict[Callable, type[UnaryOp] | type[NamedUnaryOp]] = {
     snd: Snd,
     enumerate: Enumerate,
     sum: Sum,
+    any: AnyOf,
+    all: AllOf,
     logb: Logb,
 }
 

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -419,10 +419,8 @@ def _eval_len(x):
     return len(x)
 
 def _check_bool_list(x, who: str) -> list[bool]:
-    # `any`/`all` take a list of booleans only (matches `TypeInfer`).  The
-    # native builtins would accept a tuple and coerce reals via truthiness;
-    # FPy has no truthiness, so a non-bool element is an error rather than a
-    # zero test.
+    # `any`/`all` are list-of-bool only (matches `TypeInfer`); the native
+    # builtins would accept a tuple and coerce reals via truthiness.
     if not isinstance(x, list):
         raise TypeError(f'{who} expects a list, got {x}')
     for b in x:
@@ -730,8 +728,7 @@ class BytecodeCompiler(Visitor):
                 func = pyast.Name(id=builtin, ctx=pyast.Load(), **attrs)
                 return pyast.Call(func=func, args=[arg], keywords=[], **attrs)
             case AnyOf() | AllOf():
-                # Boolean reduce-form: the guards delegate to Python's
-                # `any`/`all`.  No `ctx` keyword — neither operator rounds.
+                # Boolean reduce-form; no `ctx` keyword — neither op rounds.
                 builtin = '__fpy_any' if isinstance(e, AnyOf) else '__fpy_all'
                 func = pyast.Name(id=builtin, ctx=pyast.Load(), **attrs)
                 return pyast.Call(func=func, args=[arg], keywords=[], **attrs)

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -418,6 +418,24 @@ def _eval_len(x):
         raise TypeError(f'len() expects a list, got {x}')
     return len(x)
 
+def _check_bool_list(x, who: str) -> list[bool]:
+    # `any`/`all` take a list of booleans only (matches `TypeInfer`).  The
+    # native builtins would accept a tuple and coerce reals via truthiness;
+    # FPy has no truthiness, so a non-bool element is an error rather than a
+    # zero test.
+    if not isinstance(x, list):
+        raise TypeError(f'{who} expects a list, got {x}')
+    for b in x:
+        if not isinstance(b, bool):
+            raise TypeError(f'{who} expects a list of booleans, got {b}')
+    return x
+
+def _eval_any(x):
+    return any(_check_bool_list(x, 'any()'))
+
+def _eval_all(x):
+    return all(_check_bool_list(x, 'all()'))
+
 ###########################################################
 # Operator tables
 
@@ -531,6 +549,8 @@ def make_namespace() -> dict[str, object]:
         '__fpy_min': _eval_min,
         '__fpy_max': _eval_max,
         '__fpy_len': _eval_len,
+        '__fpy_any': _eval_any,
+        '__fpy_all': _eval_all,
         REAL_NAME: REAL,
     }
 
@@ -707,6 +727,12 @@ class BytecodeCompiler(Visitor):
                 # Reduce-form lowers to Python's built-in min/max on the
                 # list, matching the n-ary Min/Max emit.
                 builtin = '__fpy_min' if isinstance(e, AMin) else '__fpy_max'
+                func = pyast.Name(id=builtin, ctx=pyast.Load(), **attrs)
+                return pyast.Call(func=func, args=[arg], keywords=[], **attrs)
+            case AnyOf() | AllOf():
+                # Boolean reduce-form: the guards delegate to Python's
+                # `any`/`all`.  No `ctx` keyword — neither operator rounds.
+                builtin = '__fpy_any' if isinstance(e, AnyOf) else '__fpy_all'
                 func = pyast.Name(id=builtin, ctx=pyast.Load(), **attrs)
                 return pyast.Call(func=func, args=[arg], keywords=[], **attrs)
             case _:

--- a/tests/unit/analysis/test_type_infer.py
+++ b/tests/unit/analysis/test_type_infer.py
@@ -347,81 +347,68 @@ class TestTupleAccessors:
 
 
 class TestBooleanReductions:
-    """``any`` / ``all`` are ``list[bool] -> bool``.
-
-    Unlike ``fst``/``snd`` these are monomorphic: the element type is pinned to
-    ``bool``, so a ``list[real]`` operand is rejected by unification rather than
-    silently accepted via truthiness (FPy has no truthiness).
-    """
+    """``any`` / ``all`` are ``list[bool] -> bool`` — monomorphic, so a
+    ``list[real]`` operand is rejected by unification rather than accepted via
+    truthiness (FPy has none)."""
 
     @staticmethod
     def _return_type(f) -> Type:
         return TypeInfer.check(f.ast).fn_type.return_type
 
-    def test_any_parses_to_anyof_node(self):
+    def test_parses_to_reduce_nodes(self):
         @fp.fpy
         def f(bs: list[bool]) -> bool:
             return any(bs)
+
+        @fp.fpy
+        def g(bs: list[bool]) -> bool:
+            return all(bs)
 
         assert isinstance(f.ast.body.stmts[-1].expr, AnyOf)
+        assert isinstance(g.ast.body.stmts[-1].expr, AllOf)
 
-    def test_all_parses_to_allof_node(self):
-        @fp.fpy
-        def f(bs: list[bool]) -> bool:
-            return all(bs)
-
-        assert isinstance(f.ast.body.stmts[-1].expr, AllOf)
-
-    def test_any_of_bool_list_is_bool(self):
+    def test_bool_list_is_bool(self):
         @fp.fpy
         def f(bs: list[bool]) -> bool:
             return any(bs)
 
-        assert isinstance(self._return_type(f), BoolType)
-
-    def test_all_of_bool_list_is_bool(self):
         @fp.fpy
-        def f(bs: list[bool]) -> bool:
+        def g(bs: list[bool]) -> bool:
             return all(bs)
 
         assert isinstance(self._return_type(f), BoolType)
+        assert isinstance(self._return_type(g), BoolType)
 
-    def test_any_of_comprehension_of_comparisons_is_bool(self):
-        # the idiomatic use: the element type is inferred, not annotated
+    def test_comprehension_element_type_is_inferred(self):
+        # the idiomatic use: `bool` comes from the comparison, not an annotation
         @fp.fpy
         def f(xs: list[fp.Real]) -> bool:
             return any([x < 0 for x in xs])
 
         assert isinstance(self._return_type(f), BoolType)
 
-    def test_any_of_real_list_errors(self):
+    def test_real_list_errors(self):
         @fp.fpy
         def f(xs: list[fp.Real]) -> bool:
             return any(xs)
 
-        with pytest.raises(TypeInferError):
-            TypeInfer.check(f.ast)
-
-    def test_all_of_real_list_errors(self):
         @fp.fpy
-        def f(xs: list[fp.Real]) -> bool:
+        def g(xs: list[fp.Real]) -> bool:
             return all(xs)
 
-        with pytest.raises(TypeInferError):
-            TypeInfer.check(f.ast)
+        for fn in (f, g):
+            with pytest.raises(TypeInferError):
+                TypeInfer.check(fn.ast)
 
-    def test_any_of_scalar_errors(self):
+    def test_non_list_operand_errors(self):
         @fp.fpy
-        def f(b: bool) -> bool:
+        def scalar(b: bool) -> bool:
             return any(b)
 
-        with pytest.raises(TypeInferError):
-            TypeInfer.check(f.ast)
-
-    def test_any_of_tuple_errors(self):
         @fp.fpy
-        def f(t: tuple[bool, bool]) -> bool:
+        def tup(t: tuple[bool, bool]) -> bool:
             return any(t)
 
-        with pytest.raises(TypeInferError):
-            TypeInfer.check(f.ast)
+        for fn in (scalar, tup):
+            with pytest.raises(TypeInferError):
+                TypeInfer.check(fn.ast)

--- a/tests/unit/analysis/test_type_infer.py
+++ b/tests/unit/analysis/test_type_infer.py
@@ -17,7 +17,7 @@ from hypothesis import given, settings, strategies as st
 from fpy2.analysis import TypeInfer
 from fpy2.analysis.type_infer import TypeInfer as _TI
 from fpy2.analysis.type_infer import TypeInferError
-from fpy2.ast.fpyast import Ast, Expr, Fst, FuncDef, Snd
+from fpy2.ast.fpyast import AllOf, AnyOf, Ast, Expr, Fst, FuncDef, Snd
 from fpy2.types import BoolType, RealType, TupleType, Type
 
 from ..generators import (
@@ -341,6 +341,87 @@ class TestTupleAccessors:
         @fp.fpy
         def f(x: list[fp.Real]) -> fp.Real:
             return fp.snd(x)
+
+        with pytest.raises(TypeInferError):
+            TypeInfer.check(f.ast)
+
+
+class TestBooleanReductions:
+    """``any`` / ``all`` are ``list[bool] -> bool``.
+
+    Unlike ``fst``/``snd`` these are monomorphic: the element type is pinned to
+    ``bool``, so a ``list[real]`` operand is rejected by unification rather than
+    silently accepted via truthiness (FPy has no truthiness).
+    """
+
+    @staticmethod
+    def _return_type(f) -> Type:
+        return TypeInfer.check(f.ast).fn_type.return_type
+
+    def test_any_parses_to_anyof_node(self):
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            return any(bs)
+
+        assert isinstance(f.ast.body.stmts[-1].expr, AnyOf)
+
+    def test_all_parses_to_allof_node(self):
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            return all(bs)
+
+        assert isinstance(f.ast.body.stmts[-1].expr, AllOf)
+
+    def test_any_of_bool_list_is_bool(self):
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            return any(bs)
+
+        assert isinstance(self._return_type(f), BoolType)
+
+    def test_all_of_bool_list_is_bool(self):
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            return all(bs)
+
+        assert isinstance(self._return_type(f), BoolType)
+
+    def test_any_of_comprehension_of_comparisons_is_bool(self):
+        # the idiomatic use: the element type is inferred, not annotated
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            return any([x < 0 for x in xs])
+
+        assert isinstance(self._return_type(f), BoolType)
+
+    def test_any_of_real_list_errors(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            return any(xs)
+
+        with pytest.raises(TypeInferError):
+            TypeInfer.check(f.ast)
+
+    def test_all_of_real_list_errors(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            return all(xs)
+
+        with pytest.raises(TypeInferError):
+            TypeInfer.check(f.ast)
+
+    def test_any_of_scalar_errors(self):
+        @fp.fpy
+        def f(b: bool) -> bool:
+            return any(b)
+
+        with pytest.raises(TypeInferError):
+            TypeInfer.check(f.ast)
+
+    def test_any_of_tuple_errors(self):
+        @fp.fpy
+        def f(t: tuple[bool, bool]) -> bool:
+            return any(t)
 
         with pytest.raises(TypeInferError):
             TypeInfer.check(f.ast)

--- a/tests/unit/backend/cpp/test_emit_bool.py
+++ b/tests/unit/backend/cpp/test_emit_bool.py
@@ -2,6 +2,8 @@
 Phase 3b tests for the cpp emitter — booleans and comparisons.
 """
 
+import re
+
 import fpy2 as fp
 
 from fpy2.backend.cpp import CppCompiler
@@ -82,14 +84,15 @@ class TestBoolAndCompare:
 
 
 class TestBooleanReduce:
-    """``any`` / ``all`` lower to ``std::any_of`` / ``std::all_of``.
+    """``any`` / ``all`` lower to ``std::any_of`` / ``std::all_of`` with an
+    identity predicate — no hoisted loop and no casting, unlike ``AMin`` /
+    ``AMax``."""
 
-    No hoisted loop and no casting, unlike ``AMin``/``AMax``: the operand is
-    ``std::vector<bool>`` and the result is ``bool``, so the algorithm applies
-    directly with an identity predicate.  The empty range is well defined and
-    agrees with FPy (``all_of`` -> ``true``, ``any_of`` -> ``false``), so there
-    is no unguarded ``xs[0]`` as there is for ``min``/``max``.
-    """
+    @staticmethod
+    def _compile(f, elt_ty):
+        return CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[ListType(elt_ty)],
+        )
 
     def test_any_over_bool_list_arg(self):
         @fp.fpy
@@ -97,13 +100,9 @@ class TestBooleanReduce:
             with fp.FP64:
                 return any(bs)
 
-        out = CppCompiler().compile(
-            f, ctx=fp.FP64, arg_types=[ListType(BoolType())],
-        )
+        out = self._compile(f, BoolType())
         assert out.startswith('bool f(const std::vector<bool>& bs)')
         assert 'std::any_of(' in out
-        assert '.begin(), ' in out and '.end(), ' in out
-        assert 'return ' in out
 
     def test_all_over_bool_list_arg(self):
         @fp.fpy
@@ -111,9 +110,7 @@ class TestBooleanReduce:
             with fp.FP64:
                 return all(bs)
 
-        out = CppCompiler().compile(
-            f, ctx=fp.FP64, arg_types=[ListType(BoolType())],
-        )
+        out = self._compile(f, BoolType())
         assert out.startswith('bool f(const std::vector<bool>& bs)')
         assert 'std::all_of(' in out
 
@@ -123,44 +120,34 @@ class TestBooleanReduce:
             with fp.FP64:
                 return all(bs)
 
-        out = CppCompiler().compile(
-            f, ctx=fp.FP64, arg_types=[ListType(BoolType())],
-        )
-        # `[](bool <t>) { return <t>; }` -- same temp in both positions
-        import re
+        out = self._compile(f, BoolType())
         m = re.search(r'\[\]\(bool (\w+)\) \{ return (\w+); \}', out)
         assert m, f'no identity predicate in:\n{out}'
-        assert m.group(1) == m.group(2)
+        assert m.group(1) == m.group(2), 'predicate must return its parameter'
 
-    def test_operand_bound_to_auto_ref_before_iterating(self):
+    def test_operand_bound_before_iterating(self):
         """``begin()``/``end()`` on a prvalue would name iterators into two
-        different temporaries -- an invalid range.  Same reason ``Sum`` binds."""
+        different temporaries — an invalid range.  Same reason ``Sum`` binds."""
         @fp.fpy
         def f(xs: list[fp.Real]) -> bool:
             with fp.FP64:
                 return any([x < 0 for x in xs])
 
-        out = CppCompiler().compile(
-            f, ctx=fp.FP64, arg_types=[ListType(RealType(fp.FP64))],
-        )
-        assert 'auto&& ' in out
-        # the iterated name is the bound reference, not the raw expression
-        import re
+        out = self._compile(f, RealType(fp.FP64))
         bound = re.search(r'auto&& (\w+) = ', out)
         assert bound, out
-        assert f'std::any_of({bound.group(1)}.begin(), {bound.group(1)}.end()' in out
+        t = bound.group(1)
+        assert f'std::any_of({t}.begin(), {t}.end()' in out
 
     def test_over_comprehension_of_comparisons(self):
-        """The idiomatic form: the comprehension materializes a
-        ``std::vector<bool>``, then the algorithm scans it."""
+        """The comprehension materializes a ``std::vector<bool>``, which the
+        algorithm then scans."""
         @fp.fpy
         def f(xs: list[fp.Real]) -> bool:
             with fp.FP64:
                 return all([x < 0 for x in xs])
 
-        out = CppCompiler().compile(
-            f, ctx=fp.FP64, arg_types=[ListType(RealType(fp.FP64))],
-        )
+        out = self._compile(f, RealType(fp.FP64))
         assert 'std::vector<bool>' in out
         assert 'push_back(' in out
         assert 'std::all_of(' in out

--- a/tests/unit/backend/cpp/test_emit_bool.py
+++ b/tests/unit/backend/cpp/test_emit_bool.py
@@ -5,7 +5,7 @@ Phase 3b tests for the cpp emitter — booleans and comparisons.
 import fpy2 as fp
 
 from fpy2.backend.cpp import CppCompiler
-from fpy2.types import RealType
+from fpy2.types import BoolType, ListType, RealType
 
 
 class TestBoolAndCompare:
@@ -79,3 +79,88 @@ class TestBoolAndCompare:
             arg_types=[RealType(fp.FP64)] * 3,
         )
         assert '((x < y) && (y < z))' in out
+
+
+class TestBooleanReduce:
+    """``any`` / ``all`` lower to ``std::any_of`` / ``std::all_of``.
+
+    No hoisted loop and no casting, unlike ``AMin``/``AMax``: the operand is
+    ``std::vector<bool>`` and the result is ``bool``, so the algorithm applies
+    directly with an identity predicate.  The empty range is well defined and
+    agrees with FPy (``all_of`` -> ``true``, ``any_of`` -> ``false``), so there
+    is no unguarded ``xs[0]`` as there is for ``min``/``max``.
+    """
+
+    def test_any_over_bool_list_arg(self):
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            with fp.FP64:
+                return any(bs)
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[ListType(BoolType())],
+        )
+        assert out.startswith('bool f(const std::vector<bool>& bs)')
+        assert 'std::any_of(' in out
+        assert '.begin(), ' in out and '.end(), ' in out
+        assert 'return ' in out
+
+    def test_all_over_bool_list_arg(self):
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            with fp.FP64:
+                return all(bs)
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[ListType(BoolType())],
+        )
+        assert out.startswith('bool f(const std::vector<bool>& bs)')
+        assert 'std::all_of(' in out
+
+    def test_identity_predicate_is_a_bool_lambda(self):
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            with fp.FP64:
+                return all(bs)
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[ListType(BoolType())],
+        )
+        # `[](bool <t>) { return <t>; }` -- same temp in both positions
+        import re
+        m = re.search(r'\[\]\(bool (\w+)\) \{ return (\w+); \}', out)
+        assert m, f'no identity predicate in:\n{out}'
+        assert m.group(1) == m.group(2)
+
+    def test_operand_bound_to_auto_ref_before_iterating(self):
+        """``begin()``/``end()`` on a prvalue would name iterators into two
+        different temporaries -- an invalid range.  Same reason ``Sum`` binds."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return any([x < 0 for x in xs])
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[ListType(RealType(fp.FP64))],
+        )
+        assert 'auto&& ' in out
+        # the iterated name is the bound reference, not the raw expression
+        import re
+        bound = re.search(r'auto&& (\w+) = ', out)
+        assert bound, out
+        assert f'std::any_of({bound.group(1)}.begin(), {bound.group(1)}.end()' in out
+
+    def test_over_comprehension_of_comparisons(self):
+        """The idiomatic form: the comprehension materializes a
+        ``std::vector<bool>``, then the algorithm scans it."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return all([x < 0 for x in xs])
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[ListType(RealType(fp.FP64))],
+        )
+        assert 'std::vector<bool>' in out
+        assert 'push_back(' in out
+        assert 'std::all_of(' in out

--- a/tests/unit/backend/cpp/test_prelude.py
+++ b/tests/unit/backend/cpp/test_prelude.py
@@ -26,6 +26,7 @@ class TestHeaders:
         headers = cc.headers()
         # Each entry is a full ``#include`` line.
         for required in (
+            '<algorithm>',
             '<cassert>',
             '<cfenv>',
             '<cmath>',

--- a/tests/unit/backend/test_fpc_eval.py
+++ b/tests/unit/backend/test_fpc_eval.py
@@ -17,13 +17,14 @@ bugs in list-reduce and ``for``-loop lowering:
 So these tests run each program twice — once through the FPy interpreter, once
 through titanfp's interpreter on the compiled core — and require agreement.
 
-The same differential harness now also covers the boolean reductions
-(``any`` / ``all``), which are new rather than fixed — booleans are the values
-most easily lost across the titanfp boundary, so they want executing rather
-than string-matching too.
+The same harness covers the boolean reductions (``any`` / ``all``): booleans
+are the values most easily lost across the titanfp boundary, so they want
+executing rather than string-matching too.
 """
 
 import math
+
+import pytest
 
 import titanfp.fpbench.fpcast as fpc
 from titanfp.arithmetic.mpmf import MPMF, Interpreter
@@ -70,13 +71,9 @@ def _agree(fn, *args):
 
 
 def _agree_bool(fn, *args):
-    """``_agree`` for bool-returning programs.
-
-    Kept separate because ``_both`` coerces through ``float``, which would let
-    a numeric ``1.0`` masquerade as ``True`` — exactly the confusion that makes
-    boolean values delicate on the titanfp boundary (see ``_to_mpmf``).  Both
-    sides are required to be genuine ``bool``.
-    """
+    """``_agree`` for bool-returning programs.  Separate from ``_both``, which
+    coerces through ``float`` and would let a numeric ``1.0`` pass as ``True``;
+    here both sides must be a genuine ``bool``."""
     core = _compile(fn)
     got = Interpreter().interpret(core, [_to_mpmf(a) for a in args])
     want = fn(*args)
@@ -315,77 +312,57 @@ class TestBooleanReduce:
     """``any`` / ``all`` lower to a ``for``-fold seeded with the operator's
     identity (``FALSE`` / ``TRUE``), combining with ``or`` / ``and``.
 
-    The boolean list is built *inside* each program rather than passed in: a
-    boolean tensor does not survive titanfp's argument conversion, which turns
-    a Python ``bool`` into a numeric ``MPMF``, and ``MPMF`` has no
-    ``__bool__`` — so every element would read as truthy and the fold would
-    return ``True`` regardless.  That is a limitation of the interop, not of
-    the lowering.
+    Each program builds its boolean list *internally*: a boolean tensor does
+    not survive titanfp's argument conversion (Python ``bool`` becomes a
+    numeric ``MPMF``, which has no ``__bool__``, so every element reads
+    truthy).  Passing a ``list[bool]`` in would make these tests vacuous.
     """
 
     @staticmethod
-    def _any():
-        @fp.fpy
-        def f(xs: list[fp.Real], y: fp.Real) -> bool:
-            with fp.FP64:
-                return any([x < y for x in xs])
-        return f
+    def _reduce(op, n: int):
+        """``op([x < y for x in xs])`` with ``xs`` pinned to length *n*."""
+        if op is any:
+            @fp.fpy
+            def f(xs: list[fp.Real], y: fp.Real) -> bool:
+                with fp.FP64:
+                    return any([x < y for x in xs])
+        else:
+            @fp.fpy
+            def f(xs: list[fp.Real], y: fp.Real) -> bool:
+                with fp.FP64:
+                    return all([x < y for x in xs])
+        return _size(f, n)
 
-    @staticmethod
-    def _all():
-        @fp.fpy
-        def f(xs: list[fp.Real], y: fp.Real) -> bool:
-            with fp.FP64:
-                return all([x < y for x in xs])
-        return f
+    @pytest.mark.parametrize('op,xs,want', [
+        (any, [1.0, -2.0, 3.0], True),      # some true
+        (any, [1.0, 2.0, 3.0], False),      # none true
+        (any, [-1.0, -2.0, -3.0], True),    # all true
+        (all, [-1.0, -2.0, -3.0], True),    # all true
+        (all, [-1.0, 2.0, -3.0], False),    # one false
+        (all, [1.0, 2.0, 3.0], False),      # none true
+        (any, [-1.0], True),                # single element
+        (any, [1.0], False),
+        (all, [-1.0], True),
+        (all, [1.0], False),
+    ])
+    def test_matches_interpreter(self, op, xs, want):
+        assert _agree_bool(self._reduce(op, len(xs)), xs, 0.0) is want
 
-    def test_any_some_true(self):
-        assert _agree_bool(_size(self._any(), 3), [1.0, -2.0, 3.0], 0.0) is True
-
-    def test_any_none_true(self):
-        assert _agree_bool(_size(self._any(), 3), [1.0, 2.0, 3.0], 0.0) is False
-
-    def test_any_all_true(self):
-        assert _agree_bool(_size(self._any(), 3), [-1.0, -2.0, -3.0], 0.0) is True
-
-    def test_all_all_true(self):
-        assert _agree_bool(_size(self._all(), 3), [-1.0, -2.0, -3.0], 0.0) is True
-
-    def test_all_one_false(self):
-        assert _agree_bool(_size(self._all(), 3), [-1.0, 2.0, -3.0], 0.0) is False
-
-    def test_all_none_true(self):
-        assert _agree_bool(_size(self._all(), 3), [1.0, 2.0, 3.0], 0.0) is False
-
-    def test_any_single_element(self):
-        assert _agree_bool(_size(self._any(), 1), [-1.0], 0.0) is True
-        assert _agree_bool(_size(self._any(), 1), [1.0], 0.0) is False
-
-    def test_all_single_element(self):
-        assert _agree_bool(_size(self._all(), 1), [-1.0], 0.0) is True
-        assert _agree_bool(_size(self._all(), 1), [1.0], 0.0) is False
-
-    def test_fold_seeds_with_the_identity(self):
-        """The accumulator init is the identity constant, not ``(ref t 0)``.
-
-        This is what makes the empty list correct by construction, and it is
-        why the boolean fold needs no ``n - 1`` bound or ``(+ i 1)`` index
-        arithmetic.  (The empty case itself is unreachable through titanfp,
-        which cannot build a zero-length tensor, so assert on the shape.)
-        """
-        core = _compile(_size(self._all(), 3))
+    @pytest.mark.parametrize('op,identity', [(any, 'FALSE'), (all, 'TRUE')])
+    def test_fold_seeds_with_the_identity(self, op, identity):
+        """The accumulator init is the identity constant, not ``(ref t 0)`` —
+        which is what makes the empty list correct by construction.  (Empty
+        itself is unreachable through titanfp, which cannot build a
+        zero-length tensor, so assert on the shape.)"""
+        core = _compile(self._reduce(op, 3))
         fors = [e for e in _operands(core.e) + [core.e] if isinstance(e, fpc.For)]
         assert len(fors) == 1
         _, init, _ = fors[0].while_bindings[0]
-        assert isinstance(init, fpc.Constant) and str(init) == 'TRUE'
+        assert isinstance(init, fpc.Constant) and str(init) == identity
 
-        core = _compile(_size(self._any(), 3))
-        fors = [e for e in _operands(core.e) + [core.e] if isinstance(e, fpc.For)]
-        _, init, _ = fors[0].while_bindings[0]
-        assert isinstance(init, fpc.Constant) and str(init) == 'FALSE'
-
-    def test_operands_are_exprs(self):
+    @pytest.mark.parametrize('op', [any, all])
+    def test_operands_are_exprs(self, op):
         """No bare ``str`` in operand position (see TestNoBareStringOperands)."""
-        for fn in (_size(self._any(), 3), _size(self._all(), 3)):
-            bad = [o for o in _operands(_compile(fn).e) if isinstance(o, str)]
-            assert not bad, f'bare str operands in emitted core: {bad}'
+        bad = [o for o in _operands(_compile(self._reduce(op, 3)).e)
+               if isinstance(o, str)]
+        assert not bad, f'bare str operands in emitted core: {bad}'

--- a/tests/unit/backend/test_fpc_eval.py
+++ b/tests/unit/backend/test_fpc_eval.py
@@ -2,7 +2,7 @@
 Differential evaluation tests for the FPCore backend.
 
 The other ``test_fpc_*`` modules compare *emitted text*, which cannot catch a
-core that prints correctly but does not evaluate — the failure mode of three
+core that prints correctly but does not evaluate — the failure mode of four
 bugs in list-reduce and ``for``-loop lowering:
 
 - a ``for`` accumulator init that referenced the loop index, which FPCore
@@ -16,6 +16,11 @@ bugs in list-reduce and ``for``-loop lowering:
 
 So these tests run each program twice — once through the FPy interpreter, once
 through titanfp's interpreter on the compiled core — and require agreement.
+
+The same differential harness now also covers the boolean reductions
+(``any`` / ``all``), which are new rather than fixed — booleans are the values
+most easily lost across the titanfp boundary, so they want executing rather
+than string-matching too.
 """
 
 import math
@@ -61,6 +66,23 @@ def _both(fn, *args):
 def _agree(fn, *args):
     want, got = _both(fn, *args)
     assert want == got, f'FPy {want} != FPCore {got}\n  {_compile(fn).e}'
+    return want
+
+
+def _agree_bool(fn, *args):
+    """``_agree`` for bool-returning programs.
+
+    Kept separate because ``_both`` coerces through ``float``, which would let
+    a numeric ``1.0`` masquerade as ``True`` — exactly the confusion that makes
+    boolean values delicate on the titanfp boundary (see ``_to_mpmf``).  Both
+    sides are required to be genuine ``bool``.
+    """
+    core = _compile(fn)
+    got = Interpreter().interpret(core, [_to_mpmf(a) for a in args])
+    want = fn(*args)
+    assert isinstance(want, bool), f'expected bool from FPy, got {want!r}'
+    assert isinstance(got, bool), f'expected bool from FPCore, got {got!r}'
+    assert want == got, f'FPy {want} != FPCore {got}\n  {core.e}'
     return want
 
 
@@ -287,3 +309,83 @@ class TestForLoopBindsElements:
 
         # (1+2) * (10+100) = 330
         assert _agree(_size(f, 2, 2), [1.0, 2.0], [10.0, 100.0]) == 330.0
+
+
+class TestBooleanReduce:
+    """``any`` / ``all`` lower to a ``for``-fold seeded with the operator's
+    identity (``FALSE`` / ``TRUE``), combining with ``or`` / ``and``.
+
+    The boolean list is built *inside* each program rather than passed in: a
+    boolean tensor does not survive titanfp's argument conversion, which turns
+    a Python ``bool`` into a numeric ``MPMF``, and ``MPMF`` has no
+    ``__bool__`` — so every element would read as truthy and the fold would
+    return ``True`` regardless.  That is a limitation of the interop, not of
+    the lowering.
+    """
+
+    @staticmethod
+    def _any():
+        @fp.fpy
+        def f(xs: list[fp.Real], y: fp.Real) -> bool:
+            with fp.FP64:
+                return any([x < y for x in xs])
+        return f
+
+    @staticmethod
+    def _all():
+        @fp.fpy
+        def f(xs: list[fp.Real], y: fp.Real) -> bool:
+            with fp.FP64:
+                return all([x < y for x in xs])
+        return f
+
+    def test_any_some_true(self):
+        assert _agree_bool(_size(self._any(), 3), [1.0, -2.0, 3.0], 0.0) is True
+
+    def test_any_none_true(self):
+        assert _agree_bool(_size(self._any(), 3), [1.0, 2.0, 3.0], 0.0) is False
+
+    def test_any_all_true(self):
+        assert _agree_bool(_size(self._any(), 3), [-1.0, -2.0, -3.0], 0.0) is True
+
+    def test_all_all_true(self):
+        assert _agree_bool(_size(self._all(), 3), [-1.0, -2.0, -3.0], 0.0) is True
+
+    def test_all_one_false(self):
+        assert _agree_bool(_size(self._all(), 3), [-1.0, 2.0, -3.0], 0.0) is False
+
+    def test_all_none_true(self):
+        assert _agree_bool(_size(self._all(), 3), [1.0, 2.0, 3.0], 0.0) is False
+
+    def test_any_single_element(self):
+        assert _agree_bool(_size(self._any(), 1), [-1.0], 0.0) is True
+        assert _agree_bool(_size(self._any(), 1), [1.0], 0.0) is False
+
+    def test_all_single_element(self):
+        assert _agree_bool(_size(self._all(), 1), [-1.0], 0.0) is True
+        assert _agree_bool(_size(self._all(), 1), [1.0], 0.0) is False
+
+    def test_fold_seeds_with_the_identity(self):
+        """The accumulator init is the identity constant, not ``(ref t 0)``.
+
+        This is what makes the empty list correct by construction, and it is
+        why the boolean fold needs no ``n - 1`` bound or ``(+ i 1)`` index
+        arithmetic.  (The empty case itself is unreachable through titanfp,
+        which cannot build a zero-length tensor, so assert on the shape.)
+        """
+        core = _compile(_size(self._all(), 3))
+        fors = [e for e in _operands(core.e) + [core.e] if isinstance(e, fpc.For)]
+        assert len(fors) == 1
+        _, init, _ = fors[0].while_bindings[0]
+        assert isinstance(init, fpc.Constant) and str(init) == 'TRUE'
+
+        core = _compile(_size(self._any(), 3))
+        fors = [e for e in _operands(core.e) + [core.e] if isinstance(e, fpc.For)]
+        _, init, _ = fors[0].while_bindings[0]
+        assert isinstance(init, fpc.Constant) and str(init) == 'FALSE'
+
+    def test_operands_are_exprs(self):
+        """No bare ``str`` in operand position (see TestNoBareStringOperands)."""
+        for fn in (_size(self._any(), 3), _size(self._all(), 3)):
+            bad = [o for o in _operands(_compile(fn).e) if isinstance(o, str)]
+            assert not bad, f'bare str operands in emitted core: {bad}'

--- a/tests/unit/interpret/test_derived_semantics.py
+++ b/tests/unit/interpret/test_derived_semantics.py
@@ -506,21 +506,16 @@ class TestReductions:
         assert all_neg([-1.0, -2.0], ctx=FP64) is True
         assert all_neg([-1.0, 2.0], ctx=FP64) is False
 
-    def test_any_all_reject_non_bool_elements(self):
+    def test_any_all_reject_non_bool_operands(self):
         """FPy has no truthiness, so a real element is an error rather than a
-        zero test (Python's builtins would accept it)."""
+        zero test (Python's builtins would accept both of these)."""
         @fp.fpy
         def any_(bs: list[bool]) -> bool:
             return any(bs)
         with pytest.raises(TypeError):
-            any_([1.0, 0.0], ctx=FP64)
-
-    def test_any_all_reject_non_list(self):
-        @fp.fpy
-        def any_(bs: list[bool]) -> bool:
-            return any(bs)
+            any_([1.0, 0.0], ctx=FP64)      # real elements
         with pytest.raises(TypeError):
-            any_((True, False), ctx=FP64)
+            any_((True, False), ctx=FP64)   # tuple, not list
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/interpret/test_derived_semantics.py
+++ b/tests/unit/interpret/test_derived_semantics.py
@@ -451,6 +451,77 @@ class TestReductions:
         assert float(amax_(xs, ctx=FP64)) == 3.0
         assert float(amin_(xs, ctx=FP64)) == 1.0
 
+    def test_any_all_are_folds_across_contexts(self):
+        """``any``/``all`` fold with ``or``/``and`` — the doc's desugaring."""
+        @fp.fpy
+        def any_node(bs: list[bool]) -> bool:
+            return any(bs)
+        @fp.fpy
+        def any_desugar(bs: list[bool]) -> bool:
+            acc = False
+            for b in bs:
+                acc = acc or b
+            return acc
+
+        @fp.fpy
+        def all_node(bs: list[bool]) -> bool:
+            return all(bs)
+        @fp.fpy
+        def all_desugar(bs: list[bool]) -> bool:
+            acc = True
+            for b in bs:
+                acc = acc and b
+            return acc
+
+        # exhaustive over lists of length 0..3, so the empty case and every
+        # true/false arrangement are covered
+        for n in range(4):
+            for i in range(2 ** n):
+                bs = [bool(i >> k & 1) for k in range(n)]
+                _agree(any_node, any_desugar, (bs,))
+                _agree(all_node, all_desugar, (bs,))
+
+    def test_any_all_empty_is_the_identity(self):
+        """``any([])`` is ``False`` and ``all([])`` is ``True`` — unlike
+        ``min``/``max``, both are total on the empty list."""
+        @fp.fpy
+        def any_(bs: list[bool]) -> bool:
+            return any(bs)
+        @fp.fpy
+        def all_(bs: list[bool]) -> bool:
+            return all(bs)
+        assert any_([], ctx=FP64) is False
+        assert all_([], ctx=FP64) is True
+
+    def test_any_all_over_comparisons(self):
+        """The idiomatic use: a comprehension of comparisons."""
+        @fp.fpy
+        def any_neg(xs: list[fp.Real]) -> bool:
+            return any([x < 0 for x in xs])
+        @fp.fpy
+        def all_neg(xs: list[fp.Real]) -> bool:
+            return all([x < 0 for x in xs])
+        assert any_neg([1.0, -2.0, 3.0], ctx=FP64) is True
+        assert any_neg([1.0, 2.0, 3.0], ctx=FP64) is False
+        assert all_neg([-1.0, -2.0], ctx=FP64) is True
+        assert all_neg([-1.0, 2.0], ctx=FP64) is False
+
+    def test_any_all_reject_non_bool_elements(self):
+        """FPy has no truthiness, so a real element is an error rather than a
+        zero test (Python's builtins would accept it)."""
+        @fp.fpy
+        def any_(bs: list[bool]) -> bool:
+            return any(bs)
+        with pytest.raises(TypeError):
+            any_([1.0, 0.0], ctx=FP64)
+
+    def test_any_all_reject_non_list(self):
+        @fp.fpy
+        def any_(bs: list[bool]) -> bool:
+            return any(bs)
+        with pytest.raises(TypeError):
+            any_((True, False), ctx=FP64)
+
 
 # ---------------------------------------------------------------------------
 # Classification / inspection  (IsFinite, IsInf, IsNan, IsNormal, Signbit,


### PR DESCRIPTION
This PR adds support for Python builtin functions `any` and `all`. They can now be used directly in FPy programs.