### PR TITLE
Rewrite `any`/`all` of a list comprehension into a for loop

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -205,6 +205,21 @@ def example_builtin():
     ...
 ```
 
+FPy also supports the reductions `sum`, `min`, and `max` over a list of numbers,
+and `any` and `all` over a list of booleans.
+
+```python
+@fp.fpy
+def example_reductions(xs: list[fp.Real]) -> bool:
+    total = sum(xs)                            # sum of the elements
+    return any([x < 0 for x in xs]) and all([x < total for x in xs])
+```
+
+`any` and `all` require a list of **booleans** — FPy has no truthiness, so
+`any([1.0, 0.0])` is a type error rather than a test against zero. Both are
+defined on the empty list: `any([])` is `False` and `all([])` is `True`
+(`min([])` and `max([])`, by contrast, are errors).
+
 #### Slicing
 
 FPy supports list slicing `xs[start:stop]`, but its semantics **differ

--- a/docs/source/dev/derived-semantics.rst
+++ b/docs/source/dev/derived-semantics.rst
@@ -136,6 +136,45 @@ Reductions
             acc = acc + x
         return acc
 
+The *boolean* reductions fold a ``list[bool]`` with the logical operators, so
+no rounding occurs and the active context is irrelevant.  Each is seeded with
+its operator's identity, which is also the value of the empty case — unlike
+``min``/``max``, both are total on the empty list.
+
+* ``AnyOf`` — ``any(bs)`` is a left fold with ``or``, seeded ``False``
+  (so ``any([])`` is ``False``)::
+
+    @fp.fpy
+    def any_(bs: list[bool]) -> bool:
+        acc = False
+        for b in bs:
+            acc = acc or b
+        return acc
+
+* ``AllOf`` — ``all(bs)`` is a left fold with ``and``, seeded ``True``
+  (so ``all([])`` is ``True``)::
+
+    @fp.fpy
+    def all_(bs: list[bool]) -> bool:
+        acc = True
+        for b in bs:
+            acc = acc and b
+        return acc
+
+``AnyOf``/``AllOf`` are to ``Or``/``And`` what ``AMax``/``AMin`` are to
+``Max``/``Min``: the list-fold form of a scalar operator, and a distinct node so
+typing stays syntax-directed (``list[bool] -> bool`` rather than
+``bool -> ... -> bool``).  The element type is exactly ``bool``: FPy has no
+truthiness, so ``any([1.0, 0.0])`` is a type error rather than a zero test.
+
+The fold is eager, and this **matches** Python for the syntax FPy supports.
+Python's ``any``/``all`` short-circuit their *iterable*, but a list
+comprehension is fully built before ``any`` is called, so
+``any([pred(x) for x in xs])`` evaluates ``pred`` on every element in CPython
+too; only a generator expression — which FPy does not have — makes the
+short-circuit skip work.  Evaluating every element is therefore faithful, not a
+simplification.
+
 Classification and inspection
 -----------------------------
 

--- a/docs/source/dev/derived-semantics.rst
+++ b/docs/source/dev/derived-semantics.rst
@@ -127,14 +127,24 @@ Reductions
 ----------
 
 * ``Sum`` — ``sum(xs)`` is a left fold with ``+`` (rounding each step; the empty
-  sum is exact ``0``)::
+  sum is exact ``0``).  The accumulator is *seeded with the first element*, so
+  a list of ``n`` elements performs ``n - 1`` additions::
 
     @fp.fpy
     def sum(xs: list[fp.Real]) -> fp.Real:
-        acc = 0
-        for x in xs:
+        if len(xs) == 0:
+            return 0
+        acc = xs[0]
+        for x in xs[1:]:
             acc = acc + x
         return acc
+
+  Seeding with ``0`` instead would *not* be equivalent: ``0 + xs[0]`` is itself
+  a rounded operation, so it would round the first element before the fold
+  begins.  Under ``fp.FP16``, summing the exact values
+  ``[1 + 2**-11, 2**-11]`` gives ``1 + 2**-10`` as written above, but ``1.0``
+  with a zero seed — ``2**-11`` is half of FP16's spacing above ``1.0``, so
+  rounding the first element on its own is a tie that resolves down.
 
 The *boolean* reductions fold a ``list[bool]`` with the logical operators, so
 no rounding occurs and the active context is irrelevant.  Each is seeded with

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -21,7 +21,13 @@ from ...ast.visitor import DefaultVisitor
 from ...function import Function
 from ...module import Module
 from ...number import Context
-from ...transform import FreeVarElim, RoundElim, Specialize, ZipElim
+from ...transform import (
+    FreeVarElim,
+    ReduceFusion,
+    RoundElim,
+    Specialize,
+    ZipElim,
+)
 from ...transform.free_var_elim import unclosed_data_free_vars
 from ...types import Type
 from ..backend import Backend, CompileError
@@ -80,6 +86,9 @@ class CppCompiler(Backend):
             - :class:`fpy2.transform.ZipElim` (pre-monomorphize):
               skips materializing intermediate
               ``std::vector<std::tuple<...>>``s for ``zip`` iterables.
+            - :class:`fpy2.transform.ReduceFusion` (pre-monomorphize):
+              folds ``any``/``all`` over a comprehension into one loop,
+              skipping the intermediate ``std::vector<bool>``.
             - :class:`fpy2.transform.RoundElim` (post-monomorphize):
               hoists eliminable rounded operations into
               ``with fp.REAL:`` blocks so the cpp emitter's
@@ -153,8 +162,8 @@ class CppCompiler(Backend):
         """Compile a :class:`~fpy2.Module` to a single C++ translation unit.
 
         Pipeline:
-          1. **Pre-spec optimizations** (``ZipElim``) on every function in
-             the module via ``map``.
+          1. **Pre-spec optimizations** (``ZipElim``, ``ReduceFusion``) on
+             every function in the module via ``map``.
           2. **Specialize** the module: each ``(FuncDef, ctx, arg_fmts)``
              becomes one entry; cross-function calls rewire to the
              appropriate spec.
@@ -171,6 +180,8 @@ class CppCompiler(Backend):
 
         if self._optimize:
             module = module.map(lambda _m, fd: ZipElim.apply(fd))
+            # after ZipElim, so a `zip` comp is already an indexed comp
+            module = module.map(lambda _m, fd: ReduceFusion.apply(fd))
 
         # Translate ``Monomorphize``'s bare ``RuntimeError`` (e.g. arg-type
         # mismatches) into ``CppCompileError`` so callers iterating over

--- a/fpy2/transform/__init__.py
+++ b/fpy2/transform/__init__.py
@@ -13,6 +13,7 @@ from .func_inline import FuncInline
 from .if_bundling import IfBundling
 from .lift_context import LiftContext
 from .monomorphize import Monomorphize
+from .reduce_fusion import ReduceFusion
 from .rename_target import RenameTarget
 from .round_elim import RoundElim
 from .simplify_if import SimplifyIf

--- a/fpy2/transform/reduce_fusion.py
+++ b/fpy2/transform/reduce_fusion.py
@@ -6,11 +6,11 @@ eliminating the intermediate ``list[bool]``::
     r = any([<elt> for <t> in <iter>])
 
     # After
-    _acc = False
+    acc = False
     for <t> in <iter>:
-        _b = <elt>
-        _acc = _acc or _b
-    r = _acc
+        b = <elt>
+        acc = acc or b
+    r = acc
 
 (``all`` seeds ``True`` and combines with ``and``.)
 
@@ -19,9 +19,9 @@ scans it.  In C++ that is a ``std::vector<bool>`` — the bit-packed
 specialization, so a heap allocation plus per-element bit twiddling — which
 ``-O2`` does not elide; the fused form measures 2-4x faster.
 
-``_b`` is bound rather than inlined into ``_acc or <elt>``, and the bind is
+``b`` is bound rather than inlined into ``acc or <elt>``, and the bind is
 load-bearing: FPy's ``or`` short-circuits, so an inlined element would stop
-being evaluated once ``_acc`` is ``True``.  Element expressions are not total
+being evaluated once ``acc`` is ``True``.  Element expressions are not total
 (an out-of-bounds ``xs[i]``, a stuck ``fp.cast``), so skipping them is
 observable.  Binding forces every element, matching both the unfused program
 and CPython — whose ``any`` short-circuits the *iterable*, but is handed an
@@ -111,24 +111,24 @@ class _ReduceFusionInstance(DefaultTransformVisitor):
         return super()._visit_expr(e, ctx)
 
     def _fuse(self, e: 'AnyOf | AllOf', comp: ListComp, ctx: _Ctx) -> Expr:
-        """Emit the seed + loop into *ctx* and return ``Var(_acc)``."""
+        """Emit the seed + loop into *ctx* and return ``Var(acc)``."""
         is_any = isinstance(e, AnyOf)
-        acc = self.gensym.fresh('_acc')
-        elt_tmp = self.gensym.fresh('_b')
+        acc = self.gensym.fresh('acc')
+        elt = self.gensym.fresh('b')
 
         # The iterable is evaluated once, before the loop, so it keeps `ctx`
         # and a fusable reduction inside it hoists to this block too.  The
         # element sees the loop target, so it gets no statement slot.
         iterable = self._visit_expr(comp.iterables[0], ctx)
         target = self._visit_binding(comp.targets[0], ctx)
-        elt = self._visit_expr(comp.elt, None)
+        elt_expr = self._visit_expr(comp.elt, None)
 
         op = Or if is_any else And
-        combine = op([Var(acc, e.loc), Var(elt_tmp, e.loc)], e.loc)
+        combine = op([Var(acc, e.loc), Var(elt, e.loc)], e.loc)
         body = StmtBlock([
-            # binding `_b` preserves the unfused evaluation count -- see the
+            # binding `b` preserves the unfused evaluation count -- see the
             # module docstring; folding `elt` inline would short-circuit it
-            Assign(elt_tmp, None, elt, e.loc),
+            Assign(elt, None, elt_expr, e.loc),
             Assign(acc, None, combine, e.loc),
         ])
 

--- a/fpy2/transform/reduce_fusion.py
+++ b/fpy2/transform/reduce_fusion.py
@@ -1,0 +1,175 @@
+"""
+Fuse ``any`` / ``all`` over a list comprehension into a single loop,
+eliminating the intermediate ``list[bool]``::
+
+    # Before
+    r = any([<elt> for <t> in <iter>])
+
+    # After
+    _acc = False
+    for <t> in <iter>:
+        _b = <elt>
+        _acc = _acc or _b
+    r = _acc
+
+(``all`` seeds ``True`` and combines with ``and``.)
+
+Unfused, the comprehension materializes the whole list before the reduction
+scans it.  In C++ that is a ``std::vector<bool>`` — the bit-packed
+specialization, so a heap allocation plus per-element bit twiddling — which
+``-O2`` does not elide; the fused form measures 2-4x faster.
+
+``_b`` is bound rather than inlined into ``_acc or <elt>``, and the bind is
+load-bearing: FPy's ``or`` short-circuits, so an inlined element would stop
+being evaluated once ``_acc`` is ``True``.  Element expressions are not total
+(an out-of-bounds ``xs[i]``, a stuck ``fp.cast``), so skipping them is
+observable.  Binding forces every element, matching both the unfused program
+and CPython — whose ``any`` short-circuits the *iterable*, but is handed an
+already-built list.
+
+Only the boolean reductions are fused.  ``Sum`` / ``AMin`` / ``AMax`` pay the
+same allocation cost, but fusing them is blocked on the cpp emitter accepting
+an implicit narrowing inside ``std::accumulate`` that it rejects at an
+ordinary assignment; see ``docs/todos/reduce-fusion.md``.  Multi-stage
+comprehensions (``[e for a in xs for b in ys]``) would need nested loops and
+are left alone.
+"""
+
+import dataclasses
+from typing import Any
+
+from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
+from ..ast.fpyast import (
+    AllOf,
+    And,
+    AnyOf,
+    Assign,
+    BoolVal,
+    Expr,
+    ForStmt,
+    FuncDef,
+    IfExpr,
+    ListComp,
+    Or,
+    Stmt,
+    StmtBlock,
+    Var,
+)
+from ..ast.visitor import DefaultTransformVisitor
+from ..utils import Gensym
+
+
+@dataclasses.dataclass
+class _Ctx:
+    """Block-walk accumulator: :meth:`_fuse` appends the seed and loop here,
+    and :meth:`_visit_block` emits them before the enclosing statement.  A
+    ``ctx`` of ``None`` instead of a ``_Ctx`` marks a position with no
+    statement slot to hoist into, suppressing fusion there."""
+    stmts: list[Stmt]
+
+    @staticmethod
+    def default() -> '_Ctx':
+        return _Ctx(stmts=[])
+
+
+class _ReduceFusionInstance(DefaultTransformVisitor):
+    """Drives the rewrite.  Single-use — one instance per
+    :meth:`ReduceFusion.apply` call."""
+
+    func: FuncDef
+    gensym: Gensym
+
+    def __init__(self, func: FuncDef, def_use: DefineUseAnalysis):
+        self.func = func
+        self.gensym = Gensym(reserved=def_use.names())
+
+    def apply(self) -> FuncDef:
+        return self._visit_function(self.func, None)
+
+    # ------------------------------------------------------------------
+    # Block walk — the ``_Ctx``-accumulator pattern from ``ZipElim``.
+
+    def _visit_block(self, block: StmtBlock, ctx: Any) -> tuple[StmtBlock, Any]:
+        block_ctx = _Ctx.default()
+        for stmt in block.stmts:
+            new_stmt, _ = self._visit_statement(stmt, block_ctx)
+            block_ctx.stmts.append(new_stmt)
+        return StmtBlock(block_ctx.stmts), ctx
+
+    # ------------------------------------------------------------------
+    # Expression rewriting
+
+    def _visit_expr(self, e: Expr, ctx: Any) -> Expr:
+        if (
+            isinstance(ctx, _Ctx)
+            and isinstance(e, (AnyOf, AllOf))
+            and isinstance(e.arg, ListComp)
+            # multi-stage comps would need nested loops; leave them alone
+            and len(e.arg.targets) == 1
+        ):
+            return self._fuse(e, e.arg, ctx)
+        return super()._visit_expr(e, ctx)
+
+    def _fuse(self, e: 'AnyOf | AllOf', comp: ListComp, ctx: _Ctx) -> Expr:
+        """Emit the seed + loop into *ctx* and return ``Var(_acc)``."""
+        is_any = isinstance(e, AnyOf)
+        acc = self.gensym.fresh('_acc')
+        elt_tmp = self.gensym.fresh('_b')
+
+        # The iterable is evaluated once, before the loop, so it keeps `ctx`
+        # and a fusable reduction inside it hoists to this block too.  The
+        # element sees the loop target, so it gets no statement slot.
+        iterable = self._visit_expr(comp.iterables[0], ctx)
+        target = self._visit_binding(comp.targets[0], ctx)
+        elt = self._visit_expr(comp.elt, None)
+
+        op = Or if is_any else And
+        combine = op([Var(acc, e.loc), Var(elt_tmp, e.loc)], e.loc)
+        body = StmtBlock([
+            # binding `_b` preserves the unfused evaluation count -- see the
+            # module docstring; folding `elt` inline would short-circuit it
+            Assign(elt_tmp, None, elt, e.loc),
+            Assign(acc, None, combine, e.loc),
+        ])
+
+        ctx.stmts.append(Assign(acc, None, BoolVal(not is_any, e.loc), e.loc))
+        ctx.stmts.append(ForStmt(target, iterable, body, e.loc))
+        return Var(acc, e.loc)
+
+    # ------------------------------------------------------------------
+    # Positions with no statement-level slot: suppress fusion.
+
+    def _visit_list_comp(self, e: ListComp, ctx: Any) -> ListComp:
+        # The elt sees the loop targets and successive iterables reference
+        # earlier targets, so nothing inside can be hoisted to the enclosing
+        # block.  (Mirrors ``RoundElim._visit_list_comp``.)
+        targets = [self._visit_binding(t, ctx) for t in e.targets]
+        iterables = [self._visit_expr(i, None) for i in e.iterables]
+        elt = self._visit_expr(e.elt, None)
+        return ListComp(targets, iterables, elt, e.loc)
+
+    def _visit_if_expr(self, e: IfExpr, ctx: Any) -> IfExpr:
+        # The branches are conditional; hoisting a loop out of one would run
+        # it unconditionally, which is observable when the element expression
+        # can fault.  The cond is unconditional, so it keeps ``ctx``.
+        cond = self._visit_expr(e.cond, ctx)
+        ift = self._visit_expr(e.ift, None)
+        iff = self._visit_expr(e.iff, None)
+        return IfExpr(cond, ift, iff, e.loc)
+
+
+class ReduceFusion:
+    """Fuse ``any`` / ``all`` over a list comprehension into a single loop,
+    eliminating the intermediate ``list[bool]``.  See the module docstring
+    for the rewrite shape and why the element is bound to a temp."""
+
+    @staticmethod
+    def apply(func: FuncDef) -> FuncDef:
+        """Apply the transformation to a :class:`FuncDef`.  Returns a new
+        ``FuncDef``; the input is not mutated."""
+        if not isinstance(func, FuncDef):
+            raise TypeError(f"expected a 'FuncDef', got `{func}`")
+        def_use = DefineUse.analyze(func)
+        out = _ReduceFusionInstance(func, def_use).apply()
+        SyntaxCheck.check(out, ignore_unknown=True)
+        return out

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -891,11 +891,10 @@ def _regression_all_bool_list(bs: list[bool]) -> bool:
 def _regression_any_over_comprehension(xs: list[fp.Real]) -> bool:
     """The idiomatic ``any([pred for x in xs])``.
 
-    Exercises the two-pass shape the reduction has today: the comprehension
-    materializes a ``std::vector<bool>``, which the algorithm then scans.  Pins
-    that the intermediate's storage is selected as ``bool`` (not a numeric
-    type) and that the scan reads the ``auto&&``-bound reference rather than a
-    dangling temporary.
+    ``ReduceFusion`` rewrites this to an accumulator loop in the default
+    pipeline, so what runs here is the *fused* form — this is the differential
+    check that fusion preserves behaviour on generated code, empty list
+    included (``_LIST_LENS`` covers 0).
     """
     with fp.FP64:
         return any([x < 0 for x in xs])

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -863,10 +863,51 @@ def _regression_calls_user_fn(x: fp.Real, y: fp.Real) -> fp.Real:
         return _regression_call_helper(x) + _regression_call_helper(y)
 
 
+@fp.fpy
+def _regression_any_bool_list(bs: list[bool]) -> bool:
+    """``any(bs)`` over a ``list[bool]`` argument -> ``std::any_of``.
+
+    Pins the boolean reduction end to end: a ``std::vector<bool>`` parameter
+    (whose proxy-reference specialization is easy to get wrong), and the empty
+    case — ``_LIST_LENS`` includes ``0``, so ``any([]) == false`` is checked
+    against the interpreter on every run rather than by hand.
+    """
+    return any(bs)
+
+
+@fp.fpy
+def _regression_all_bool_list(bs: list[bool]) -> bool:
+    """``all(bs)`` over a ``list[bool]`` argument -> ``std::all_of``.
+
+    The ``all`` half of :func:`_regression_any_bool_list`; separate because a
+    single boolean result cannot distinguish a bug in one operator from a bug
+    in the other.  Also pins the *other* empty-list identity,
+    ``all([]) == true``.
+    """
+    return all(bs)
+
+
+@fp.fpy
+def _regression_any_over_comprehension(xs: list[fp.Real]) -> bool:
+    """The idiomatic ``any([pred for x in xs])``.
+
+    Exercises the two-pass shape the reduction has today: the comprehension
+    materializes a ``std::vector<bool>``, which the algorithm then scans.  Pins
+    that the intermediate's storage is selected as ``bool`` (not a numeric
+    type) and that the scan reads the ``auto&&``-bound reference rather than a
+    dangling temporary.
+    """
+    with fp.FP64:
+        return any([x < 0 for x in xs])
+
+
 _regression_funcs: list[fp.Function] = [
     _regression_quant_dot_real_widen,
     _regression_empty_range,
     _regression_calls_user_fn,
+    _regression_any_bool_list,
+    _regression_all_bool_list,
+    _regression_any_over_comprehension,
 ]
 
 

--- a/tests/unit/backend/cpp/test_emit_bool.py
+++ b/tests/unit/backend/cpp/test_emit_bool.py
@@ -89,8 +89,8 @@ class TestBooleanReduce:
     ``AMax``."""
 
     @staticmethod
-    def _compile(f, elt_ty):
-        return CppCompiler().compile(
+    def _compile(f, elt_ty, **kwargs):
+        return CppCompiler(**kwargs).compile(
             f, ctx=fp.FP64, arg_types=[ListType(elt_ty)],
         )
 
@@ -129,25 +129,40 @@ class TestBooleanReduce:
         """``begin()``/``end()`` on a prvalue would name iterators into two
         different temporaries — an invalid range.  Same reason ``Sum`` binds."""
         @fp.fpy
-        def f(xs: list[fp.Real]) -> bool:
+        def f(bs: list[bool]) -> bool:
             with fp.FP64:
-                return any([x < 0 for x in xs])
+                return any(bs)
 
-        out = self._compile(f, RealType(fp.FP64))
+        out = self._compile(f, BoolType())
         bound = re.search(r'auto&& (\w+) = ', out)
         assert bound, out
         t = bound.group(1)
         assert f'std::any_of({t}.begin(), {t}.end()' in out
 
-    def test_over_comprehension_of_comparisons(self):
-        """The comprehension materializes a ``std::vector<bool>``, which the
-        algorithm then scans."""
+    def test_comprehension_operand_is_fused_away(self):
+        """``ReduceFusion`` runs in the default (optimizing) pipeline, so the
+        idiomatic form emits an accumulator loop with no intermediate
+        vector."""
         @fp.fpy
         def f(xs: list[fp.Real]) -> bool:
             with fp.FP64:
                 return all([x < 0 for x in xs])
 
         out = self._compile(f, RealType(fp.FP64))
+        assert 'std::vector<bool>' not in out
+        assert 'std::all_of(' not in out
+        assert '&&' in out          # folded with `and` in the loop body
+
+    def test_comprehension_operand_unfused_without_optimize(self):
+        """With ``optimize=False`` the surface AST compiles verbatim: the
+        comprehension materializes a ``std::vector<bool>`` that
+        ``std::all_of`` then scans."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return all([x < 0 for x in xs])
+
+        out = self._compile(f, RealType(fp.FP64), optimize=False)
         assert 'std::vector<bool>' in out
         assert 'push_back(' in out
         assert 'std::all_of(' in out

--- a/tests/unit/interpret/test_derived_semantics.py
+++ b/tests/unit/interpret/test_derived_semantics.py
@@ -433,12 +433,48 @@ class TestReductions:
             return sum(xs)
         @fp.fpy
         def sum_desugar(xs: list[fp.Real]) -> fp.Real:
-            acc = 0
-            for x in xs:
+            if len(xs) == 0:
+                return 0
+            acc = xs[0]
+            for x in xs[1:]:
                 acc = acc + x
             return acc
         # values that round differently at each step under a finite context
         _agree(sum_node, sum_desugar, ([0.1, 0.2, 0.3, 0.4],))
+        # ...plus the boundary cases the fold shape depends on
+        _agree(sum_node, sum_desugar, ([],))
+        _agree(sum_node, sum_desugar, ([1.0],))
+        _agree(sum_node, sum_desugar, ([1024.0, 1.0, 1.0],))
+
+    def test_sum_seeds_with_first_element_not_zero(self):
+        """``sum`` seeds the accumulator with ``xs[0]``, unrounded — it does
+        *not* start from ``0``.  ``0 + xs[0]`` is itself a rounded operation, so
+        a zero seed would round the first element before the fold begins.
+
+        The two shapes differ whenever that extra rounding is lossy.  Here the
+        elements are exact under ``REAL`` and ``2**-11`` is half of FP16's
+        spacing above ``1.0``, so rounding ``1 + 2**-11`` on its own is a tie
+        that resolves down to ``1.0`` and the second element cannot recover it.
+        """
+        @fp.fpy
+        def node() -> fp.Real:
+            with REAL:
+                ys = [1 + fp.rational(1, 2048), fp.rational(1, 2048)]
+            with FP16:
+                return sum(ys)
+
+        @fp.fpy
+        def seed_zero() -> fp.Real:
+            with REAL:
+                ys = [1 + fp.rational(1, 2048), fp.rational(1, 2048)]
+            with FP16:
+                acc = fp.round(0)
+                for y in ys:
+                    acc = acc + y
+                return acc
+
+        assert float(node()) == 1.0 + 2 ** -10
+        assert float(seed_zero()) == 1.0     # the shape the doc used to claim
 
     def test_amax_amin_reduce_form(self):
         @fp.fpy

--- a/tests/unit/transform/test_reduce_fusion.py
+++ b/tests/unit/transform/test_reduce_fusion.py
@@ -1,7 +1,7 @@
 """
 Unit tests for the :class:`fpy2.transform.ReduceFusion` transform.
 
-The rewrite mints fresh ``_acc`` / ``_b`` names via ``Gensym``, so an
+The rewrite mints fresh ``acc`` / ``b`` names via ``Gensym``, so an
 ``is_equiv`` comparison against a hand-written golden AST is brittle.  As in
 ``test_zip_elim``, the tests assert:
 
@@ -109,7 +109,7 @@ class TestRewriteFires:
         assert isinstance(seed.expr, BoolVal) and seed.expr.val is True
 
     def test_loop_body_binds_element_before_folding(self):
-        """The body must be ``_b = <elt>; _acc = _acc or _b`` — folding
+        """The body must be ``b = <elt>; acc = acc or b`` — folding
         ``<elt>`` inline would let ``or`` short-circuit it away."""
         @fp.fpy
         def f(xs: list[fp.Real]) -> bool:
@@ -164,7 +164,7 @@ class TestSemanticsPreserved:
 
         ``xs[i]`` walks off the end.  Unfused, the comprehension evaluates
         every element and raises.  If the rewrite inlined the element into
-        ``_acc or <elt>``, ``or`` would short-circuit once ``_acc`` is True
+        ``acc or <elt>``, ``or`` would short-circuit once ``acc`` is True
         and the program would return instead of raising.
         """
         @fp.fpy

--- a/tests/unit/transform/test_reduce_fusion.py
+++ b/tests/unit/transform/test_reduce_fusion.py
@@ -1,0 +1,276 @@
+"""
+Unit tests for the :class:`fpy2.transform.ReduceFusion` transform.
+
+The rewrite mints fresh ``_acc`` / ``_b`` names via ``Gensym``, so an
+``is_equiv`` comparison against a hand-written golden AST is brittle.  As in
+``test_zip_elim``, the tests assert:
+
+1. **Structural shape** — the reduction is gone, replaced by a seeded
+   accumulator and a ``for`` loop whose body binds the element before
+   folding it.
+2. **Semantic equivalence** — the fused function agrees with the original on
+   concrete inputs, *including when the element expression raises*.  That
+   last part is the whole reason the element is bound to a temp rather than
+   inlined, so it gets its own test.
+
+Negative tests (unchanged inputs) use ``is_equiv`` against the original.
+"""
+
+import pytest
+
+import fpy2 as fp
+
+from fpy2 import Function
+from fpy2.ast.fpyast import (
+    AllOf, AnyOf, Assign, BoolVal, ForStmt, ListComp, Or, Var,
+)
+from fpy2.transform import ReduceFusion
+
+
+def _fuse(f) -> Function:
+    return Function(ReduceFusion.apply(f.ast))
+
+
+def _find(ast, cls):
+    """First node of type *cls* reachable in *ast.body*, descending into
+    compound statements."""
+    def walk(stmts):
+        for s in stmts:
+            if isinstance(s, cls):
+                return s
+            body = getattr(s, 'body', None)
+            if body is not None and hasattr(body, 'stmts'):
+                hit = walk(body.stmts)
+                if hit is not None:
+                    return hit
+        return None
+    return walk(ast.body.stmts)
+
+
+def _has_node(ast, cls) -> bool:
+    """Whether any expression of type *cls* survives anywhere in *ast*."""
+    from fpy2.ast import DefaultVisitor
+
+    found = []
+
+    class _V(DefaultVisitor):
+        def _visit_expr(self, e, ctx):
+            if isinstance(e, cls):
+                found.append(e)
+            return super()._visit_expr(e, ctx)
+
+    _V()._visit_function(ast, None)
+    return bool(found)
+
+
+def _agree(f, args_list):
+    """The fused function matches the original on every input — same value,
+    or the same exception type."""
+    g = _fuse(f)
+
+    def run(fn, args):
+        try:
+            return ('value', fn(*args))
+        except Exception as e:  # noqa: BLE001 -- exception *type* is the check
+            return ('raises', type(e).__name__)
+
+    for args in args_list:
+        assert run(f, args) == run(g, args), f'diverged on {args}'
+    return g
+
+
+class TestRewriteFires:
+    """``any``/``all`` over a comprehension becomes a seeded loop."""
+
+    def test_any_becomes_seeded_loop(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return any([x < 0 for x in xs])
+
+        out = ReduceFusion.apply(f.ast)
+        assert not _has_node(out, AnyOf), 'reduction should be gone'
+        assert not _has_node(out, ListComp), 'intermediate list should be gone'
+        seed = _find(out, Assign)
+        assert isinstance(seed.expr, BoolVal) and seed.expr.val is False, (
+            '`any` seeds the accumulator with False'
+        )
+        assert _find(out, ForStmt) is not None
+
+    def test_all_seeds_true(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return all([x < 0 for x in xs])
+
+        out = ReduceFusion.apply(f.ast)
+        assert not _has_node(out, AllOf)
+        seed = _find(out, Assign)
+        assert isinstance(seed.expr, BoolVal) and seed.expr.val is True
+
+    def test_loop_body_binds_element_before_folding(self):
+        """The body must be ``_b = <elt>; _acc = _acc or _b`` — folding
+        ``<elt>`` inline would let ``or`` short-circuit it away."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return any([x < 0 for x in xs])
+
+        loop = _find(ReduceFusion.apply(f.ast), ForStmt)
+        assert len(loop.body.stmts) == 2
+        bind, fold = loop.body.stmts
+        assert isinstance(bind, Assign)
+        # the fold's operands are both plain variable references
+        assert isinstance(fold.expr, Or)
+        assert all(isinstance(a, Var) for a in fold.expr.args), (
+            'element must be folded via a Var, not inlined'
+        )
+        # ...and one of them is the name the bind just defined
+        assert str(bind.target) in {str(a.name) for a in fold.expr.args}
+
+    def test_idempotent(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return any([x < 0 for x in xs])
+
+        once = ReduceFusion.apply(f.ast)
+        twice = ReduceFusion.apply(once)
+        assert once.format() == twice.format()
+
+
+class TestSemanticsPreserved:
+
+    def test_any_matches_on_values(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return any([x < 0 for x in xs])
+
+        g = _agree(f, [([],), ([1.0],), ([-1.0],), ([1.0, -2.0, 3.0],), ([1.0, 2.0],)])
+        assert g([], ctx=fp.FP64) is False        # empty identity survives
+
+    def test_all_matches_on_values(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return all([x < 0 for x in xs])
+
+        g = _agree(f, [([],), ([1.0],), ([-1.0],), ([-1.0, -2.0],), ([-1.0, 2.0],)])
+        assert g([], ctx=fp.FP64) is True
+
+    def test_faulting_element_still_faults(self):
+        """The motivating case for binding the element.
+
+        ``xs[i]`` walks off the end.  Unfused, the comprehension evaluates
+        every element and raises.  If the rewrite inlined the element into
+        ``_acc or <elt>``, ``or`` would short-circuit once ``_acc`` is True
+        and the program would return instead of raising.
+        """
+        @fp.fpy
+        def f(xs: list[fp.Real], n: fp.Real) -> bool:
+            with fp.FP64:
+                return any([xs[i] < 0 for i in range(n)])
+
+        # xs[0] < 0 decides `any` immediately, but n=4 overruns a length-3 list
+        with pytest.raises(IndexError):
+            f([-1.0, 2.0, 3.0], 4, ctx=fp.FP64)
+        with pytest.raises(IndexError):
+            _fuse(f)([-1.0, 2.0, 3.0], 4, ctx=fp.FP64)
+
+        _agree(f, [([-1.0, 2.0, 3.0], 4), ([-1.0, 2.0, 3.0], 3), ([1.0, 2.0, 3.0], 4)])
+
+    def test_nested_in_larger_expression(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], y: fp.Real) -> bool:
+            with fp.FP64:
+                return any([x < 0 for x in xs]) and (y > 0)
+
+        _agree(f, [([1.0, -2.0], 1.0), ([1.0, 2.0], 1.0), ([-1.0], -1.0), ([], 1.0)])
+
+    def test_two_reductions_in_one_statement(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return any([x < 0 for x in xs]) and all([x < 10 for x in xs])
+
+        out = ReduceFusion.apply(f.ast)
+        assert not _has_node(out, AnyOf) and not _has_node(out, AllOf)
+        _agree(f, [([1.0, -2.0],), ([1.0, 20.0],), ([-1.0, 2.0],), ([],)])
+
+    def test_inside_loop_and_if_condition(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                n = fp.round(0)
+                for x in xs:
+                    if any([y < x for y in xs]):
+                        n = n + 1
+                return n
+
+        _agree(f, [([1.0, 2.0, 3.0],), ([],), ([5.0],)])
+
+
+class TestRewriteSuppressed:
+    """Positions with no statement slot, and operands that aren't comps."""
+
+    def test_non_comprehension_operand_untouched(self):
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            return any(bs)
+
+        out = ReduceFusion.apply(f.ast)
+        assert out.is_equiv(f.ast)
+        assert _has_node(out, AnyOf)
+
+    def test_if_expr_branch_not_fused(self):
+        """Hoisting a loop out of a conditional branch would run it
+        unconditionally — observable when the element can fault."""
+        @fp.fpy
+        def f(xs: list[fp.Real], c: bool) -> bool:
+            with fp.FP64:
+                return any([xs[0] < 0 for _ in xs]) if c else False
+
+        out = ReduceFusion.apply(f.ast)
+        assert _has_node(out, AnyOf), 'branch reduction must be left in place'
+        # `xs[0]` on an empty list would raise if the branch were hoisted
+        _agree(f, [([], False), ([1.0], True), ([1.0], False)])
+
+    def test_nested_inside_a_comprehension_not_fused(self):
+        @fp.fpy
+        def f(xss: list[fp.Real]) -> bool:
+            with fp.FP64:
+                inner = [any([y < x for y in xss]) for x in xss]
+                return all(inner)
+
+        out = ReduceFusion.apply(f.ast)
+        # the inner reduction sits in a comp element -> no statement slot
+        assert _has_node(out, AnyOf)
+        _agree(f, [([1.0, 2.0],), ([],), ([3.0],)])
+
+    def test_multi_stage_comprehension_left_alone(self):
+        """``[e for a in xs for b in ys]`` has two targets; fusing it needs
+        nested loops, so the pass declines."""
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return any([a < b for a in xs for b in ys])
+
+        out = ReduceFusion.apply(f.ast)
+        assert out.is_equiv(f.ast)
+        _agree(f, [([1.0, 2.0], [3.0]), ([5.0], [3.0]), ([], [1.0]), ([1.0], [])])
+
+
+class TestTupleBindingTarget:
+
+    def test_zip_comprehension_fuses(self):
+        """A ``zip`` comp is single-stage — one target, one iterable — so it
+        fuses, with the tuple binding carried onto the ``for``."""
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> bool:
+            with fp.FP64:
+                return any([a < b for a, b in zip(xs, ys)])
+
+        out = ReduceFusion.apply(f.ast)
+        assert not _has_node(out, AnyOf)
+        _agree(f, [([1.0, 2.0], [3.0, 1.0]), ([1.0], [0.0]), ([], [])])


### PR DESCRIPTION
An expression `any`/`all` of a list comprehension materializes the list of boolean values, but this is inefficient. This PR adds a program transformation to rewrite this pattern into a for loop to never materialize a list.