### PR TITLE
Fix interpreter

### DIFF
--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -65,18 +65,13 @@ def _cvt_arg(arg):
 def _arg_to_value(arg: Any):
     """Convert a value crossing the *Python* boundary into an FPy value.
 
-    Containers are rebuilt **unconditionally**, which isolates the caller: FPy
-    lists are shared, so an FPy callee's ``xs[i] = e`` would otherwise reach back
-    into the Python caller's own list.
+    Containers are rebuilt unconditionally so the caller is isolated: FPy lists
+    are shared, so an FPy callee's ``xs[i] = e`` would otherwise write the Python
+    caller's own list.  Skipping the rebuild when the elements were already FPy
+    values made that isolation depend on how the caller built the list.
 
-    The rebuild used to be skipped when every element was already an FPy value,
-    which made isolation depend on how the caller happened to build the list —
-    a list of Python ``float``\\ s was copied, a list of :class:`Float` was not.
-    Same program, opposite effect on the caller's data.
-
-    This costs one deep copy per *outer* call.  Calls between FPy functions skip
-    this path entirely (``eval(..., convert=False)``) and keep sharing, so the
-    cost is not per-call.
+    One deep copy per *outer* call only — FPy-to-FPy calls bypass this entirely
+    (``eval(..., convert=False)``) and keep sharing.
     """
     return _cvt_arg(arg)
 
@@ -174,13 +169,9 @@ def _construct_context(cls: type[Context], args: tuple, kwargs: dict[str, object
 
 
 def _call_fpy(fn: Function, args, ctx):
-    """Invoke an FPy function from *inside* the interpreter.
-
-    Bypasses ``Function.__call__`` so the Python-boundary conversions are
-    skipped: they normalise representations for Python callers and rebuild
-    containers, and rebuilding is what breaks list sharing between an FPy caller
-    and its callee.
-    """
+    """Invoke an FPy function from *inside* the interpreter, bypassing
+    ``Function.__call__`` so the Python-boundary conversions are skipped —
+    rebuilding containers there would break list sharing with the callee."""
     rt = fn.runtime if fn.runtime is not None else get_default_interpreter()
     return rt.eval(fn, args, ctx, convert=False)
 
@@ -1169,11 +1160,9 @@ class BytecodeInterpreter(Interpreter):
         self, func: Function, args, ctx: Context | None = None,
         *, convert: bool = True,
     ):
-        """*convert* applies the Python-boundary conversions.  Leave it ``True``
-        for a call arriving from Python; pass ``False`` for an FPy-to-FPy call,
-        where they are not merely unnecessary but wrong — they rebuild lists and
-        tuples, which breaks the object identity FPy's sharing semantics rely
-        on."""
+        """``convert`` applies the Python-boundary conversions: ``True`` for a
+        call from Python, ``False`` for FPy-to-FPy, where rebuilding containers
+        would break list sharing."""
         if not isinstance(func, Function):
             raise TypeError(f'Expected Function, got `{func}`')
         # compile the function to bytecode
@@ -1185,7 +1174,6 @@ class BytecodeInterpreter(Interpreter):
             self.func_cache[func.ast] = fn
         # compute the context to use during evaluation
         ctx = self._func_ctx(func.ast, ctx)
-        # convert arguments to FPy values (Python boundary only)
         if convert:
             args = tuple(_arg_to_value(arg) for arg in args)
         # call the function with the given arguments
@@ -1193,6 +1181,9 @@ class BytecodeInterpreter(Interpreter):
         return _cvt_return(res) if convert else res
 
     def eval_expr(self, expr: Expr, env: dict[NamedId, Any], ctx: Context):
+        # Always converts: the only caller is `PartialEval`, whose environment
+        # holds analysis-time values rather than a running FPy program's, so
+        # this is a boundary like the Python one.
         if not isinstance(expr, Expr):
             raise TypeError(f'Expected Expr, got `{expr}`')
         # convert the expression to a function definition

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -19,7 +19,7 @@ from ..function import Function
 from ..number import FP64, INTEGER, REAL, Float, RealFloat
 from ..primitive import Primitive
 from ..utils import Gensym, is_dyadic
-from .interpreter import Interpreter
+from .interpreter import Interpreter, get_default_interpreter
 
 ###########################################################
 # Runtime
@@ -46,8 +46,16 @@ def _is_integer(x: Float | Fraction) -> bool:
             raise TypeError(f'expected a real number, got `{x}`')
 
 def _is_value(x):
+    """Is *x* already an FPy runtime value, needing no conversion?
+
+    ``Fraction`` is included because it *is* one — :data:`RealValue` is
+    ``Float | Fraction``, and an unrounded literal (``xs[0] = 77``) legitimately
+    stores a ``Fraction``.  Omitting it made ``_arg_to_value`` rebuild any list
+    holding one, which silently broke object identity across a call boundary
+    even though ``_cvt_arg`` leaves the elements untouched.
+    """
     match x:
-        case bool() | Float() | Context():
+        case bool() | Float() | Fraction() | Context():
             return True
         case tuple() | list():
             return all(_is_value(v) for v in x)
@@ -167,13 +175,25 @@ def _construct_context(cls: type[Context], args: tuple, kwargs: dict[str, object
     return cls(*ctor_args, **ctor_kwargs)
 
 
+def _call_fpy(fn: Function, args, ctx):
+    """Invoke an FPy function from *inside* the interpreter.
+
+    Bypasses ``Function.__call__`` so the Python-boundary conversions are
+    skipped: they normalise representations for Python callers and rebuild
+    containers, and rebuilding is what breaks list sharing between an FPy caller
+    and its callee.
+    """
+    rt = fn.runtime if fn.runtime is not None else get_default_interpreter()
+    return rt.eval(fn, args, ctx, convert=False)
+
+
 def _eval_call(fn, ctx, *args, **kwargs):
     match fn:
         case Function():
             # calling FPy function
             if kwargs:
                 raise RuntimeError('FPy functions do not support keyword arguments')
-            return fn(*args, ctx=ctx)
+            return _call_fpy(fn, args, ctx)
         case Primitive():
             # calling FPy primitive
             if kwargs:
@@ -1147,7 +1167,15 @@ class BytecodeInterpreter(Interpreter):
         ast = FuncDef(name='<expr>', args=args, body=body, meta=meta, loc=loc)
         return ast, names
 
-    def eval(self, func: Function, args, ctx: Context | None = None):
+    def eval(
+        self, func: Function, args, ctx: Context | None = None,
+        *, convert: bool = True,
+    ):
+        """*convert* applies the Python-boundary conversions.  Leave it ``True``
+        for a call arriving from Python; pass ``False`` for an FPy-to-FPy call,
+        where they are not merely unnecessary but wrong — they rebuild lists and
+        tuples, which breaks the object identity FPy's sharing semantics rely
+        on."""
         if not isinstance(func, Function):
             raise TypeError(f'Expected Function, got `{func}`')
         # compile the function to bytecode
@@ -1159,11 +1187,12 @@ class BytecodeInterpreter(Interpreter):
             self.func_cache[func.ast] = fn
         # compute the context to use during evaluation
         ctx = self._func_ctx(func.ast, ctx)
-        # convert arguments to FPy values
-        args = tuple(_arg_to_value(arg) for arg in args)
+        # convert arguments to FPy values (Python boundary only)
+        if convert:
+            args = tuple(_arg_to_value(arg) for arg in args)
         # call the function with the given arguments
         res = fn(*args, __ctx__=ctx)
-        return _cvt_return(res)
+        return _cvt_return(res) if convert else res
 
     def eval_expr(self, expr: Expr, env: dict[NamedId, Any], ctx: Context):
         if not isinstance(expr, Expr):

--- a/fpy2/interpret/byte.py
+++ b/fpy2/interpret/byte.py
@@ -45,23 +45,6 @@ def _is_integer(x: Float | Fraction) -> bool:
         case _:
             raise TypeError(f'expected a real number, got `{x}`')
 
-def _is_value(x):
-    """Is *x* already an FPy runtime value, needing no conversion?
-
-    ``Fraction`` is included because it *is* one — :data:`RealValue` is
-    ``Float | Fraction``, and an unrounded literal (``xs[0] = 77``) legitimately
-    stores a ``Fraction``.  Omitting it made ``_arg_to_value`` rebuild any list
-    holding one, which silently broke object identity across a call boundary
-    even though ``_cvt_arg`` leaves the elements untouched.
-    """
-    match x:
-        case bool() | Float() | Fraction() | Context():
-            return True
-        case tuple() | list():
-            return all(_is_value(v) for v in x)
-        case _:
-            return False
-
 def _cvt_arg(arg):
     match arg:
         case bool() | Float() | Context():
@@ -80,7 +63,22 @@ def _cvt_arg(arg):
             return arg
 
 def _arg_to_value(arg: Any):
-    return arg if _is_value(arg) else _cvt_arg(arg)
+    """Convert a value crossing the *Python* boundary into an FPy value.
+
+    Containers are rebuilt **unconditionally**, which isolates the caller: FPy
+    lists are shared, so an FPy callee's ``xs[i] = e`` would otherwise reach back
+    into the Python caller's own list.
+
+    The rebuild used to be skipped when every element was already an FPy value,
+    which made isolation depend on how the caller happened to build the list —
+    a list of Python ``float``\\ s was copied, a list of :class:`Float` was not.
+    Same program, opposite effect on the caller's data.
+
+    This costs one deep copy per *outer* call.  Calls between FPy functions skip
+    this path entirely (``eval(..., convert=False)``) and keep sharing, so the
+    cost is not per-call.
+    """
+    return _cvt_arg(arg)
 
 def _is_return_value(x) -> bool:
     match x:

--- a/fpy2/interpret/interpreter.py
+++ b/fpy2/interpret/interpreter.py
@@ -24,11 +24,20 @@ class Interpreter(ABC):
         self.ctx = ctx
 
     @abstractmethod
-    def eval(self, func: Function, args, ctx: Context | None = None):
+    def eval(
+        self, func: Function, args, ctx: Context | None = None,
+        *, convert: bool = True,
+    ):
         """
         Evaluates a function `func` on arguments `args` under
         a rounding context `ctx`. If `ctx` is None, the rounding
         context is the native Python floating-point context.
+
+        `convert` applies the Python-boundary conversions that normalise
+        argument and result representations. Leave it `True` for a call
+        arriving from Python. An interpreter calling one FPy function from
+        another must pass `False`: those conversions rebuild lists and tuples,
+        which would break the object identity FPy's sharing semantics rely on.
         """
         ...
 

--- a/fpy2/interpret/interpreter.py
+++ b/fpy2/interpret/interpreter.py
@@ -34,10 +34,9 @@ class Interpreter(ABC):
         context is the native Python floating-point context.
 
         `convert` applies the Python-boundary conversions that normalise
-        argument and result representations. Leave it `True` for a call
-        arriving from Python. An interpreter calling one FPy function from
-        another must pass `False`: those conversions rebuild lists and tuples,
-        which would break the object identity FPy's sharing semantics rely on.
+        argument and result representations. Pass `False` when calling one FPy
+        function from another: those conversions rebuild lists and tuples,
+        which would break the object identity FPy's list sharing relies on.
         """
         ...
 

--- a/tests/unit/interpret/test_list_sharing.py
+++ b/tests/unit/interpret/test_list_sharing.py
@@ -1,0 +1,231 @@
+"""
+Interpreter behaviour of list sharing across an FPy call boundary.
+
+FPy lists are **shared**: assignment aliases, ``xs[i] = e`` mutates the list
+object, and passing or returning a list carries the identity with it.
+
+``Interpreter.eval`` broke that by applying the Python-boundary conversions to
+*every* call, FPy-to-FPy included.  Those conversions rebuild lists and tuples,
+which severs the alias.  They fire only when an element isn't already a
+``Float``/``bool``/``Context``, so an unrounded literal (``xs[0] = 77`` stores a
+``Fraction``) was enough to trigger them — making sharing depend on whether the
+last store was a literal or a computed value.  That is why the tests below cover
+*both* spellings of the same program.
+
+The last class pins what must survive: the conversions still apply at the Python
+edge, so a Python caller keeps getting canonical values.  Its final test records a
+*separate*, pre-existing gap this work surfaced but did not change — whether that
+edge isolates a caller's list at all is representation-dependent.
+"""
+
+from fractions import Fraction
+
+import fpy2 as fp
+
+FP64 = fp.FP64
+
+
+class TestParameterSharing:
+    """A callee writing a list parameter writes the caller's list."""
+
+    def test_callee_write_is_visible_to_caller(self):
+        @fp.fpy
+        def callee(zs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                zs[0] = 77
+                return 0
+
+        @fp.fpy
+        def caller(xs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                _ = callee(xs)
+                return xs[0]
+
+        assert float(caller([1.0, 2.0], ctx=FP64)) == 77.0
+
+    def test_sharing_holds_when_the_list_already_holds_a_fraction(self):
+        """``xs[0] = 77`` stores an unrounded ``Fraction``, which is what used
+        to trip the conversion; the list must still be passed by identity."""
+        @fp.fpy
+        def touch(zs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                zs[1] = zs[1] + 1        # computed: stays a Float
+                return 0
+
+        @fp.fpy
+        def caller(xs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                xs[0] = 77               # unrounded literal -> Fraction
+                _ = touch(xs)
+                return xs[1]             # 3 if shared, 2 if the list was copied
+
+        assert float(caller([1.0, 2.0], ctx=FP64)) == 3.0
+
+
+class TestReturnSharing:
+    """A returned list keeps its identity, so the caller's binding aliases it."""
+
+    def test_returned_parameter_aliases(self):
+        @fp.fpy
+        def ident(zs: list[fp.Real]) -> list[fp.Real]:
+            return zs
+
+        @fp.fpy
+        def caller(xs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                ys = ident(xs)
+                ys[0] = 99
+                return xs[0]
+
+        assert float(caller([1.0, 2.0], ctx=FP64)) == 99.0
+
+    def test_mutate_then_return_aliases(self):
+        """The case that revealed the bug: the callee's write was visible to the
+        caller *and* the returned list was a copy — an incoherent pair.  The
+        write turned an element into a ``Fraction``, which tripped the return
+        conversion into rebuilding the list."""
+        @fp.fpy
+        def bump(zs: list[fp.Real]) -> list[fp.Real]:
+            with FP64:
+                zs[0] = 77
+                return zs
+
+        @fp.fpy
+        def caller(xs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                ys = bump(xs)
+                ys[1] = 55           # through the returned alias
+                return xs[1]         # 55 if shared, 2 if copied
+
+        assert float(caller([1.0, 2.0], ctx=FP64)) == 55.0
+
+    def test_literal_and_computed_stores_behave_alike(self):
+        """Sharing must not depend on element representation.  These two callees
+        differ only in whether the stored value is a literal (a ``Fraction``) or
+        computed (a ``Float``); before the fix they disagreed."""
+        @fp.fpy
+        def store_literal(zs: list[fp.Real]) -> list[fp.Real]:
+            with FP64:
+                zs[0] = 77
+                return zs
+
+        @fp.fpy
+        def store_computed(zs: list[fp.Real]) -> list[fp.Real]:
+            with FP64:
+                zs[0] = zs[0] + 76
+                return zs
+
+        @fp.fpy
+        def via_literal(xs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                ys = store_literal(xs)
+                ys[1] = ys[1] + 53
+                return xs[1]
+
+        @fp.fpy
+        def via_computed(xs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                ys = store_computed(xs)
+                ys[1] = ys[1] + 53
+                return xs[1]
+
+        lit = float(via_literal([1.0, 2.0], ctx=FP64))
+        calc = float(via_computed([1.0, 2.0], ctx=FP64))
+        assert lit == calc == 55.0
+
+
+class TestNestedSharing:
+    """An inner list handed to a callee is shared too — the identity travels
+    through a projection, not just a bare name."""
+
+    def test_callee_writes_an_inner_list(self):
+        @fp.fpy
+        def callee(row: list[fp.Real]) -> fp.Real:
+            with FP64:
+                row[0] = 42
+                return 0
+
+        @fp.fpy
+        def caller(xss: list[list[fp.Real]]) -> fp.Real:
+            with FP64:
+                _ = callee(xss[0])
+                return xss[0][0]
+
+        assert float(caller([[1.0, 2.0], [3.0, 4.0]], ctx=FP64)) == 42.0
+
+
+class TestPythonBoundary:
+    """The fix narrows the boundary conversions to the Python edge rather than
+    removing them, so a Python caller still gets canonical values.  Over-applying
+    it would have started handing raw ``Fraction``\ s back to Python code.
+
+    The last test pins a separate, pre-existing gap that this work surfaced but
+    did not change.
+    """
+
+    def test_returned_literal_is_a_float_not_a_fraction(self):
+        @fp.fpy
+        def f() -> fp.Real:
+            with FP64:
+                xs = [0.0, 0.0]
+                xs[0] = 77          # unrounded literal -> Fraction internally
+                return xs[0]
+
+        out = f(ctx=FP64)
+        assert isinstance(out, fp.Float), f'expected Float at the boundary, got {type(out)}'
+        assert float(out) == 77.0
+
+    def test_returned_list_elements_are_converted(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with FP64:
+                xs[0] = 77
+                return xs
+
+        out = f([0.0, 0.0], ctx=FP64)
+        assert all(isinstance(v, fp.Float) for v in out), (
+            f'expected all Float at the boundary, got {[type(v) for v in out]}'
+        )
+
+    def test_non_dyadic_rational_stays_exact(self):
+        """``_cvt_return`` converts only *dyadic* rationals; a non-dyadic one is
+        left as a ``Fraction`` so no precision is invented."""
+        @fp.fpy(ctx=fp.REAL)
+        def f() -> fp.Real:
+            return fp.rational(1, 3)
+
+        assert f() == Fraction(1, 3)
+
+    def test_python_list_isolation_is_representation_dependent(self):
+        """**Known gap, pinned deliberately.**
+
+        Whether a Python caller's list is isolated from an FPy callee's writes
+        depends on the element representation, because ``_arg_to_value`` uses
+        "is every element already an FPy value?" to decide whether to rebuild the
+        container.  Those are different questions:
+
+        - a list of Python ``float``\ s needs conversion, so it is rebuilt and
+          the caller is isolated;
+        - a list of ``Float``\ s (or ``Fraction``\ s) needs none, so it is
+          passed by identity and the callee's write reaches the caller.
+
+        Both are asserted below so the inconsistency is visible rather than
+        latent.  Deciding it needs a call on whether the Python boundary should
+        isolate at all; if it should, the boundary must copy unconditionally
+        instead of only when a conversion happens to be required.
+        """
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with FP64:
+                xs[0] = 99
+                return xs[0]
+
+        # needs conversion -> rebuilt -> caller isolated
+        py_floats = [1.0, 2.0]
+        assert float(f(py_floats, ctx=FP64)) == 99.0
+        assert py_floats == [1.0, 2.0]
+
+        # needs no conversion -> passed by identity -> caller is written
+        fpy_floats = [fp.Float.from_float(1.0), fp.Float.from_float(2.0)]
+        assert float(f(fpy_floats, ctx=FP64)) == 99.0
+        assert float(fpy_floats[0]) == 99.0

--- a/tests/unit/interpret/test_list_sharing.py
+++ b/tests/unit/interpret/test_list_sharing.py
@@ -1,22 +1,19 @@
 """
 Interpreter behaviour of list sharing across an FPy call boundary.
 
-FPy lists are **shared**: assignment aliases, ``xs[i] = e`` mutates the list
-object, and passing or returning a list carries the identity with it.
+FPy lists are shared: assignment aliases, ``xs[i] = e`` mutates the list object,
+and passing or returning a list carries the identity with it.
 
-``Interpreter.eval`` broke that by applying the Python-boundary conversions to
-*every* call, FPy-to-FPy included.  Those conversions rebuild lists and tuples,
-which severs the alias.  They fire only when an element isn't already a
-``Float``/``bool``/``Context``, so an unrounded literal (``xs[0] = 77`` stores a
-``Fraction``) was enough to trigger them — making sharing depend on whether the
-last store was a literal or a computed value.  That is why the tests below cover
-*both* spellings of the same program.
+``Interpreter.eval`` broke that by applying its Python-boundary conversions to
+*every* call, FPy-to-FPy included; those rebuild containers, severing the alias.
+They fired only when an element wasn't already a ``Float``/``bool``/``Context``,
+so an unrounded literal (``xs[0] = 77`` stores a ``Fraction``) was enough to
+trigger one — making sharing depend on whether the last store was a literal or a
+computed value.  Hence the tests covering both spellings of one program.
 
-The last class covers the Python edge, where the conversions remain: a caller
-still gets canonical values, and its container is now rebuilt *unconditionally* so
-an FPy callee can never write it.  That rebuild used to be skipped whenever every
-element already happened to be an FPy value — the same representation-dependence,
-from the other direction.
+The conversions remain at the Python edge, where the container is now rebuilt
+*unconditionally*: skipping it whenever the elements happened to already be FPy
+values made caller isolation representation-dependent in the same way.
 """
 
 from fractions import Fraction
@@ -82,9 +79,7 @@ class TestReturnSharing:
 
     def test_mutate_then_return_aliases(self):
         """The case that revealed the bug: the callee's write was visible to the
-        caller *and* the returned list was a copy — an incoherent pair.  The
-        write turned an element into a ``Fraction``, which tripped the return
-        conversion into rebuilding the list."""
+        caller *and* the returned list was a copy — an incoherent pair."""
         @fp.fpy
         def bump(zs: list[fp.Real]) -> list[fp.Real]:
             with FP64:
@@ -156,13 +151,9 @@ class TestNestedSharing:
 
 
 class TestPythonBoundary:
-    """The fix narrows the boundary conversions to the Python edge rather than
-    removing them, so a Python caller still gets canonical values.  Over-applying
-    it would have started handing raw ``Fraction``\ s back to Python code.
-
-    The last two tests cover caller isolation, which the same conflation of
-    "is a value" with "needs no copy" had made representation-dependent.
-    """
+    """Conversions remain at the Python edge, so a caller still gets canonical
+    values; over-applying the fix would have handed raw ``Fraction`` values
+    back to Python.  The last two tests cover caller isolation."""
 
     def test_returned_literal_is_a_float_not_a_fraction(self):
         @fp.fpy
@@ -199,14 +190,9 @@ class TestPythonBoundary:
 
     def test_python_caller_list_is_always_isolated(self):
         """A Python caller's container is rebuilt unconditionally, so an FPy
-        callee's ``xs[i] = e`` never reaches back into it.
-
-        This used to depend on the element representation: the rebuild was
-        skipped when every element was already an FPy value, so a list of Python
-        ``float``\ s was copied while a list of :class:`Float` was passed by
-        identity and written through.  Every representation below is checked
-        because that is exactly what differed.
-        """
+        callee's ``xs[i] = e`` never reaches back into it.  All four
+        representations are checked because that is exactly what used to
+        differ — ``Float`` and ``Fraction`` lists were passed by identity."""
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:
             with FP64:

--- a/tests/unit/interpret/test_list_sharing.py
+++ b/tests/unit/interpret/test_list_sharing.py
@@ -12,10 +12,11 @@ which severs the alias.  They fire only when an element isn't already a
 last store was a literal or a computed value.  That is why the tests below cover
 *both* spellings of the same program.
 
-The last class pins what must survive: the conversions still apply at the Python
-edge, so a Python caller keeps getting canonical values.  Its final test records a
-*separate*, pre-existing gap this work surfaced but did not change — whether that
-edge isolates a caller's list at all is representation-dependent.
+The last class covers the Python edge, where the conversions remain: a caller
+still gets canonical values, and its container is now rebuilt *unconditionally* so
+an FPy callee can never write it.  That rebuild used to be skipped whenever every
+element already happened to be an FPy value — the same representation-dependence,
+from the other direction.
 """
 
 from fractions import Fraction
@@ -159,8 +160,8 @@ class TestPythonBoundary:
     removing them, so a Python caller still gets canonical values.  Over-applying
     it would have started handing raw ``Fraction``\ s back to Python code.
 
-    The last test pins a separate, pre-existing gap that this work surfaced but
-    did not change.
+    The last two tests cover caller isolation, which the same conflation of
+    "is a value" with "needs no copy" had made representation-dependent.
     """
 
     def test_returned_literal_is_a_float_not_a_fraction(self):
@@ -196,23 +197,15 @@ class TestPythonBoundary:
 
         assert f() == Fraction(1, 3)
 
-    def test_python_list_isolation_is_representation_dependent(self):
-        """**Known gap, pinned deliberately.**
+    def test_python_caller_list_is_always_isolated(self):
+        """A Python caller's container is rebuilt unconditionally, so an FPy
+        callee's ``xs[i] = e`` never reaches back into it.
 
-        Whether a Python caller's list is isolated from an FPy callee's writes
-        depends on the element representation, because ``_arg_to_value`` uses
-        "is every element already an FPy value?" to decide whether to rebuild the
-        container.  Those are different questions:
-
-        - a list of Python ``float``\ s needs conversion, so it is rebuilt and
-          the caller is isolated;
-        - a list of ``Float``\ s (or ``Fraction``\ s) needs none, so it is
-          passed by identity and the callee's write reaches the caller.
-
-        Both are asserted below so the inconsistency is visible rather than
-        latent.  Deciding it needs a call on whether the Python boundary should
-        isolate at all; if it should, the boundary must copy unconditionally
-        instead of only when a conversion happens to be required.
+        This used to depend on the element representation: the rebuild was
+        skipped when every element was already an FPy value, so a list of Python
+        ``float``\ s was copied while a list of :class:`Float` was passed by
+        identity and written through.  Every representation below is checked
+        because that is exactly what differed.
         """
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:
@@ -220,12 +213,25 @@ class TestPythonBoundary:
                 xs[0] = 99
                 return xs[0]
 
-        # needs conversion -> rebuilt -> caller isolated
-        py_floats = [1.0, 2.0]
-        assert float(f(py_floats, ctx=FP64)) == 99.0
-        assert py_floats == [1.0, 2.0]
+        for src, label in (
+            ([1.0, 2.0], 'Python float'),
+            ([1, 2], 'Python int'),
+            ([Fraction(1), Fraction(2)], 'Fraction'),
+            ([fp.Float.from_float(1.0), fp.Float.from_float(2.0)], 'Float'),
+        ):
+            before = [float(v) for v in src]
+            assert float(f(src, ctx=FP64)) == 99.0
+            assert [float(v) for v in src] == before, f'leaked for {label}'
 
-        # needs no conversion -> passed by identity -> caller is written
-        fpy_floats = [fp.Float.from_float(1.0), fp.Float.from_float(2.0)]
-        assert float(f(fpy_floats, ctx=FP64)) == 99.0
-        assert float(fpy_floats[0]) == 99.0
+    def test_nested_python_caller_list_is_isolated(self):
+        """Isolation is deep — an inner list must be rebuilt too, or a callee
+        writing ``xss[0][0]`` would reach the caller's inner list."""
+        @fp.fpy
+        def f(xss: list[list[fp.Real]]) -> fp.Real:
+            with FP64:
+                xss[0][0] = 99
+                return xss[0][0]
+
+        src = [[fp.Float.from_float(1.0)], [fp.Float.from_float(2.0)]]
+        assert float(f(src, ctx=FP64)) == 99.0
+        assert float(src[0][0]) == 1.0


### PR DESCRIPTION
This PR fixes the interpreter. When calling a function from Python, any structured data (i.e., lists and tuples) is copied. When calling a function from FPy, structured data is not copied.