### PR TITLE
Fix C++ compiler

### DIFF
--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -226,6 +226,14 @@ class CppCompiler(Backend):
             raise CppCompileError(
                 f'storage selection failed for `{func.name}`: {e}'
             ) from e
+        except Exception as e:
+            # An internal invariant failure in `storage.py` (e.g. an `assert`
+            # in `_supremum`) would otherwise reach the caller as a bare
+            # AssertionError naming neither the function nor the backend.
+            raise CppCompileError(
+                f'storage selection failed for `{func.name}`: '
+                f'internal error: {e!r}'
+            ) from e
 
         # Call.fn → emitted name.  ``Specialize`` rewired each Call.fn at
         # the source so call.fn.ast.name is the target spec's emit name.

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -296,12 +296,15 @@ class CppEmitter(Visitor):
         Used by visitors that need to emit setup statements alongside
         an expression result — comprehensions, slices, tuple-binding
         destructure sources, ``enumerate``, ``zip``, etc.  The
-        ``__cpp_tmp`` prefix keeps these distinct from any identifier
-        the source program could introduce (FPy doesn't allow leading
-        underscores in user-visible names).
+        The ``_tmp`` prefix keeps these distinct from any identifier the
+        source program could introduce (FPy doesn't allow leading underscores
+        in user-visible names).  A single leading underscore is deliberate: an
+        identifier containing ``__`` is reserved to the implementation at every
+        scope, and ``__cpp_`` in particular is the standard's feature-test-macro
+        prefix.
         """
         self._tmp_counter += 1
-        return f'__cpp_tmp{self._tmp_counter}'
+        return f'_tmp{self._tmp_counter}'
 
     # ------------------------------------------------------------------
     # Public entry
@@ -1750,7 +1753,7 @@ class CppEmitter(Visitor):
             # NaN-propagating wrapper around ``std::fmin`` / ``std::fmax``
             # (see :data:`CPP_HELPERS`).  ±0 ordering is delegated to the
             # underlying ``std::fmin`` / ``std::fmax``.
-            fn = '__fpy_min' if isinstance(e, Min) else '__fpy_max'
+            fn = 'fpy::min' if isinstance(e, Min) else 'fpy::max'
         else:
             fn = 'std::min' if isinstance(e, Min) else 'std::max'
         result = casted[0]
@@ -1812,7 +1815,7 @@ class CppEmitter(Visitor):
         if result_ty.is_float():
             # NaN-propagating wrapper around ``std::fmin`` / ``std::fmax``;
             # see :meth:`_emit_min_max` and :data:`CPP_HELPERS`.
-            fn = '__fpy_min' if isinstance(e, AMin) else '__fpy_max'
+            fn = 'fpy::min' if isinstance(e, AMin) else 'fpy::max'
         else:
             fn = 'std::min' if isinstance(e, AMin) else 'std::max'
 
@@ -2150,9 +2153,9 @@ class CppEmitter(Visitor):
 
     def _visit_list_slice(self, e: ListSlice, ctx) -> str:
         # ``xs[start:stop]`` →
-        #   auto&& __cpp_tmpN = <xs>;
-        #   <result_ty>(__cpp_tmpN.begin() + start,
-        #               __cpp_tmpN.begin() + stop)
+        #   auto&& _tmpN = <xs>;
+        #   <result_ty>(_tmpN.begin() + start,
+        #               _tmpN.begin() + stop)
         #
         # Binding the value to a reference avoids re-evaluating ``<xs>``
         # when it isn't a simple lvalue (and matches the interpreter,

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -424,8 +424,11 @@ class CppEmitter(Visitor):
 
     @staticmethod
     def _is_aggregate(storage: CppType) -> bool:
-        """A ``std::vector`` / ``std::tuple`` — copying it is O(n), unlike
-        a scalar (where a copy is free and by-value is idiomatic)."""
+        """A list or a tuple — worth binding by reference rather than copying.
+
+        For a tuple because a copy is O(size); for a list because a copy of the
+        handle touches the refcount.  A scalar copy is free.
+        """
         return isinstance(storage, (CppList, CppTuple))
 
     def _is_rebound(self, d: Definition) -> bool:
@@ -433,11 +436,14 @@ class CppEmitter(Visitor):
 
         ``xs[i] = e`` is not a rebind — it mutates the list the handle already
         points at, and ``storage_infer`` keeps that def in the same class.  Only
-        an ``Assign`` to the same name is.
+        an ``Assign`` to the same name is, and *d*'s own defining assignment does
+        not count: a local bound once by ``x = y`` is not rebound.
         """
         cls = self.storage.def_class[d]
         return any(
-            isinstance(m, AssignDef) and isinstance(m.site, Assign)
+            m is not d
+            and isinstance(m, AssignDef)
+            and isinstance(m.site, Assign)
             for m in self.storage.class_members[cls]
         )
 
@@ -477,26 +483,28 @@ class CppEmitter(Visitor):
             return f'const {storage.format()}& {name}'
         return f'{storage.format()} {name}'
 
-    def _is_readonly_alias(self, stmt: Assign, target_def, target_storage: CppType) -> bool:
-        """Whether ``x = y`` can bind a ``const`` reference to ``y`` instead
-        of copying it.
+    def _is_readonly_alias(
+        self, stmt: Assign, target_def, target_storage: CppType,
+    ) -> bool:
+        """Whether ``x = y`` can bind a ``const`` reference instead of copying.
 
-        Safe iff the RHS is a bare variable, the value is an aggregate, and
-        *both* the target and the source are written exactly once (single
-        storage classes).  Then neither side can observe a mutation through
-        the other, so a reference is indistinguishable from a copy — minus
-        the O(n) copy.  (This is the local-variable analog of the const-ref
-        parameter and loop-variable bindings.)"""
+        A list is a handle now, so copying one is O(1) and *shares* the elements
+        — the correctness argument this used to need is gone, and what is left is
+        a small saving: a reference skips a refcount bump.  The condition is the
+        same as :meth:`_arg_decl`'s, for the same reason — a ``const`` reference
+        cannot be rebound.
+
+        Still worth it for a tuple, where a copy is O(size).
+        """
         if not isinstance(stmt.expr, Var):
             return False
         if not self._is_aggregate(target_storage):
             return False
         if target_def not in self.storage.declare_at_assign:
             return False
-        if not self.storage.is_single_def(target_def):
+        if self._is_rebound(target_def):
             return False
-        src_def = self.def_use.find_def_from_use(stmt.expr)
-        return self.storage.is_single_def(src_def)
+        return not self._is_rebound(self.def_use.find_def_from_use(stmt.expr))
 
     def _emit_bind(self, name: NamedId, site, rhs: str) -> None:
         """Emit a single ``T name = rhs;`` (declare-on-assign) or

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -37,11 +37,13 @@ from contextlib import contextmanager
 from fractions import Fraction
 
 from ...analysis import (
+    AssignDef,
     ContextScope,
     ContextScopeSite,
     ContextUseAnalysis,
     ContextUseSite,
     DefineUseAnalysis,
+    Definition,
     FormatAnalysis,
 )
 from ...analysis.format_infer import (
@@ -300,48 +302,86 @@ class CppEmitter(Visitor):
     # representation is a change to this block.
 
     @staticmethod
+    def _elt_of(ty: CppType) -> str:
+        """The element type of a list storage type."""
+        if not isinstance(ty, CppList):
+            raise CppEmitError(f'expected a list storage type, got {ty!r}')
+        return ty.elt.format()
+
+    @staticmethod
     def _list_len(base: str) -> str:
         """``len(xs)``."""
-        return f'{base}.size()'
+        return f'{base}->size()'
 
     @staticmethod
     def _list_at(base: str, idx: str) -> str:
         """``xs[i]``.  The cast belongs here because C++ ``operator[]`` takes an
         unsigned index while FPy indices are signed."""
-        return f'{base}[static_cast<size_t>({idx})]'
+        return f'(*{base})[static_cast<size_t>({idx})]'
+
+    @staticmethod
+    def _list_at_raw(base: str, idx: str) -> str:
+        """``xs[i]`` where *idx* is already a ``size_t`` — an emitter-internal
+        loop counter rather than an FPy index, so no cast is needed."""
+        return f'(*{base})[{idx}]'
+
+    def _list_range(self, base: str) -> str:
+        """The operand of a range-``for`` over a list.
+
+        A temporary handle is bound to a name first.  Range-``for`` extends the
+        lifetime of the range-init's *own* result, and ``*handle`` is a
+        reference to the pointee — so the handle itself would be destroyed at
+        the end of the range-init, freeing the elements before the first
+        iteration.
+        """
+        if base.isidentifier():
+            return f'*{base}'
+        tmp = self._fresh_temp()
+        self.writer.add_line(f'auto&& {tmp} = {base};')
+        return f'*{tmp}'
 
     @staticmethod
     def _list_begin(base: str) -> str:
-        return f'{base}.begin()'
+        return f'{base}->begin()'
 
     @staticmethod
     def _list_end(base: str) -> str:
-        return f'{base}.end()'
+        return f'{base}->end()'
 
     @staticmethod
     def _list_push(base: str, elt: str) -> str:
         """Append to a list under construction."""
-        return f'{base}.push_back({elt})'
+        return f'{base}->push_back({elt})'
 
-    @staticmethod
-    def _list_new_sized(ty: CppType, n: str) -> str:
-        """An initialiser for a list of *n* default-initialised elements."""
-        return f'{ty.format()}({n})'
+    @classmethod
+    def _list_new_sized(cls, ty: CppType, n: str) -> str:
+        """A new list of *n* default-initialised elements."""
+        return f'fpy::make_list<{cls._elt_of(ty)}>({n})'
 
-    @staticmethod
-    def _list_new_filled(ty: CppType, n: str, fill: str) -> str:
-        """An initialiser for a list of *n* copies of *fill*."""
-        return f'{ty.format()}({n}, {fill})'
+    @classmethod
+    def _list_empty(cls, ty: CppType) -> str:
+        """A new empty list.  Never emit a bare declaration for a list: an
+        uninitialised ``fpy::list`` is a *null* handle, unlike an empty
+        ``std::vector``."""
+        return cls._list_new_sized(ty, '0')
 
-    @staticmethod
-    def _list_new_init(ty: CppType, parts: list[str]) -> str:
-        """An initialiser for a list of the given elements."""
-        return f'{ty.format()}{{{", ".join(parts)}}}'
+    @classmethod
+    def _list_new_filled(cls, ty: CppType, n: str, fill: str) -> str:
+        """A new list of *n* copies of *fill*."""
+        elt = cls._elt_of(ty)
+        return f'std::make_shared<std::vector<{elt}> >({n}, {fill})'
 
-    @staticmethod
-    def _list_new_range(ty: CppType, first: str, last: str) -> str:
-        """An initialiser copying the half-open iterator range."""
-        return f'{ty.format()}({first}, {last})'
+    @classmethod
+    def _list_new_init(cls, ty: CppType, parts: list[str]) -> str:
+        """A new list of the given elements."""
+        elt = cls._elt_of(ty)
+        return f'fpy::make_list<{elt}>({{{", ".join(parts)}}})'
+
+    @classmethod
+    def _list_new_range(cls, ty: CppType, first: str, last: str) -> str:
+        """A new list copying the half-open iterator range."""
+        elt = cls._elt_of(ty)
+        return f'std::make_shared<std::vector<{elt}> >({first}, {last})'
 
     def _fresh_temp(self) -> str:
         """Allocate a fresh emitter-only temporary identifier.
@@ -388,28 +428,52 @@ class CppEmitter(Visitor):
         a scalar (where a copy is free and by-value is idiomatic)."""
         return isinstance(storage, (CppList, CppTuple))
 
+    def _is_rebound(self, d: Definition) -> bool:
+        """Is the name *d* introduces ever bound to a different value?
+
+        ``xs[i] = e`` is not a rebind — it mutates the list the handle already
+        points at, and ``storage_infer`` keeps that def in the same class.  Only
+        an ``Assign`` to the same name is.
+        """
+        cls = self.storage.def_class[d]
+        return any(
+            isinstance(m, AssignDef) and isinstance(m.site, Assign)
+            for m in self.storage.class_members[cls]
+        )
+
     def _arg_decl(self, arg: Argument, storage: CppType) -> str:
-        """Parameter declaration.  An aggregate parameter the body never
-        writes (its storage class has a single member — no reassignment,
-        no in-place mutation) is taken by ``const&`` to avoid copying it on
-        every call; everything else stays by value, faithful to FPy's
-        value semantics (a written parameter needs its own copy)."""
+        """Parameter declaration.
+
+        A list parameter is ``const fpy::list<T>&`` unless the body *rebinds*
+        the name.  ``const`` applies to the handle, not the elements — a callee
+        can still write ``xs[i] = e`` and the caller sees it, which is exactly
+        FPy's parameter semantics.  A reference also leaves the refcount
+        untouched, which measurement showed is the only case where the atomic
+        control block costs anything.
+
+        Rebinding is different: it must stay local to the callee, so such a
+        parameter takes its own copy of the handle.  A tuple follows the same
+        rule (copying one is O(size)); a scalar is always by value.
+        """
         assert isinstance(arg.name, NamedId)
         d = self.def_use.find_def_from_site(arg.name, arg)
-        if self._is_aggregate(storage) and self.storage.is_single_def(d):
+        if self._is_aggregate(storage) and not self._is_rebound(d):
             return f'const {storage.format()}& {arg.name}'
         return f'{storage.format()} {arg.name}'
 
     def _foreach_decl(self, target_def, name: str) -> str:
-        """Loop-variable declaration for a range-for over a container.  A
-        non-scalar element bound read-only is taken by ``const&`` to avoid
-        copying every element; scalars and mutated elements stay by value.
-        ``target_def is None`` marks a discarded/anonymous element (always
-        read-only) — ``const auto&`` lets the element type deduce."""
+        """Loop-variable declaration for a range-for over a container.
+
+        Same rule as :meth:`_arg_decl`: an element that is never rebound binds
+        by ``const&``, which shares the element and skips a refcount bump per
+        iteration.  Writing ``row[i] = e`` through it still reaches the
+        container.  ``target_def is None`` marks a discarded element — always
+        read-only, and ``const auto&`` lets the type deduce.
+        """
         if target_def is None:
             return f'const auto& {name}'
         storage = self.storage.storage_of(target_def)
-        if self._is_aggregate(storage) and self.storage.is_single_def(target_def):
+        if self._is_aggregate(storage) and not self._is_rebound(target_def):
             return f'const {storage.format()}& {name}'
         return f'{storage.format()} {name}'
 
@@ -574,7 +638,14 @@ class CppEmitter(Visitor):
         # Zero-initialise via ``T name{};`` so reads-before-writes
         # are well-defined (FPy analyses ensure this can't happen,
         # but the initialiser also serves as a paper-trail).
-        self.writer.add_line(f'{storage.format()} {name}{{}};')
+        if isinstance(storage, CppList):
+            # a bare ``fpy::list`` is a *null* handle, not an empty list, so a
+            # hoisted list must be given one
+            self.writer.add_line(
+                f'{storage.format()} {name} = {self._list_empty(storage)};'
+            )
+        else:
+            self.writer.add_line(f'{storage.format()} {name}{{}};')
 
     def _infer_return_storage(self, func: FuncDef) -> CppType | None:
         """Pull the storage type for the function's return value from
@@ -1412,8 +1483,8 @@ class CppEmitter(Visitor):
         self.writer.add_line(f'auto&& {src} = {src_str};')
         result = self._fresh_temp()
         self.writer.add_line(
-            f'{result_ty.format()} {result}'
-            f'({self._list_len(src)});'
+            f'{result_ty.format()} {result} = '
+            f'{self._list_new_sized(result_ty, self._list_len(src))};'
         )
         i = self._fresh_temp()
         self.writer.add_line(
@@ -1421,8 +1492,9 @@ class CppEmitter(Visitor):
         )
         self.writer.indent()
         self.writer.add_line(
-            f'{result}[{i}] = std::make_tuple('
-            f'static_cast<{idx_ty.format()}>({i}), {src}[{i}]);'
+            f'{self._list_at_raw(result, i)} = std::make_tuple('
+            f'static_cast<{idx_ty.format()}>({i}), '
+            f'{self._list_at_raw(src, i)});'
         )
         self.writer.dedent()
         self.writer.add_line('}')
@@ -1495,7 +1567,8 @@ class CppEmitter(Visitor):
                     f'static_cast<size_t>({stop_cast} > 0 ? {stop_cast} : 0)'
                 )
                 self.writer.add_line(
-                    f'{result_ty.format()} {tmp}({size_expr});'
+                    f'{result_ty.format()} {tmp} = '
+                    f'{self._list_new_sized(result_ty, size_expr)};'
                 )
                 self.writer.add_line(
                     f'std::iota({self._list_begin(tmp)}, '
@@ -1515,7 +1588,8 @@ class CppEmitter(Visitor):
                     f'? ({stop_cast} - {start_cast}) : 0)'
                 )
                 self.writer.add_line(
-                    f'{result_ty.format()} {tmp}({size_expr});'
+                    f'{result_ty.format()} {tmp} = '
+                    f'{self._list_new_sized(result_ty, size_expr)};'
                 )
                 self.writer.add_line(
                     f'std::iota({self._list_begin(tmp)}, '
@@ -1534,7 +1608,10 @@ class CppEmitter(Visitor):
                 stop_cast = self._maybe_cast(stop, stop_ty, result_ty.elt)
                 step_cast = self._maybe_cast(step, step_ty, result_ty.elt)
                 ctr = self._fresh_temp()
-                self.writer.add_line(f'{result_ty.format()} {tmp};')
+                self.writer.add_line(
+                    f'{result_ty.format()} {tmp} = '
+                    f'{self._list_empty(result_ty)};'
+                )
                 self.writer.add_line(
                     f'for ({int_ty} {ctr} = {start_cast}; '
                     f'{ctr} < {stop_cast}; {ctr} += {step_cast}) {{'
@@ -1587,8 +1664,9 @@ class CppEmitter(Visitor):
                 f'(type `{xs_ty!r}`)',
                 at=e,
             )
-        xs = self._visit_expr(e.first, ctx)
-        access = xs + ''.join(['[0]'] * d)
+        access = self._visit_expr(e.first, ctx)
+        for _ in range(d):
+            access = self._list_at(access, '0')
         result_ty = self._storage_for_expr(e)
         return f'static_cast<{result_ty.format()}>({self._list_len(access)})'
 
@@ -1887,7 +1965,9 @@ class CppEmitter(Visitor):
             f'for (size_t {i} = 1; {i} < {self._list_len(src)}; ++{i}) {{'
         )
         self.writer.indent()
-        elt = self._maybe_cast(f'{src}[{i}]', elt_ty, result_ty, at=e)
+        elt = self._maybe_cast(
+            self._list_at_raw(src, i), elt_ty, result_ty, at=e,
+        )
         self.writer.add_line(f'{acc} = {fn}({acc}, {elt});')
         self.writer.dedent()
         self.writer.add_line('}')
@@ -1961,16 +2041,18 @@ class CppEmitter(Visitor):
 
         result = self._fresh_temp()
         self.writer.add_line(
-            f'{result_ty.format()} {result}'
-            f'({self._list_len(srcs[0])});'
+            f'{result_ty.format()} {result} = '
+            f'{self._list_new_sized(result_ty, self._list_len(srcs[0]))};'
         )
         i = self._fresh_temp()
         self.writer.add_line(
             f'for (size_t {i} = 0; {i} < {self._list_len(srcs[0])}; ++{i}) {{'
         )
         self.writer.indent()
-        elts = ', '.join(f'{s}[{i}]' for s in srcs)
-        self.writer.add_line(f'{result}[{i}] = std::make_tuple({elts});')
+        elts = ', '.join(self._list_at_raw(s, i) for s in srcs)
+        self.writer.add_line(
+            f'{self._list_at_raw(result, i)} = std::make_tuple({elts});'
+        )
         self.writer.dedent()
         self.writer.add_line('}')
         return result
@@ -2080,7 +2162,10 @@ class CppEmitter(Visitor):
         # the temp + copy.
         result_ty = self._storage_for_expr(e)
         tmp = self._fresh_temp()
-        self.writer.add_line(f'{result_ty.format()} {tmp};')
+        self.writer.add_line(
+                    f'{result_ty.format()} {tmp} = '
+                    f'{self._list_empty(result_ty)};'
+                )
 
         for target, iterable in zip(e.targets, e.iterables):
             self._open_comp_loop(target, iterable, e, ctx)
@@ -2160,7 +2245,7 @@ class CppEmitter(Visitor):
                 tmp = self._fresh_temp()
                 iter_str = self._visit_expr(iterable, ctx)
                 # element read-only (only destructured) -> bind by const&
-                self.writer.add_line(f'for (const auto& {tmp} : {iter_str}) {{')
+                self.writer.add_line(f'for (const auto& {tmp} : {self._list_range(iter_str)}) {{')
                 self.writer.indent()
                 self._destructure(target, tmp, comp_site)
                 return
@@ -2195,7 +2280,7 @@ class CppEmitter(Visitor):
             case _:
                 iter_str = self._visit_expr(iterable, ctx)
                 decl = self._foreach_decl(loop_def, target_name)
-                self.writer.add_line(f'for ({decl} : {iter_str}) {{')
+                self.writer.add_line(f'for ({decl} : {self._list_range(iter_str)}) {{')
         self.writer.indent()
 
     def _visit_list_ref(self, e: ListRef, ctx) -> str:
@@ -2409,7 +2494,10 @@ class CppEmitter(Visitor):
             case _:
                 # discarded element -> bind by const& (no per-element copy)
                 iter_str = self._visit_expr(stmt.iterable, ctx)
-                header = f'for ({self._foreach_decl(None, target)} : {iter_str})'
+                header = (
+                    f'for ({self._foreach_decl(None, target)} : '
+                    f'{self._list_range(iter_str)})'
+                )
         self.writer.add_line(f'{header} {{')
         self.writer.indent()
         self._visit_block(stmt.body, ctx)
@@ -2455,7 +2543,10 @@ class CppEmitter(Visitor):
                 # range-for over a container: bind the element (const& for
                 # read-only aggregates — no per-element copy).
                 iter_str = self._visit_expr(stmt.iterable, ctx)
-                header = f'for ({self._foreach_decl(target_def, target)} : {iter_str})'
+                header = (
+                    f'for ({self._foreach_decl(target_def, target)} : '
+                    f'{self._list_range(iter_str)})'
+                )
         self.writer.add_line(f'{header} {{')
         self.writer.indent()
         self._visit_block(stmt.body, ctx)
@@ -2475,7 +2566,7 @@ class CppEmitter(Visitor):
         iter_str = self._visit_expr(stmt.iterable, ctx)
         tmp = self._fresh_temp()
         # element read-only (only destructured) -> bind by const&
-        self.writer.add_line(f'for (const auto& {tmp} : {iter_str}) {{')
+        self.writer.add_line(f'for (const auto& {tmp} : {self._list_range(iter_str)}) {{')
         self.writer.indent()
         assert isinstance(stmt.target, TupleBinding)
         self._destructure(stmt.target, tmp, stmt)

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -290,6 +290,59 @@ class CppEmitter(Visitor):
         # under an FP64-RNE function free of fenv noise.
         self._current_rm: RM | None = None
 
+    # ------------------------------------------------------------------
+    # List representation
+    #
+    # Every emission that spells out how a list is stored or accessed goes
+    # through one of these.  They take (and return) already-emitted C++
+    # strings, so they are purely syntactic -- the point is that the mapping
+    # from "an FPy list" to C++ lives here and nowhere else, and changing the
+    # representation is a change to this block.
+
+    @staticmethod
+    def _list_len(base: str) -> str:
+        """``len(xs)``."""
+        return f'{base}.size()'
+
+    @staticmethod
+    def _list_at(base: str, idx: str) -> str:
+        """``xs[i]``.  The cast belongs here because C++ ``operator[]`` takes an
+        unsigned index while FPy indices are signed."""
+        return f'{base}[static_cast<size_t>({idx})]'
+
+    @staticmethod
+    def _list_begin(base: str) -> str:
+        return f'{base}.begin()'
+
+    @staticmethod
+    def _list_end(base: str) -> str:
+        return f'{base}.end()'
+
+    @staticmethod
+    def _list_push(base: str, elt: str) -> str:
+        """Append to a list under construction."""
+        return f'{base}.push_back({elt})'
+
+    @staticmethod
+    def _list_new_sized(ty: CppType, n: str) -> str:
+        """An initialiser for a list of *n* default-initialised elements."""
+        return f'{ty.format()}({n})'
+
+    @staticmethod
+    def _list_new_filled(ty: CppType, n: str, fill: str) -> str:
+        """An initialiser for a list of *n* copies of *fill*."""
+        return f'{ty.format()}({n}, {fill})'
+
+    @staticmethod
+    def _list_new_init(ty: CppType, parts: list[str]) -> str:
+        """An initialiser for a list of the given elements."""
+        return f'{ty.format()}{{{", ".join(parts)}}}'
+
+    @staticmethod
+    def _list_new_range(ty: CppType, first: str, last: str) -> str:
+        """An initialiser copying the half-open iterator range."""
+        return f'{ty.format()}({first}, {last})'
+
     def _fresh_temp(self) -> str:
         """Allocate a fresh emitter-only temporary identifier.
 
@@ -641,7 +694,7 @@ class CppEmitter(Visitor):
                 ):
                     elt_str = self._explicit_cast(elt_str, elt_target)
             parts.append(elt_str)
-        return f'{wrapper_ty.format()}{{{", ".join(parts)}}}'
+        return self._list_new_init(wrapper_ty, parts)
 
     def _visit_return(self, stmt: ReturnStmt, ctx):
         rhs = self._visit_expr(stmt.expr, ctx)
@@ -1252,7 +1305,7 @@ class CppEmitter(Visitor):
                 # type stable across platforms where ``size_t``
                 # differs from ``int64_t``.
                 result_ty = self._storage_for_expr(e)
-                return f'static_cast<{result_ty.format()}>({arg}.size())'
+                return f'static_cast<{result_ty.format()}>({self._list_len(arg)})'
             case Sum():
                 # ``sum(xs)`` → ``std::accumulate(begin, end, T(0))``
                 # with ``T`` taken from format inference.  Bind the operand
@@ -1266,7 +1319,8 @@ class CppEmitter(Visitor):
                 src = self._fresh_temp()
                 self.writer.add_line(f'auto&& {src} = {arg};')
                 return (
-                    f'std::accumulate({src}.begin(), {src}.end(), '
+                    f'std::accumulate({self._list_begin(src)}, '
+                    f'{self._list_end(src)}, '
                     f'static_cast<{result_ty.format()}>(0))'
                 )
             case AMin() | AMax():
@@ -1358,11 +1412,12 @@ class CppEmitter(Visitor):
         self.writer.add_line(f'auto&& {src} = {src_str};')
         result = self._fresh_temp()
         self.writer.add_line(
-            f'{result_ty.format()} {result}({src}.size());'
+            f'{result_ty.format()} {result}'
+            f'({self._list_len(src)});'
         )
         i = self._fresh_temp()
         self.writer.add_line(
-            f'for (size_t {i} = 0; {i} < {src}.size(); ++{i}) {{'
+            f'for (size_t {i} = 0; {i} < {self._list_len(src)}; ++{i}) {{'
         )
         self.writer.indent()
         self.writer.add_line(
@@ -1443,7 +1498,8 @@ class CppEmitter(Visitor):
                     f'{result_ty.format()} {tmp}({size_expr});'
                 )
                 self.writer.add_line(
-                    f'std::iota({tmp}.begin(), {tmp}.end(), '
+                    f'std::iota({self._list_begin(tmp)}, '
+                    f'{self._list_end(tmp)}, '
                     f'static_cast<{int_ty}>(0));'
                 )
                 return tmp
@@ -1462,7 +1518,8 @@ class CppEmitter(Visitor):
                     f'{result_ty.format()} {tmp}({size_expr});'
                 )
                 self.writer.add_line(
-                    f'std::iota({tmp}.begin(), {tmp}.end(), {start_cast});'
+                    f'std::iota({self._list_begin(tmp)}, '
+                    f'{self._list_end(tmp)}, {start_cast});'
                 )
                 return tmp
             case Range3():
@@ -1483,7 +1540,7 @@ class CppEmitter(Visitor):
                     f'{ctr} < {stop_cast}; {ctr} += {step_cast}) {{'
                 )
                 self.writer.indent()
-                self.writer.add_line(f'{tmp}.push_back({ctr});')
+                self.writer.add_line(f'{self._list_push(tmp, ctr)};')
                 self.writer.dedent()
                 self.writer.add_line('}')
                 return tmp
@@ -1533,7 +1590,7 @@ class CppEmitter(Visitor):
         xs = self._visit_expr(e.first, ctx)
         access = xs + ''.join(['[0]'] * d)
         result_ty = self._storage_for_expr(e)
-        return f'static_cast<{result_ty.format()}>({access}.size())'
+        return f'static_cast<{result_ty.format()}>({self._list_len(access)})'
 
     # ------------------------------------------------------------------
     # Stubs for AST nodes not yet handled — classification ops
@@ -1780,7 +1837,7 @@ class CppEmitter(Visitor):
         self.writer.add_line(f'auto&& {src} = {arg_str};')
         pred = self._fresh_temp()
         return (
-            f'{fn}({src}.begin(), {src}.end(), '
+            f'{fn}({self._list_begin(src)}, {self._list_end(src)}, '
             f'[](bool {pred}) {{ return {pred}; }})'
         )
 
@@ -1827,7 +1884,7 @@ class CppEmitter(Visitor):
         self.writer.add_line(f'{result_ty.format()} {acc} = {init};')
         i = self._fresh_temp()
         self.writer.add_line(
-            f'for (size_t {i} = 1; {i} < {src}.size(); ++{i}) {{'
+            f'for (size_t {i} = 1; {i} < {self._list_len(src)}; ++{i}) {{'
         )
         self.writer.indent()
         elt = self._maybe_cast(f'{src}[{i}]', elt_ty, result_ty, at=e)
@@ -1877,7 +1934,7 @@ class CppEmitter(Visitor):
         # ``ty`` is now the scalar / tuple leaf.
         inner = f'{ty.format()}{{}}'
         for layer, d in zip(reversed(peeled), reversed(dim_strs)):
-            inner = f'{layer.format()}({d}, {inner})'
+            inner = self._list_new_filled(layer, d, inner)
         return inner
 
     def _emit_zip(self, e: Zip, ctx) -> str:
@@ -1904,11 +1961,12 @@ class CppEmitter(Visitor):
 
         result = self._fresh_temp()
         self.writer.add_line(
-            f'{result_ty.format()} {result}({srcs[0]}.size());'
+            f'{result_ty.format()} {result}'
+            f'({self._list_len(srcs[0])});'
         )
         i = self._fresh_temp()
         self.writer.add_line(
-            f'for (size_t {i} = 0; {i} < {srcs[0]}.size(); ++{i}) {{'
+            f'for (size_t {i} = 0; {i} < {self._list_len(srcs[0])}; ++{i}) {{'
         )
         self.writer.indent()
         elts = ', '.join(f'{s}[{i}]' for s in srcs)
@@ -2008,9 +2066,8 @@ class CppEmitter(Visitor):
     def _visit_list_expr(self, e: ListExpr, ctx) -> str:
         # ``[a, b, c]`` → ``std::vector<T>{a, b, c}`` where ``T`` comes
         # from format inference on the list expression.
-        elts = ', '.join(self._visit_expr(elt, ctx) for elt in e.elts)
-        result_ty = self._storage_for_expr(e)
-        return f'{result_ty.format()}{{{elts}}}'
+        parts = [self._visit_expr(elt, ctx) for elt in e.elts]
+        return self._list_new_init(self._storage_for_expr(e), parts)
 
     def _visit_list_comp(self, e: ListComp, ctx) -> str:
         # ``[elt for x1 in iter1 [for x2 in iter2 ...]]``
@@ -2029,7 +2086,7 @@ class CppEmitter(Visitor):
             self._open_comp_loop(target, iterable, e, ctx)
 
         elt = self._visit_expr(e.elt, ctx)
-        self.writer.add_line(f'{tmp}.push_back({elt});')
+        self.writer.add_line(f'{self._list_push(tmp, elt)};')
 
         for _ in e.targets:
             self.writer.dedent()
@@ -2149,7 +2206,7 @@ class CppEmitter(Visitor):
         # C++'s undefined-behaviour-on-out-of-range).
         value = self._visit_expr(e.value, ctx)
         index = self._visit_expr(e.index, ctx)
-        return f'{value}[static_cast<size_t>({index})]'
+        return self._list_at(value, index)
 
     def _visit_list_slice(self, e: ListSlice, ctx) -> str:
         # ``xs[start:stop]`` →
@@ -2174,15 +2231,17 @@ class CppEmitter(Visitor):
         else:
             start = f'static_cast<size_t>({self._visit_expr(e.start, ctx)})'
         if e.stop is None:
-            stop = f'{arr_tmp}.size()'
+            stop = self._list_len(arr_tmp)
         else:
             stop = f'static_cast<size_t>({self._visit_expr(e.stop, ctx)})'
 
         result_ty = self._storage_for_expr(e)
         return (
-            f'{result_ty.format()}('
-            f'{arr_tmp}.begin() + {start}, '
-            f'{arr_tmp}.begin() + {stop})'
+            self._list_new_range(
+                result_ty,
+                f'{self._list_begin(arr_tmp)} + {start}',
+                f'{self._list_begin(arr_tmp)} + {stop}',
+            )
         )
     def _visit_if_expr(self, e, ctx) -> str:
         # ``cond ? ift : iff`` — both branches must share a C++ type,
@@ -2219,11 +2278,10 @@ class CppEmitter(Visitor):
         # sides — emit a direct subscript-store.
         target_def = self.def_use.find_def_from_site(stmt.var, stmt)
         target_name = self.storage.def_to_name[target_def]
-        idx_strs = [
-            f'static_cast<size_t>({self._visit_expr(idx, ctx)})'
-            for idx in stmt.indices
-        ]
-        chain = target_name + ''.join(f'[{i}]' for i in idx_strs)
+        idxs = [self._visit_expr(idx, ctx) for idx in stmt.indices]
+        chain = target_name
+        for idx in idxs:
+            chain = self._list_at(chain, idx)
         rhs = self._visit_expr(stmt.expr, ctx)
         self.writer.add_line(f'{chain} = {rhs};')
 

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -295,17 +295,15 @@ class CppEmitter(Visitor):
     # ------------------------------------------------------------------
     # List representation
     #
-    # Every emission that spells out how a list is stored or accessed goes
-    # through one of these.  They take (and return) already-emitted C++
-    # strings, so they are purely syntactic -- the point is that the mapping
-    # from "an FPy list" to C++ lives here and nowhere else, and changing the
-    # representation is a change to this block.
+    # Purely syntactic: these take and return emitted C++ strings.  The point is
+    # that how a list is stored and accessed is spelled out here and nowhere
+    # else, so changing the representation is a change to this block plus
+    # ``fpy::list`` in ``.utils``.
 
     @staticmethod
     def _elt_of(ty: CppType) -> str:
         """The element type of a list storage type."""
-        if not isinstance(ty, CppList):
-            raise CppEmitError(f'expected a list storage type, got {ty!r}')
+        assert isinstance(ty, CppList), f'not a list storage type: {ty!r}'
         return ty.elt.format()
 
     @staticmethod
@@ -325,20 +323,26 @@ class CppEmitter(Visitor):
         loop counter rather than an FPy index, so no cast is needed."""
         return f'(*{base})[{idx}]'
 
+    def _bind_operand(self, expr: str) -> str:
+        """A name for *expr*, so it can be read more than once.
+
+        Already a name — evaluated once, no side effects — so nothing to bind.
+        Otherwise bind it to a temp; a list is a handle, so this costs nothing.
+        """
+        if expr.isidentifier():
+            return expr
+        tmp = self._fresh_temp()
+        self.writer.add_line(f'auto&& {tmp} = {expr};')
+        return tmp
+
     def _list_range(self, base: str) -> str:
         """The operand of a range-``for`` over a list.
 
-        A temporary handle is bound to a name first.  Range-``for`` extends the
-        lifetime of the range-init's *own* result, and ``*handle`` is a
-        reference to the pointee — so the handle itself would be destroyed at
-        the end of the range-init, freeing the elements before the first
-        iteration.
+        A temporary handle must be bound to a name: range-``for`` extends the
+        lifetime of the range-init's own result, and ``*handle`` is a reference
+        to the pointee, so the handle would be freed before the first iteration.
         """
-        if base.isidentifier():
-            return f'*{base}'
-        tmp = self._fresh_temp()
-        self.writer.add_line(f'auto&& {tmp} = {base};')
-        return f'*{tmp}'
+        return f'*{self._bind_operand(base)}'
 
     @staticmethod
     def _list_begin(base: str) -> str:
@@ -368,8 +372,7 @@ class CppEmitter(Visitor):
     @classmethod
     def _list_new_filled(cls, ty: CppType, n: str, fill: str) -> str:
         """A new list of *n* copies of *fill*."""
-        elt = cls._elt_of(ty)
-        return f'std::make_shared<std::vector<{elt}> >({n}, {fill})'
+        return f'fpy::make_list<{cls._elt_of(ty)}>({n}, {fill})'
 
     @classmethod
     def _list_new_init(cls, ty: CppType, parts: list[str]) -> str:
@@ -380,8 +383,7 @@ class CppEmitter(Visitor):
     @classmethod
     def _list_new_range(cls, ty: CppType, first: str, last: str) -> str:
         """A new list copying the half-open iterator range."""
-        elt = cls._elt_of(ty)
-        return f'std::make_shared<std::vector<{elt}> >({first}, {last})'
+        return f'fpy::make_list<{cls._elt_of(ty)}>({first}, {last})'
 
     def _fresh_temp(self) -> str:
         """Allocate a fresh emitter-only temporary identifier.
@@ -1395,8 +1397,7 @@ class CppEmitter(Visitor):
                 # lifetime-extends a temporary and binds an lvalue without
                 # copying.
                 result_ty = self._storage_for_expr(e)
-                src = self._fresh_temp()
-                self.writer.add_line(f'auto&& {src} = {arg};')
+                src = self._bind_operand(arg)
                 return (
                     f'std::accumulate({self._list_begin(src)}, '
                     f'{self._list_end(src)}, '
@@ -1432,9 +1433,7 @@ class CppEmitter(Visitor):
         # Unconsumed tail: materialize the remaining elements as a new tuple,
         # binding the base to a temp so it is evaluated once across the gets.
         assert isinstance(acc.ty, CppTuple)
-        tmp = self._fresh_temp()
-        # base read only via the gets below -> reference, no copy
-        self.writer.add_line(f'auto&& {tmp} = {acc.s};')
+        tmp = self._bind_operand(acc.s)
         gets = ', '.join(
             f'std::get<{i}>({tmp})' for i in range(acc.off, len(acc.ty.elts))
         )
@@ -1471,7 +1470,7 @@ class CppEmitter(Visitor):
         return acc.s, acc.ty
 
     def _emit_enumerate(self, e: Enumerate, src_str: str) -> str:
-        """``enumerate(xs)`` builds a ``std::vector<std::tuple<I, T>>``
+        """``enumerate(xs)`` builds a ``fpy::list<std::tuple<I, T>>``
         where ``I`` is the index integer type and ``T`` is the source
         element type — both come from format inference on the
         Enumerate node itself.
@@ -1486,9 +1485,7 @@ class CppEmitter(Visitor):
             )
         idx_ty = result_ty.elt.elts[0]
 
-        src = self._fresh_temp()
-        # source read only (size + indexing) -> reference, no copy
-        self.writer.add_line(f'auto&& {src} = {src_str};')
+        src = self._bind_operand(src_str)
         result = self._fresh_temp()
         self.writer.add_line(
             f'{result_ty.format()} {result} = '
@@ -1919,8 +1916,7 @@ class CppEmitter(Visitor):
         fn = 'std::any_of' if isinstance(e, AnyOf) else 'std::all_of'
         # Bind first, as ``Sum`` does: on a prvalue operand ``begin()`` and
         # ``end()`` would name iterators into different temporaries.
-        src = self._fresh_temp()
-        self.writer.add_line(f'auto&& {src} = {arg_str};')
+        src = self._bind_operand(arg_str)
         pred = self._fresh_temp()
         return (
             f'{fn}({self._list_begin(src)}, {self._list_end(src)}, '
@@ -1962,9 +1958,7 @@ class CppEmitter(Visitor):
         else:
             fn = 'std::min' if isinstance(e, AMin) else 'std::max'
 
-        src = self._fresh_temp()
-        # source read only (indexing + size) -> reference, no copy
-        self.writer.add_line(f'auto&& {src} = {arg_str};')
+        src = self._bind_operand(arg_str)
         acc = self._fresh_temp()
         init = self._maybe_cast(f'{src}[0]', elt_ty, result_ty, at=e)
         self.writer.add_line(f'{result_ty.format()} {acc} = {init};')
@@ -1985,7 +1979,7 @@ class CppEmitter(Visitor):
         """``empty(d1, ..., dN)`` builds an ``N``-dimensional zero-
         initialised vector.  The result's storage shape comes from
         format inference; we read the dimension sizes off the call
-        site and emit nested ``std::vector<T>(d, ...)`` constructors
+        site and emit nested ``fpy::make_list<T>(d, ...)`` calls
         right-to-left so the innermost element type bubbles out.
 
         ``empty()`` with zero args returns ``T()`` — a scalar, which
@@ -2027,7 +2021,7 @@ class CppEmitter(Visitor):
 
     def _emit_zip(self, e: Zip, ctx) -> str:
         """``zip(xs1, …, xsN)`` builds a
-        ``std::vector<std::tuple<T1, …, TN>>`` whose length matches the
+        ``fpy::list<std::tuple<T1, …, TN>>`` whose length matches the
         first iterable.  Each iterable is bound to a temp once to
         evaluate side-effects in source order; the tuple type comes
         from format inference on the Zip node."""
@@ -2042,9 +2036,7 @@ class CppEmitter(Visitor):
         srcs: list[str] = []
         for arg in e.args:
             arg_str = self._visit_expr(arg, ctx)
-            s = self._fresh_temp()
-            # source read only (size + indexing) -> reference, no copy
-            self.writer.add_line(f'auto&& {s} = {arg_str};')
+            s = self._bind_operand(arg_str)
             srcs.append(s)
 
         result = self._fresh_temp()
@@ -2154,7 +2146,7 @@ class CppEmitter(Visitor):
         return f'std::make_tuple({elts})'
 
     def _visit_list_expr(self, e: ListExpr, ctx) -> str:
-        # ``[a, b, c]`` → ``std::vector<T>{a, b, c}`` where ``T`` comes
+        # ``[a, b, c]`` → ``fpy::make_list<T>({a, b, c})`` where ``T`` comes
         # from format inference on the list expression.
         parts = [self._visit_expr(elt, ctx) for elt in e.elts]
         return self._list_new_init(self._storage_for_expr(e), parts)
@@ -2162,7 +2154,7 @@ class CppEmitter(Visitor):
     def _visit_list_comp(self, e: ListComp, ctx) -> str:
         # ``[elt for x1 in iter1 [for x2 in iter2 ...]]``
         #
-        # Emitted as a temporary ``std::vector<T> tmp;`` followed by
+        # Emitted as a temporary ``fpy::list<T> tmp;`` followed by
         # nested for-loops that ``push_back`` the element expression
         # into ``tmp``.  Returns the temp's name as the comprehension's
         # value.  The temp shape mirrors the cpp/ backend; future
@@ -2315,9 +2307,7 @@ class CppEmitter(Visitor):
         # Indices are cast to ``size_t`` to match the iterator-arithmetic
         # API.  Strict bounds-checking against the interpreter's behaviour
         # is a TODO (slice-out-of-range, negative-index handling, etc.).
-        arr_tmp = self._fresh_temp()
-        arr_str = self._visit_expr(e.value, ctx)
-        self.writer.add_line(f'auto&& {arr_tmp} = {arr_str};')
+        arr_tmp = self._bind_operand(self._visit_expr(e.value, ctx))
 
         if e.start is None:
             start = '0'

--- a/fpy2/backend/cpp/types.py
+++ b/fpy2/backend/cpp/types.py
@@ -67,7 +67,11 @@ class CppScalar(enum.Enum):
 
 @default_repr
 class CppList:
-    """``std::vector<T>``."""
+    """``fpy::list<T>`` — a handle to a shared, mutable sequence.
+
+    FPy lists alias on assignment, which a bare ``std::vector`` (a value type)
+    cannot express; see the ``fpy::list`` comment in :mod:`.utils`.
+    """
     elt: 'CppType'
 
     def __init__(self, elt: 'CppType'):
@@ -80,7 +84,11 @@ class CppList:
         return hash((CppList, self.elt))
 
     def format(self) -> str:
-        return f'std::vector<{self.elt.format()}>'
+        return f'fpy::list<{self.elt.format()}>'
+
+    def elt_format(self) -> str:
+        """The element type, for the ``fpy::`` constructors."""
+        return self.elt.format()
 
 
 @default_repr

--- a/fpy2/backend/cpp/types.py
+++ b/fpy2/backend/cpp/types.py
@@ -86,10 +86,6 @@ class CppList:
     def format(self) -> str:
         return f'fpy::list<{self.elt.format()}>'
 
-    def elt_format(self) -> str:
-        """The element type, for the ``fpy::`` constructors."""
-        return self.elt.format()
-
 
 @default_repr
 class CppTuple:

--- a/fpy2/backend/cpp/utils.py
+++ b/fpy2/backend/cpp/utils.py
@@ -41,12 +41,19 @@ indirection.  Notes on the choices, kept here rather than in the emitted code:
 - Reference counting suffices with no collector: FPy has no recursive list type,
   so no location can be stored within itself and no cycle is constructible.
 
-Only what the emitter emits is shipped.  A program embedding a generated kernel
-therefore builds a list with ``std::make_shared`` — or, to pass storage it
-already owns without copying, a ``shared_ptr`` with a no-op deleter.  That
-borrowed handle must not outlive the vector, which holds because a callee cannot
-retain one: FPy has no globals, and captures are materialized before
-compilation.  See ``_test_abi`` in ``tests/infra/backend/cpp.py``.
+Interop is by conversion at the call site (``borrow`` / ``copy_in`` /
+``copy_out``) rather than by emitting a wrapper per function, so the choice
+between sharing and copying stays with the caller and the emitted signature is
+the only signature.  Two consequences worth knowing:
+
+- A ``vector<vector<T>>`` can only be copied.  The caller stores rows by value
+  where a list stores handles, so no arrangement makes a write through either
+  side visible to the other.
+- A borrowed handle must not outlive its vector.  That holds because a callee
+  cannot retain one: FPy has no globals, and captures are materialized before
+  compilation.
+
+Pinned by ``_test_abi`` in ``tests/infra/backend/cpp.py``.
 """
 
 
@@ -119,6 +126,41 @@ inline list<T> make_list(std::initializer_list<T> il) {
 template <typename T, typename It>
 inline list<T> make_list(It first, It last) {
     return std::make_shared<std::vector<T> >(first, last);
+}
+
+// Interop: a program holding `std::vector` converts here.  A flat vector can be
+// shared or copied; a nested one can only be copied.
+
+// Must not outlive `v`.
+template <typename T>
+inline list<T> borrow(std::vector<T>& v) {
+    return list<T>(&v, [](std::vector<T>*) {});
+}
+
+template <typename T>
+inline list<T> copy_in(const std::vector<T>& v) {
+    return std::make_shared<std::vector<T> >(v);
+}
+
+template <typename T>
+inline list<list<T> > copy_in(const std::vector<std::vector<T> >& vs) {
+    list<list<T> > out = make_list<list<T> >(vs.size());
+    for (std::size_t i = 0; i < vs.size(); ++i)
+        (*out)[i] = copy_in(vs[i]);
+    return out;
+}
+
+template <typename T>
+inline std::vector<T> copy_out(const list<T>& xs) {
+    return *xs;
+}
+
+template <typename T>
+inline std::vector<std::vector<T> > copy_out(const list<list<T> >& xss) {
+    std::vector<std::vector<T> > out(xss->size());
+    for (std::size_t i = 0; i < xss->size(); ++i)
+        out[i] = *(*xss)[i];
+    return out;
 }
 
 }  // namespace fpy

--- a/fpy2/backend/cpp/utils.py
+++ b/fpy2/backend/cpp/utils.py
@@ -40,7 +40,9 @@ CPP_HEADERS: tuple[str, ...] = (
     '#include <cmath>',
     '#include <cstddef>',
     '#include <cstdint>',
+    '#include <initializer_list>',
     '#include <limits>',
+    '#include <memory>',
     '#include <numeric>',
     '#include <vector>',
     '#include <tuple>',
@@ -57,8 +59,10 @@ CPP_HEADERS: tuple[str, ...] = (
 # Only emitted for floating-point ``T``; integer ``min`` / ``max``
 # continue to use ``std::min`` / ``std::max`` (no NaN, no signed-zero).
 CPP_HELPERS: str = '''\
+namespace fpy {
+
 template <typename T>
-inline T __fpy_min(T a, T b) {
+inline T min(T a, T b) {
     if (std::isnan(a) || std::isnan(b))
         return std::numeric_limits<T>::quiet_NaN();
     if (a == b)
@@ -67,11 +71,62 @@ inline T __fpy_min(T a, T b) {
 }
 
 template <typename T>
-inline T __fpy_max(T a, T b) {
+inline T max(T a, T b) {
     if (std::isnan(a) || std::isnan(b))
         return std::numeric_limits<T>::quiet_NaN();
     if (a == b)
         return std::signbit(a) ? b : a;
     return (a < b) ? b : a;
 }
+
+// An FPy list: a reference to a shared, mutable sequence.
+//
+// FPy list semantics are Python's -- assignment aliases, `xs[i] = e` mutates
+// the object, and passing / returning / projecting carries the identity along.
+// A bare `std::vector` is a *value*, so it cannot express that; the shared
+// pointer adds the level of indirection that can.  Copying a `list` shares the
+// elements; only `make_list` / `clone` allocate new ones.
+//
+// Deliberately a plain alias rather than a wrapper class: `std::shared_ptr`
+// already has exactly the required semantics, and a host program embedding a
+// generated kernel can handle one without depending on anything of ours.
+//
+// The control block is atomic, so a handle copy is an atomic increment.  The
+// emitter therefore passes handles by `const list<T>&` wherever the name is not
+// rebound -- a reference does no refcounting, and measurement showed that
+// passing by value in a hot call chain is the only case where the atomic cost is
+// visible at all.
+//
+// No cycle can be constructed -- FPy's type syntax cannot express a recursive
+// list type -- so reference counting never leaks and no collector is needed.
+template <typename T>
+using list = std::shared_ptr<std::vector<T> >;
+
+template <typename T>
+inline list<T> make_list(std::size_t n) {
+    return std::make_shared<std::vector<T> >(n);
+}
+
+template <typename T>
+inline list<T> make_list(std::initializer_list<T> il) {
+    return std::make_shared<std::vector<T> >(il);
+}
+
+// An independent list with the same elements -- FPy's `xs[:]`, and the explicit
+// opt-out from sharing.
+template <typename T>
+inline list<T> clone(const list<T>& xs) {
+    return std::make_shared<std::vector<T> >(*xs);
+}
+
+// A non-owning handle onto storage someone else owns, for passing a caller's
+// vector into a kernel without copying it.  Sound only because the handle
+// cannot outlive the call: FPy has no globals and `FreeVarElim` materializes
+// captures, so a callee cannot retain it.
+template <typename T>
+inline list<T> borrow(std::vector<T>& v) {
+    return list<T>(&v, [](std::vector<T>*) {});
+}
+
+}  // namespace fpy
 '''

--- a/fpy2/backend/cpp/utils.py
+++ b/fpy2/backend/cpp/utils.py
@@ -19,17 +19,34 @@ Header coverage tracks what the emitter actually uses:
   ``std::isnan`` / etc. dispatched through the op table.
 - ``<cstddef>``: ``size_t`` for vector indexing.
 - ``<cstdint>``: fixed-width ``int8_t`` … ``uint64_t``.
+- ``<initializer_list>``: ``fpy::make_list`` from a braced list.
+- ``<limits>``: ``quiet_NaN`` in ``fpy::min`` / ``fpy::max``.
+- ``<memory>``: ``std::shared_ptr`` behind ``fpy::list``.
 - ``<numeric>``: ``std::accumulate`` for ``Sum``.
-- ``<vector>``: ``std::vector<T>`` for FPy lists.
+- ``<vector>``: the element storage inside ``fpy::list``.
 - ``<tuple>``: ``std::tuple`` / ``std::make_tuple`` / ``std::get`` for
   tuples and tuple-binding destructuring.
 
-Helpers is currently empty — cpp doesn't yet need any custom
-runtime support beyond what ``<cmath>`` / ``std::vector`` already
-give us.  The slot exists so future additions (e.g., an RAII
-``fenv`` guard to fix the function-level fesetround leak, or
-bounds-checked subscript helpers for strict slice semantics) have a
-home.
+``fpy::list`` is why the runtime exists.  FPy lists alias on assignment, so a
+``std::vector`` — a value — cannot represent one; the handle supplies the
+indirection.  Notes on the choices, kept here rather than in the emitted code:
+
+- A plain alias for ``std::shared_ptr``, not a wrapper class: the standard type
+  already has the required semantics, and a program embedding a generated kernel
+  can then handle a list without depending on anything of ours.
+- The control block is atomic, so copying a handle is an atomic increment.  The
+  emitter passes ``const list<T>&`` wherever a name is not rebound (see
+  ``_arg_decl``); a reference does no refcounting, which is what keeps the atomic
+  off the hot path.
+- Reference counting suffices with no collector: FPy has no recursive list type,
+  so no location can be stored within itself and no cycle is constructible.
+
+Only what the emitter emits is shipped.  A program embedding a generated kernel
+therefore builds a list with ``std::make_shared`` — or, to pass storage it
+already owns without copying, a ``shared_ptr`` with a no-op deleter.  That
+borrowed handle must not outlive the vector, which holds because a callee cannot
+retain one: FPy has no globals, and captures are materialized before
+compilation.  See ``_test_abi`` in ``tests/infra/backend/cpp.py``.
 """
 
 
@@ -79,26 +96,8 @@ inline T max(T a, T b) {
     return (a < b) ? b : a;
 }
 
-// An FPy list: a reference to a shared, mutable sequence.
-//
-// FPy list semantics are Python's -- assignment aliases, `xs[i] = e` mutates
-// the object, and passing / returning / projecting carries the identity along.
-// A bare `std::vector` is a *value*, so it cannot express that; the shared
-// pointer adds the level of indirection that can.  Copying a `list` shares the
-// elements; only `make_list` / `clone` allocate new ones.
-//
-// Deliberately a plain alias rather than a wrapper class: `std::shared_ptr`
-// already has exactly the required semantics, and a host program embedding a
-// generated kernel can handle one without depending on anything of ours.
-//
-// The control block is atomic, so a handle copy is an atomic increment.  The
-// emitter therefore passes handles by `const list<T>&` wherever the name is not
-// rebound -- a reference does no refcounting, and measurement showed that
-// passing by value in a hot call chain is the only case where the atomic cost is
-// visible at all.
-//
-// No cycle can be constructed -- FPy's type syntax cannot express a recursive
-// list type -- so reference counting never leaks and no collector is needed.
+// An FPy list: a handle to a shared, mutable sequence.  Copying a `list` shares
+// its elements; only `make_list` allocates.
 template <typename T>
 using list = std::shared_ptr<std::vector<T> >;
 
@@ -108,24 +107,18 @@ inline list<T> make_list(std::size_t n) {
 }
 
 template <typename T>
+inline list<T> make_list(std::size_t n, const T& x) {
+    return std::make_shared<std::vector<T> >(n, x);
+}
+
+template <typename T>
 inline list<T> make_list(std::initializer_list<T> il) {
     return std::make_shared<std::vector<T> >(il);
 }
 
-// An independent list with the same elements -- FPy's `xs[:]`, and the explicit
-// opt-out from sharing.
-template <typename T>
-inline list<T> clone(const list<T>& xs) {
-    return std::make_shared<std::vector<T> >(*xs);
-}
-
-// A non-owning handle onto storage someone else owns, for passing a caller's
-// vector into a kernel without copying it.  Sound only because the handle
-// cannot outlive the call: FPy has no globals and `FreeVarElim` materializes
-// captures, so a callee cannot retain it.
-template <typename T>
-inline list<T> borrow(std::vector<T>& v) {
-    return list<T>(&v, [](std::vector<T>*) {});
+template <typename T, typename It>
+inline list<T> make_list(It first, It last) {
+    return std::make_shared<std::vector<T> >(first, last);
 }
 
 }  // namespace fpy

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -809,6 +809,106 @@ def _test_library(
     return failures
 
 
+def _test_runtime(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, str]]:
+    """Compile and run a self-test of the emitted runtime prelude (``fpy::``).
+
+    The prelude is handwritten C++ that every emitted unit depends on, so it is
+    worth checking directly rather than only through generated code.  Asserts
+    the sharing contract ``fpy::list`` exists to provide: copying a list shares
+    its elements, an element of a nested list is the same object, and
+    ``clone()`` is the opt-out.
+    """
+    group = 'runtime'
+    compiler = fp.CppCompiler()
+    cpp_path = output_dir / 'runtime_selftest.cpp'
+    print(f'Compiling runtime self-test to `{cpp_path}`')
+    with open(cpp_path, 'w') as f:
+        print('\n'.join(compiler.headers()), file=f)
+        print(compiler.helpers(), file=f)
+        print(_RUNTIME_SELFTEST, file=f)
+
+    if mode == 'emit':
+        return []
+    if _CXX is None:
+        print('  SKIPPED (no C++ compiler driver)')
+        return []
+
+    exe = cpp_path.with_suffix('.exe')
+    cmd = [_CXX] + _CPP_OPTIONS + ['-o', str(exe), str(cpp_path)]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        print(f'  FAILED to build: {e.stderr[-400:]}')
+        return [(group, 'runtime_selftest', f'build failed: {e.stderr[-200:]}')]
+
+    r = subprocess.run([str(exe)], capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f'  FAILED: {r.stdout.strip()} {r.stderr.strip()}')
+        return [(group, 'runtime_selftest', f'assertion failed: {r.stdout.strip()}')]
+    return []
+
+
+_RUNTIME_SELFTEST: str = """\
+#include <cstdio>
+
+int main() {
+    // copying a handle shares the elements
+    fpy::list<double> xs = fpy::make_list<double>({1.0, 2.0, 3.0});
+    fpy::list<double> ys = xs;
+    (*ys)[0] = 99.0;
+    assert((*xs)[0] == 99.0);
+
+    // ...and clone() is the opt-out
+    fpy::list<double> zs = fpy::clone(xs);
+    (*zs)[0] = 7.0;
+    assert((*xs)[0] == 99.0);
+
+    // an element of a nested list is the same object, at every slot
+    fpy::list<fpy::list<double> > m =
+        fpy::make_list<fpy::list<double> >({xs, xs});
+    (*(*m)[0])[1] = 42.0;
+    assert((*xs)[1] == 42.0);
+    assert((*(*m)[1])[1] == 42.0);
+
+    // a projection shares, and survives its container's slot being replaced
+    fpy::list<double> row = (*m)[0];
+    (*m)[0] = zs;
+    (*row)[2] = 5.0;
+    assert((*xs)[2] == 5.0);
+    assert((*(*m)[0])[2] != 5.0);
+
+    // range-for over the pointee, and size
+    fpy::list<double> acc = fpy::make_list<double>(3);
+    std::size_t i = 0;
+    for (double v : *xs) { (*acc)[i] = v; ++i; }
+    assert(i == 3 && acc->size() == 3);
+
+    // contiguous storage for C interop
+    double* raw = xs->data();
+    raw[0] = -1.0;
+    assert((*xs)[0] == -1.0);
+
+    // borrow(): a non-owning handle writes through to the caller's vector
+    std::vector<double> owned(2, 1.0);
+    {
+        fpy::list<double> h = fpy::borrow(owned);
+        (*h)[0] = 8.0;
+    }
+    assert(owned[0] == 8.0);
+
+    // refcounting: the last owner keeps the elements alive
+    {
+        fpy::list<double> tmp = xs;
+        (*tmp)[0] = 3.5;
+    }
+    assert((*xs)[0] == 3.5);
+
+    std::printf("runtime self-test OK\\n");
+    return 0;
+}
+"""
+
+
 def _test_libraries(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, str]]:
     failures: list[tuple[str, str, str]] = []
     for mod in _modules:
@@ -1328,6 +1428,7 @@ def test_compile_cpp(delete: bool = True, mode: str = 'compile'):
     print(f"Running C++ tests (mode={mode}) with output under `{output_dir}`")
     failures: list[tuple[str, str, str]] = []
     cov: Counter[str] = Counter()
+    failures += _test_runtime(output_dir, mode=mode)
     failures += _test_unit(output_dir, mode=mode, cov=cov)
     failures += _test_libraries(output_dir, mode=mode)
     failures += _test_regressions(output_dir, mode=mode, cov=cov)

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -116,7 +116,6 @@ _run_ignore: list[str] = [
     # numerically equal, a signed-zero-from-reduction edge.  This function
     # exists to pin widening codegen (which compiles), not exact execution.
     '_regression_quant_dot_real_widen',
-
 ]
 
 
@@ -796,8 +795,8 @@ def _test_runtime(output_dir: Path, mode: str = 'compile') -> list[tuple[str, st
     The prelude is handwritten C++ that every emitted unit depends on, so it is
     worth checking directly rather than only through generated code.  Asserts
     the sharing contract ``fpy::list`` exists to provide: copying a list shares
-    its elements, an element of a nested list is the same object, and
-    ``clone()`` is the opt-out.
+    its elements, an element of a nested list is the same object, and copying
+    the range is the opt-out.
     """
     group = 'runtime'
     compiler = fp.CppCompiler()
@@ -839,8 +838,9 @@ int main() {
     (*ys)[0] = 99.0;
     assert((*xs)[0] == 99.0);
 
-    // ...and clone() is the opt-out
-    fpy::list<double> zs = fpy::clone(xs);
+    // ...and an explicit copy is the opt-out -- the idiom the emitter emits
+    // for `xs[:]`
+    fpy::list<double> zs = fpy::make_list<double>(xs->begin(), xs->end());
     (*zs)[0] = 7.0;
     assert((*xs)[0] == 99.0);
 
@@ -869,14 +869,6 @@ int main() {
     raw[0] = -1.0;
     assert((*xs)[0] == -1.0);
 
-    // borrow(): a non-owning handle writes through to the caller's vector
-    std::vector<double> owned(2, 1.0);
-    {
-        fpy::list<double> h = fpy::borrow(owned);
-        (*h)[0] = 8.0;
-    }
-    assert(owned[0] == 8.0);
-
     // refcounting: the last owner keeps the elements alive
     {
         fpy::list<double> tmp = xs;
@@ -904,18 +896,13 @@ def _abi_scale_in_place(xs: list[fp.Real], k: fp.Real) -> fp.Real:
 def _test_abi(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, str]]:
     """Compile a kernel and call it the way an embedding program would.
 
-    The differential driver builds each argument as a fresh ``fpy::list``, which
-    mirrors the interpreter's Python-boundary isolation — so nothing in the
-    corpus exercises handing a kernel storage the *caller* owns.  That is the
-    case that matters for embedding a generated kernel in a larger system, so it
-    is pinned here:
-
-    - ``fpy::borrow`` passes a caller's ``std::vector`` with no copy, and the
-      kernel's writes land in it;
-    - ``fpy::make_list`` copies, and the caller's vector is untouched.
-
-    Both are one line at the call site, which is the whole claim: a host needs
-    no dependency on anything of ours beyond ``std::shared_ptr``.
+    The differential driver builds each argument as a fresh ``fpy::list``, so
+    nothing in the corpus covers handing a kernel storage the *caller* owns —
+    which is the case that matters for embedding.  ``fpy::borrow`` passes a
+    A ``shared_ptr`` with a no-op deleter passes a vector with no copy and the
+    kernel's writes land in it; constructing from the values copies instead, and
+    the caller's vector is untouched.  Both are plain standard C++ — the runtime
+    ships only what the emitter emits.
     """
     group = 'abi'
     compiler = fp.CppCompiler()
@@ -962,16 +949,21 @@ def _test_abi(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, s
 
 _ABI_MAIN: str = """\
 int main() {
-    // borrow: the kernel writes through to storage the caller owns
+    // A `shared_ptr` with a no-op deleter hands the kernel storage the caller
+    // owns: no copy, and the kernel's writes land in it.  Safe because the
+    // handle cannot outlive the call -- FPy has no globals, and captures are
+    // materialized before compilation, so a callee cannot retain one.
     {
         std::vector<double> owned;
         owned.push_back(1.0);
         owned.push_back(2.0);
-        double acc = _abi_scale_in_place(fpy::borrow(owned), 3.0);
+        fpy::list<double> borrowed(&owned, [](std::vector<double>*) {});
+        double acc = _abi_scale_in_place(borrowed, 3.0);
         assert(acc == 9.0);
         assert(owned[0] == 3.0 && owned[1] == 6.0);
     }
-    // make_list: copies, so the caller's vector is untouched
+    // Constructing a list from the values instead copies, so the caller's
+    // vector is untouched.
     {
         std::vector<double> owned;
         owned.push_back(1.0);
@@ -1116,10 +1108,11 @@ def _regression_any_over_comprehension(xs: list[fp.Real]) -> bool:
 # value type, so every place the backend copies a list is a place the generated
 # code can disagree with the interpreter.
 #
-# One function per *route* by which a list can reach a copy.  Those that
-# currently diverge are listed in `_run_ignore` with a pointer back here; the
-# rest are pins — they are correct today and must stay correct.  Each guards the
-# empty case because `_LIST_LENS` includes 0.
+# One function per *route* by which a list can reach a copy.  All of them are
+# executed and bit-compared against the interpreter on every `--mode run`; the
+# eleven that once diverged were the acceptance criterion for representing a
+# list as `fpy::list`.  Each guards the empty case because `_LIST_LENS`
+# includes 0.
 
 
 @fp.fpy

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -890,6 +890,103 @@ int main() {
 """
 
 
+@fp.fpy
+def _abi_scale_in_place(xs: list[fp.Real], k: fp.Real) -> fp.Real:
+    """Kernel for the ABI test: mutates its argument and returns a value."""
+    with fp.FP64:
+        acc = 0.0
+        for i in range(len(xs)):
+            xs[i] = xs[i] * k
+            acc = acc + xs[i]
+        return acc
+
+
+def _test_abi(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, str]]:
+    """Compile a kernel and call it the way an embedding program would.
+
+    The differential driver builds each argument as a fresh ``fpy::list``, which
+    mirrors the interpreter's Python-boundary isolation — so nothing in the
+    corpus exercises handing a kernel storage the *caller* owns.  That is the
+    case that matters for embedding a generated kernel in a larger system, so it
+    is pinned here:
+
+    - ``fpy::borrow`` passes a caller's ``std::vector`` with no copy, and the
+      kernel's writes land in it;
+    - ``fpy::make_list`` copies, and the caller's vector is untouched.
+
+    Both are one line at the call site, which is the whole claim: a host needs
+    no dependency on anything of ours beyond ``std::shared_ptr``.
+    """
+    group = 'abi'
+    compiler = fp.CppCompiler()
+    cpp_path = output_dir / 'abi_boundary.cpp'
+    print(f'Compiling ABI boundary test to `{cpp_path}`')
+    arg_types = [
+        fp.types.ListType(fp.types.RealType(fp.FP64)),
+        fp.types.RealType(fp.FP64),
+    ]
+    with open(cpp_path, 'w') as f:
+        print('\n'.join(compiler.headers()), file=f)
+        print('#include <cstdio>', file=f)
+        print(compiler.helpers(), file=f)
+        print(
+            compiler.compile(
+                _abi_scale_in_place, ctx=fp.FP64, arg_types=arg_types,
+            ),
+            file=f,
+        )
+        print(_ABI_MAIN, file=f)
+
+    if mode == 'emit':
+        return []
+    if _CXX is None:
+        print('  SKIPPED (no C++ compiler driver)')
+        return []
+
+    exe = cpp_path.with_suffix('.exe')
+    try:
+        subprocess.run(
+            [_CXX, *_CPP_OPTIONS, '-o', str(exe), str(cpp_path)],
+            check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f'  FAILED to build: {e.stderr[-400:]}')
+        return [(group, 'abi_boundary', f'build failed: {e.stderr[-200:]}')]
+
+    r = subprocess.run([str(exe)], capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f'  FAILED: {r.stdout.strip()} {r.stderr.strip()}')
+        return [(group, 'abi_boundary', f'assertion failed: {r.stdout.strip()}')]
+    return []
+
+
+_ABI_MAIN: str = """\
+int main() {
+    // borrow: the kernel writes through to storage the caller owns
+    {
+        std::vector<double> owned;
+        owned.push_back(1.0);
+        owned.push_back(2.0);
+        double acc = _abi_scale_in_place(fpy::borrow(owned), 3.0);
+        assert(acc == 9.0);
+        assert(owned[0] == 3.0 && owned[1] == 6.0);
+    }
+    // make_list: copies, so the caller's vector is untouched
+    {
+        std::vector<double> owned;
+        owned.push_back(1.0);
+        owned.push_back(2.0);
+        double acc = _abi_scale_in_place(
+            fpy::make_list<double>({owned[0], owned[1]}), 3.0);
+        assert(acc == 9.0);
+        assert(owned[0] == 1.0 && owned[1] == 2.0);
+    }
+    std::printf("abi boundary OK\\n");
+    return 0;
+}
+"""
+
+
 def _test_libraries(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, str]]:
     failures: list[tuple[str, str, str]] = []
     for mod in _modules:
@@ -1410,6 +1507,7 @@ def test_compile_cpp(delete: bool = True, mode: str = 'compile'):
     failures: list[tuple[str, str, str]] = []
     cov: Counter[str] = Counter()
     failures += _test_runtime(output_dir, mode=mode)
+    failures += _test_abi(output_dir, mode=mode)
     failures += _test_unit(output_dir, mode=mode, cov=cov)
     failures += _test_libraries(output_dir, mode=mode)
     failures += _test_regressions(output_dir, mode=mode, cov=cov)

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -7,6 +7,7 @@ import fpy2 as fp
 import hashlib
 import math
 import random
+import re
 import shutil
 import signal
 import struct
@@ -115,6 +116,28 @@ _run_ignore: list[str] = [
     # numerically equal, a signed-zero-from-reduction edge.  This function
     # exists to pin widening codegen (which compiles), not exact execution.
     '_regression_quant_dot_real_widen',
+
+    # --- known list-aliasing divergences -----------------------------------
+    # FPy lists are shared; `std::vector` is a value type, so the backend
+    # copies where FPy would alias and these produce wrong answers rather
+    # than errors.  Each names a distinct route by which a list reaches a
+    # copy; see the "List-aliasing regressions" section below for what each
+    # one does.  They are compiled and `cc`-checked on every run — only the
+    # execution comparison is suppressed.
+    #
+    # This list is the acceptance criterion for fixing the representation:
+    # when it is empty, the backend and the interpreter agree about sharing.
+    '_regression_alias_then_mutate',
+    '_regression_callee_mutates_param',
+    '_regression_returned_list_aliases',
+    '_regression_projected_element',
+    '_regression_loop_variable',
+    '_regression_list_into_list',
+    '_regression_list_into_tuple',
+    '_regression_comprehension_of_rows',
+    '_regression_nested_slice',
+    '_regression_one_list_two_indices',
+    '_regression_enumerate_row_write',
 ]
 
 
@@ -632,7 +655,7 @@ def _test_unit_tests(
     compiler = fp.CppCompiler(unsafe_cast_int=True)
     failures: list[tuple[str, str, str]] = []
     for func in funcs:
-        if func.name in ignore:
+        if func.name in ignore or not _selected(func.name):
             continue
 
         try:
@@ -744,7 +767,11 @@ def _test_library(
     # into the combined module that we emit.
     accepted: list[tuple[fp.Function, list]] = []
     for func in mod.__dict__.values():
-        if isinstance(func, fp.Function) and func.name not in ignore:
+        if (
+            isinstance(func, fp.Function)
+            and func.name not in ignore
+            and _selected(func.name)
+        ):
             ty_info = fp.analysis.TypeInfer.check(func.ast)
             arg_types = [_inst_type(ty) for ty in ty_info.arg_types]
             probe = fp.Module()
@@ -756,6 +783,9 @@ def _test_library(
                 failures.append((group, func.name, str(e)))
                 continue
             accepted.append((func, arg_types))
+
+    if not accepted:
+        return failures
 
     combined = fp.Module()
     for func, arg_types in accepted:
@@ -900,6 +930,239 @@ def _regression_any_over_comprehension(xs: list[fp.Real]) -> bool:
         return any([x < 0 for x in xs])
 
 
+###########################################################
+# List-aliasing regressions
+#
+# FPy lists are shared: assignment aliases, `xs[i] = e` mutates the object, and
+# passing/returning/projecting carries the identity along.  `std::vector` is a
+# value type, so every place the backend copies a list is a place the generated
+# code can disagree with the interpreter.
+#
+# One function per *route* by which a list can reach a copy.  Those that
+# currently diverge are listed in `_run_ignore` with a pointer back here; the
+# rest are pins — they are correct today and must stay correct.  Each guards the
+# empty case because `_LIST_LENS` includes 0.
+
+
+@fp.fpy
+def _regression_alias_then_mutate(xs: list[fp.Real]) -> fp.Real:
+    """Route: a bare `ys = xs` alias, then a write through the alias."""
+    with fp.FP64:
+        if len(xs) == 0:
+            return 0
+        ys = xs
+        ys[0] = 99
+        return xs[0]
+
+
+@fp.fpy
+def _regression_alias_readonly(xs: list[fp.Real]) -> fp.Real:
+    """Pin: a read-only alias.  Nothing is written, so a copy is unobservable
+    and the backend is free to pick `const&`.  Guards against a fix for the
+    route above that pessimizes this one."""
+    with fp.FP64:
+        if len(xs) == 0:
+            return 0
+        ys = xs
+        return ys[0] + xs[0]
+
+
+@fp.fpy
+def _regression_writes_its_arg(zs: list[fp.Real]) -> fp.Real:
+    """Callee for :func:`_regression_callee_mutates_param`."""
+    with fp.FP64:
+        zs[0] = 99
+        return 0
+
+
+@fp.fpy
+def _regression_callee_mutates_param(xs: list[fp.Real]) -> fp.Real:
+    """Route: a callee writes its list parameter; FPy shares, so the caller
+    must see it."""
+    with fp.FP64:
+        if len(xs) == 0:
+            return 0
+        v = _regression_writes_its_arg(xs)
+        return xs[0] + v
+
+
+@fp.fpy
+def _regression_returns_its_argument(zs: list[fp.Real]) -> list[fp.Real]:
+    """Callee for :func:`_regression_returned_list_aliases`."""
+    return zs
+
+
+@fp.fpy
+def _regression_returned_list_aliases(xs: list[fp.Real]) -> fp.Real:
+    """Route: a returned list keeps its identity, so the caller's binding
+    aliases the list it passed in."""
+    with fp.FP64:
+        if len(xs) == 0:
+            return 0
+        ys = _regression_returns_its_argument(xs)
+        ys[0] = 99
+        return xs[0]
+
+
+@fp.fpy
+def _regression_projected_element(xss: list[list[fp.Real]]) -> fp.Real:
+    """Route: projection *out of* a container.  An element lives inside its
+    container, so `inner` is that element, not a copy of it."""
+    with fp.FP64:
+        if len(xss) == 0:
+            return 0
+        inner = xss[0]
+        inner[0] = 99
+        return xss[0][0]
+
+
+@fp.fpy
+def _regression_loop_variable(xss: list[list[fp.Real]]) -> fp.Real:
+    """Route: the same projection through a loop variable."""
+    with fp.FP64:
+        if len(xss) == 0:
+            return 0
+        for row in xss:
+            row[0] = 99
+        return xss[0][0]
+
+
+@fp.fpy
+def _regression_list_into_list(xs: list[fp.Real]) -> fp.Real:
+    """Route: construction *into* a container.  `std::vector` owns its
+    elements, so the copy happens at construction, before any name exists that
+    could have been a reference instead."""
+    with fp.FP64:
+        if len(xs) == 0:
+            return 0
+        zss = [xs]
+        zss[0][0] = 99
+        return xs[0]
+
+
+@fp.fpy
+def _regression_list_into_tuple(xs: list[fp.Real]) -> fp.Real:
+    """Route: the same construction into a tuple.  Tuples are immutable, so
+    copying one is normally unobservable — but not when it holds a list."""
+    with fp.FP64:
+        if len(xs) == 0:
+            return 0
+        t = (xs, 1.0)
+        ys = fp.fst(t)
+        ys[0] = 99
+        return xs[0]
+
+
+@fp.fpy
+def _regression_comprehension_of_rows(xss: list[list[fp.Real]]) -> fp.Real:
+    """Route: `[row for row in xss]` is a new *outer* list over the *same*
+    inner lists.  Contrast `_regression_comprehension_deep_copy`."""
+    with fp.FP64:
+        if len(xss) == 0:
+            return 0
+        yss = [row for row in xss]
+        yss[0][0] = 99
+        return xss[0][0]
+
+
+@fp.fpy
+def _regression_comprehension_deep_copy(xss: list[list[fp.Real]]) -> fp.Real:
+    """Pin: one character of difference from the route above — the element is a
+    fresh comprehension, so this really is a deep copy and `xss` is untouched."""
+    with fp.FP64:
+        if len(xss) == 0:
+            return 0
+        yss = [[x for x in row] for row in xss]
+        yss[0][0] = 99
+        return xss[0][0]
+
+
+@fp.fpy
+def _regression_nested_slice(xss: list[list[fp.Real]]) -> fp.Real:
+    """Route: slicing is *shallow* — a fresh outer list over the same inner
+    lists.  The C++ range constructor copies every element."""
+    with fp.FP64:
+        if len(xss) == 0:
+            return 0
+        yss = xss[0:1]
+        yss[0][0] = 99
+        return xss[0][0]
+
+
+@fp.fpy
+def _regression_flat_slice(xs: list[fp.Real]) -> fp.Real:
+    """Pin: a slice of a *flat* list has scalar elements, so one level of copy
+    is all there is and C++ agrees."""
+    with fp.FP64:
+        if len(xs) == 0:
+            return 0
+        ys = xs[0:1]
+        ys[0] = 99
+        return xs[0]
+
+
+@fp.fpy
+def _regression_one_list_two_indices(xs: list[fp.Real]) -> fp.Real:
+    """Route: one list placed at two indices.  `x[0]` and `x[1]` are one object
+    in FPy and two independent vectors in C++."""
+    with fp.FP64:
+        if len(xs) == 0:
+            return 0
+        a = [xs[0], xs[0]]
+        x = [a, a]
+        x[0][0] = 99
+        return x[1][0]
+
+
+@fp.fpy
+def _regression_enumerate_row_write(xss: list[list[fp.Real]]) -> fp.Real:
+    """Route: `enumerate` lowers to a materialized `vector<tuple<I, T>>`, which
+    deep-copies every row.  Notable because that copy site is synthesized by
+    codegen and appears nowhere in the AST."""
+    with fp.FP64:
+        if len(xss) == 0:
+            return 0
+        acc = 0.0
+        for (i, row) in enumerate(xss):
+            row[0] = 99
+            acc = acc + 1.0
+        return xss[0][0] + acc
+
+
+@fp.fpy
+def _regression_conditional_alias(
+    xs: list[fp.Real], zs: list[fp.Real], c: fp.Real,
+) -> fp.Real:
+    """Pin: one name aliasing a *different* list on each path.  No C++
+    reference can stand for both, so the backend must either hoist a variable
+    (as it does today) or refuse — but never silently rename one to the
+    other."""
+    with fp.FP64:
+        if len(xs) == 0 or len(zs) == 0:
+            return 0
+        if c > 0:
+            ys = xs
+        else:
+            ys = zs
+        return ys[0]
+
+
+@fp.fpy
+def _regression_replaced_slot(
+    xss: list[list[fp.Real]], ys: list[fp.Real],
+) -> fp.Real:
+    """Pin: a projection names an *object*, not a slot.  After `xss[0] = ys`,
+    `row` is still the detached old list — a C++ reference would follow the
+    slot instead."""
+    with fp.FP64:
+        if len(xss) == 0 or len(ys) == 0:
+            return 0
+        row = xss[0]
+        xss[0] = ys
+        row[0] = 99
+        return xss[0][0] + ys[0]
+
+
 _regression_funcs: list[fp.Function] = [
     _regression_quant_dot_real_widen,
     _regression_empty_range,
@@ -907,6 +1170,22 @@ _regression_funcs: list[fp.Function] = [
     _regression_any_bool_list,
     _regression_all_bool_list,
     _regression_any_over_comprehension,
+    _regression_alias_then_mutate,
+    _regression_alias_readonly,
+    _regression_callee_mutates_param,
+    _regression_returned_list_aliases,
+    _regression_projected_element,
+    _regression_loop_variable,
+    _regression_list_into_list,
+    _regression_list_into_tuple,
+    _regression_comprehension_of_rows,
+    _regression_comprehension_deep_copy,
+    _regression_nested_slice,
+    _regression_flat_slice,
+    _regression_one_list_two_indices,
+    _regression_enumerate_row_write,
+    _regression_conditional_alias,
+    _regression_replaced_slot,
 ]
 
 
@@ -955,6 +1234,8 @@ def _test_typed_regressions(
     compiler = fp.CppCompiler(unsafe_cast_int=True)
     failures: list[tuple[str, str, str]] = []
     for func, arg_types in _typed_regression_funcs:
+        if not _selected(func.name):
+            continue
         try:
             cpp_path = _compile(
                 output_dir, 'typed_regressions', compiler, func, arg_types,
@@ -982,6 +1263,20 @@ def _test_regressions(
         output_dir, 'regressions', _regression_funcs, ignore=[],
         mode=mode, cov=cov,
     )
+
+###########################################################
+# Name filter
+
+_select: 're.Pattern[str] | None' = None
+"""``-k`` filter set by the CLI.  ``None`` — the default, and what the pytest
+entry point uses — tests everything."""
+
+
+def _selected(name: str) -> bool:
+    """Whether *name* passes the ``-k`` filter (a regex, searched not anchored,
+    so a plain substring works)."""
+    return _select is None or _select.search(name) is not None
+
 
 ###########################################################
 # Main tester
@@ -1065,7 +1360,15 @@ if __name__ == '__main__':
              "run: also execute eligible functions and bit-compare vs. the interpreter",
     )
     parser.add_argument('--no-cc', action='store_true', help="Alias for --mode emit (emit C++ only)")
+    parser.add_argument(
+        '-k', dest='select', metavar='PATTERN', default=None,
+        help="Only test functions whose name matches PATTERN (a regex, searched "
+             "anywhere in the name), like pytest's -k",
+    )
     args = parser.parse_args()
+    if args.select is not None:
+        _select = re.compile(args.select)
+        print(f'Filtering to function names matching `{args.select}`')
 
     # arguments
     delete: bool = not args.keep

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -117,27 +117,6 @@ _run_ignore: list[str] = [
     # exists to pin widening codegen (which compiles), not exact execution.
     '_regression_quant_dot_real_widen',
 
-    # --- known list-aliasing divergences -----------------------------------
-    # FPy lists are shared; `std::vector` is a value type, so the backend
-    # copies where FPy would alias and these produce wrong answers rather
-    # than errors.  Each names a distinct route by which a list reaches a
-    # copy; see the "List-aliasing regressions" section below for what each
-    # one does.  They are compiled and `cc`-checked on every run — only the
-    # execution comparison is suppressed.
-    #
-    # This list is the acceptance criterion for fixing the representation:
-    # when it is empty, the backend and the interpreter agree about sharing.
-    '_regression_alias_then_mutate',
-    '_regression_callee_mutates_param',
-    '_regression_returned_list_aliases',
-    '_regression_projected_element',
-    '_regression_loop_variable',
-    '_regression_list_into_list',
-    '_regression_list_into_tuple',
-    '_regression_comprehension_of_rows',
-    '_regression_nested_slice',
-    '_regression_one_list_two_indices',
-    '_regression_enumerate_row_write',
 ]
 
 
@@ -203,14 +182,14 @@ def _emit_print(expr: str, value, lines: list[str], counter: list[int]) -> None:
     if isinstance(value, bool):
         lines.append(f'  std::printf("%d ", (int)({expr}));')
     elif isinstance(value, list):
-        lines.append(f'  std::printf("%zu ", (size_t)(({expr}).size()));')
+        lines.append(f'  std::printf("%zu ", (size_t)(({expr})->size()));')
         if value:  # homogeneous: one representative element shape
             i = counter[0]
             counter[0] += 1
             elt = f'__e{i}'
             # ``auto`` (by value), not ``auto&``: ``std::vector<bool>`` yields
             # proxy rvalues that a non-const reference cannot bind to.
-            lines.append(f'  for (auto {elt} : ({expr})) {{')
+            lines.append(f'  for (auto {elt} : *({expr})) {{')
             _emit_print(elt, value[0], lines, counter)
             lines.append('  }')
     elif isinstance(value, tuple):
@@ -398,7 +377,9 @@ def _cpp_type(ty) -> str:
         case fp.types.BoolType():
             return 'bool'
         case fp.types.ListType():
-            return f'std::vector<{_cpp_type(ty.elt)}>'
+            # must match `CppList.format()`: a list is a shared handle, not a
+            # bare vector
+            return f'fpy::list<{_cpp_type(ty.elt)}>'
         case fp.types.TupleType():
             return f'std::tuple<{", ".join(_cpp_type(elt) for elt in ty.elts)}>'
         case _:
@@ -424,7 +405,7 @@ def _cpp_literal(value, ty) -> str:
             return 'true' if value else 'false'
         case fp.types.ListType():
             elts = ', '.join(_cpp_literal(v, ty.elt) for v in value)
-            return f'{_cpp_type(ty)}{{{elts}}}'
+            return f'fpy::make_list<{_cpp_type(ty.elt)}>({{{elts}}})'
         case fp.types.TupleType():
             elts = ', '.join(_cpp_literal(v, e) for v, e in zip(value, ty.elts))
             return f'std::make_tuple({elts})'

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -884,7 +884,7 @@ int main() {
 
 @fp.fpy
 def _abi_scale_in_place(xs: list[fp.Real], k: fp.Real) -> fp.Real:
-    """Kernel for the ABI test: mutates its argument and returns a value."""
+    """Mutates its argument and returns a value."""
     with fp.FP64:
         acc = 0.0
         for i in range(len(xs)):
@@ -893,35 +893,48 @@ def _abi_scale_in_place(xs: list[fp.Real], k: fp.Real) -> fp.Real:
         return acc
 
 
-def _test_abi(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, str]]:
-    """Compile a kernel and call it the way an embedding program would.
+@fp.fpy
+def _abi_fresh_result(xs: list[fp.Real]) -> list[fp.Real]:
+    """Returns a new list, so its handle is the sole owner."""
+    with fp.FP64:
+        return [x * 2 for x in xs]
 
-    The differential driver builds each argument as a fresh ``fpy::list``, so
-    nothing in the corpus covers handing a kernel storage the *caller* owns —
-    which is the case that matters for embedding.  ``fpy::borrow`` passes a
-    A ``shared_ptr`` with a no-op deleter passes a vector with no copy and the
-    kernel's writes land in it; constructing from the values copies instead, and
-    the caller's vector is untouched.  Both are plain standard C++ — the runtime
-    ships only what the emitter emits.
+
+@fp.fpy
+def _abi_row_element_write(xss: list[list[fp.Real]]) -> fp.Real:
+    """Writes an *element* of a row: reaches the caller's buffer directly."""
+    with fp.FP64:
+        for row in xss:
+            row[0] = 99
+        return xss[0][0]
+
+
+def _test_abi(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, str]]:
+    """Compile kernels and call them the way an embedding program would.
+
+    Nothing in the corpus covers handing a kernel storage the *caller* owns —
+    the differential driver builds fresh ``fpy::list`` arguments — so the
+    ``fpy::`` conversions are pinned here: ``borrow`` shares a flat vector,
+    ``copy_in`` does not, ``copy_out`` reads a result back, and a
+    ``vector<vector<T>>`` can only be copied, so a kernel's write must *not*
+    reach the caller.
     """
     group = 'abi'
     compiler = fp.CppCompiler()
     cpp_path = output_dir / 'abi_boundary.cpp'
     print(f'Compiling ABI boundary test to `{cpp_path}`')
-    arg_types = [
-        fp.types.ListType(fp.types.RealType(fp.FP64)),
-        fp.types.RealType(fp.FP64),
-    ]
+    lst = fp.types.ListType(fp.types.RealType(fp.FP64))
+    real = fp.types.RealType(fp.FP64)
+    nested = fp.types.ListType(lst)
+    module = fp.Module()
+    module.add(_abi_scale_in_place, ctx=fp.FP64, arg_types=[lst, real])
+    module.add(_abi_fresh_result, ctx=fp.FP64, arg_types=[lst])
+    module.add(_abi_row_element_write, ctx=fp.FP64, arg_types=[nested])
     with open(cpp_path, 'w') as f:
         print('\n'.join(compiler.headers()), file=f)
         print('#include <cstdio>', file=f)
         print(compiler.helpers(), file=f)
-        print(
-            compiler.compile(
-                _abi_scale_in_place, ctx=fp.FP64, arg_types=arg_types,
-            ),
-            file=f,
-        )
+        print(compiler.compile_module(module), file=f)
         print(_ABI_MAIN, file=f)
 
     if mode == 'emit':
@@ -949,29 +962,49 @@ def _test_abi(output_dir: Path, mode: str = 'compile') -> list[tuple[str, str, s
 
 _ABI_MAIN: str = """\
 int main() {
-    // A `shared_ptr` with a no-op deleter hands the kernel storage the caller
-    // owns: no copy, and the kernel's writes land in it.  Safe because the
-    // handle cannot outlive the call -- FPy has no globals, and captures are
-    // materialized before compilation, so a callee cannot retain one.
+    // borrow: shares the caller's buffer, so the kernel's writes land in it
     {
-        std::vector<double> owned;
-        owned.push_back(1.0);
-        owned.push_back(2.0);
-        fpy::list<double> borrowed(&owned, [](std::vector<double>*) {});
-        double acc = _abi_scale_in_place(borrowed, 3.0);
+        std::vector<double> v(2, 1.0);
+        v[1] = 2.0;
+        const double* buf = v.data();
+        double acc = _abi_scale_in_place(fpy::borrow(v), 3.0);
         assert(acc == 9.0);
-        assert(owned[0] == 3.0 && owned[1] == 6.0);
+        assert(v[0] == 3.0 && v[1] == 6.0);
+        assert(v.data() == buf);          // shared, not reallocated
     }
-    // Constructing a list from the values instead copies, so the caller's
-    // vector is untouched.
+    // copy_in: the caller's vector is untouched
     {
-        std::vector<double> owned;
-        owned.push_back(1.0);
-        owned.push_back(2.0);
-        double acc = _abi_scale_in_place(
-            fpy::make_list<double>({owned[0], owned[1]}), 3.0);
+        std::vector<double> v(2, 1.0);
+        v[1] = 2.0;
+        double acc = _abi_scale_in_place(fpy::copy_in(v), 3.0);
         assert(acc == 9.0);
-        assert(owned[0] == 1.0 && owned[1] == 2.0);
+        assert(v[0] == 1.0 && v[1] == 2.0);
+    }
+    // copy_out: read a result back into a native vector
+    {
+        std::vector<double> v(2, 1.0);
+        v[1] = 2.0;
+        std::vector<double> out = fpy::copy_out(_abi_fresh_result(fpy::borrow(v)));
+        assert(out.size() == 2 && out[0] == 2.0 && out[1] == 4.0);
+    }
+    // A nested vector is copied in, so the kernel's write does *not* reach the
+    // caller -- there is no faithful way to share rows, so none is offered.
+    {
+        std::vector<std::vector<double> > m(2, std::vector<double>(2, 1.0));
+        m[1][0] = 2.0;
+        double got = _abi_row_element_write(fpy::copy_in(m));
+        assert(got == 99.0);
+        assert(m[0][0] == 1.0 && m[1][0] == 2.0);
+    }
+    // ...and copied out row by row.
+    {
+        std::vector<std::vector<double> > m(1, std::vector<double>(2, 1.0));
+        fpy::list<fpy::list<double> > h = fpy::copy_in(m);
+        double got = _abi_row_element_write(h);
+        assert(got == 99.0);
+        std::vector<std::vector<double> > out = fpy::copy_out(h);
+        assert(out.size() == 1 && out[0][0] == 99.0);
+        assert(m[0][0] == 1.0);
     }
     std::printf("abi boundary OK\\n");
     return 0;

--- a/tests/unit/backend/cpp/test_compile.py
+++ b/tests/unit/backend/cpp/test_compile.py
@@ -77,7 +77,7 @@ class TestCppCompilerStub:
                 RealType(fp.FP64), RealType(fp.FP64),
             ))],
         )
-        assert 'std::vector<std::tuple<double, double>>' in out
+        assert 'fpy::list<std::tuple<double, double>>' in out
 
     def test_real_accumulator_loop_terminates(self):
         """A loop that accumulates into a literal-initialized scalar

--- a/tests/unit/backend/cpp/test_emit_bool.py
+++ b/tests/unit/backend/cpp/test_emit_bool.py
@@ -101,7 +101,7 @@ class TestBooleanReduce:
                 return any(bs)
 
         out = self._compile(f, BoolType())
-        assert out.startswith('bool f(const std::vector<bool>& bs)')
+        assert out.startswith('bool f(const fpy::list<bool>& bs)')
         assert 'std::any_of(' in out
 
     def test_all_over_bool_list_arg(self):
@@ -111,7 +111,7 @@ class TestBooleanReduce:
                 return all(bs)
 
         out = self._compile(f, BoolType())
-        assert out.startswith('bool f(const std::vector<bool>& bs)')
+        assert out.startswith('bool f(const fpy::list<bool>& bs)')
         assert 'std::all_of(' in out
 
     def test_identity_predicate_is_a_bool_lambda(self):
@@ -137,7 +137,7 @@ class TestBooleanReduce:
         bound = re.search(r'auto&& (\w+) = ', out)
         assert bound, out
         t = bound.group(1)
-        assert f'std::any_of({t}.begin(), {t}.end()' in out
+        assert f'std::any_of({t}->begin(), {t}->end()' in out
 
     def test_comprehension_operand_is_fused_away(self):
         """``ReduceFusion`` runs in the default (optimizing) pipeline, so the
@@ -149,13 +149,13 @@ class TestBooleanReduce:
                 return all([x < 0 for x in xs])
 
         out = self._compile(f, RealType(fp.FP64))
-        assert 'std::vector<bool>' not in out
+        assert 'fpy::list<bool>' not in out
         assert 'std::all_of(' not in out
         assert '&&' in out          # folded with `and` in the loop body
 
     def test_comprehension_operand_unfused_without_optimize(self):
         """With ``optimize=False`` the surface AST compiles verbatim: the
-        comprehension materializes a ``std::vector<bool>`` that
+        comprehension materializes a ``fpy::list<bool>`` that
         ``std::all_of`` then scans."""
         @fp.fpy
         def f(xs: list[fp.Real]) -> bool:
@@ -163,6 +163,6 @@ class TestBooleanReduce:
                 return all([x < 0 for x in xs])
 
         out = self._compile(f, RealType(fp.FP64), optimize=False)
-        assert 'std::vector<bool>' in out
+        assert 'fpy::list<bool>' in out
         assert 'push_back(' in out
         assert 'std::all_of(' in out

--- a/tests/unit/backend/cpp/test_emit_bool.py
+++ b/tests/unit/backend/cpp/test_emit_bool.py
@@ -125,19 +125,31 @@ class TestBooleanReduce:
         assert m, f'no identity predicate in:\n{out}'
         assert m.group(1) == m.group(2), 'predicate must return its parameter'
 
-    def test_operand_bound_before_iterating(self):
+    def test_prvalue_operand_is_bound_before_iterating(self):
         """``begin()``/``end()`` on a prvalue would name iterators into two
         different temporaries — an invalid range.  Same reason ``Sum`` binds."""
+        @fp.fpy
+        def f(bs: list[bool]) -> bool:
+            with fp.FP64:
+                return any(bs[1:])
+
+        out = self._compile(f, BoolType())
+        bound = re.search(r'auto&& (\w+) = fpy::make_list', out)
+        assert bound, out
+        t = bound.group(1)
+        assert f'std::any_of({t}->begin(), {t}->end()' in out
+
+    def test_named_operand_is_not_bound(self):
+        """A name is evaluated once already, so there is nothing to bind — and
+        a list is a handle, so there was never a copy to avoid either."""
         @fp.fpy
         def f(bs: list[bool]) -> bool:
             with fp.FP64:
                 return any(bs)
 
         out = self._compile(f, BoolType())
-        bound = re.search(r'auto&& (\w+) = ', out)
-        assert bound, out
-        t = bound.group(1)
-        assert f'std::any_of({t}->begin(), {t}->end()' in out
+        assert 'std::any_of(bs->begin(), bs->end()' in out
+        assert 'auto&&' not in out
 
     def test_comprehension_operand_is_fused_away(self):
         """``ReduceFusion`` runs in the default (optimizing) pipeline, so the

--- a/tests/unit/backend/cpp/test_emit_builtins.py
+++ b/tests/unit/backend/cpp/test_emit_builtins.py
@@ -33,13 +33,14 @@ class TestSum:
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64))],
         )
-        # The operand is bound to a reference (``auto&&``) so begin()/end()
-        # name the same object — required when the operand is a prvalue;
-        # ``accumulate`` then folds over that binding.
-        assert 'auto&& ' in out and '= xs;' in out
-        assert 'std::accumulate(' in out
-        assert '->begin(), ' in out
-        assert '->end(), static_cast<double>(0))' in out
+        # A named operand is read directly; only a prvalue needs binding so
+        # that begin()/end() name the same object (see
+        # ``test_prvalue_operand_is_bound_before_iterating`` in test_emit_bool).
+        assert 'auto&&' not in out
+        assert (
+            'std::accumulate(xs->begin(), xs->end(), '
+            'static_cast<double>(0))'
+        ) in out
 
 
 class TestEnumerate:
@@ -65,8 +66,8 @@ class TestEnumerate:
         assert 'fpy::list<std::tuple<int64_t, double>>' in out
         # Loop populates the result with (size_t-cast index, source elt).
         assert (
-            'std::make_tuple(static_cast<int64_t>(_tmp3), '
-            '(*_tmp1)[_tmp3]);'
+            'std::make_tuple(static_cast<int64_t>(_tmp2), '
+            '(*xs)[_tmp2]);'
         ) in out
         # Then the outer for-loop destructures into ``i``/``x``.
         assert 'int64_t i = std::get<0>' in out
@@ -96,14 +97,10 @@ class TestZip:
                 ListType(RealType(fp.FP64)),
             ],
         )
-        # Both iterables bound to temps.
-        assert 'auto&& _tmp1 = xs;' in out
-        assert 'auto&& _tmp2 = ys;' in out
-        # Per-element tuple draws from both temps.
-        assert (
-            'std::make_tuple((*_tmp1)[_tmp4], '
-            '(*_tmp2)[_tmp4]);'
-        ) in out
+        # Both iterables are names, so neither needs a temp; the per-element
+        # tuple indexes them directly.
+        assert 'auto&&' not in out
+        assert 'std::make_tuple((*xs)[_tmp2], (*ys)[_tmp2]);' in out
         # Loop body destructures back to ``x``/``y``.
         assert 'double x = std::get<0>' in out
         assert 'double y = std::get<1>' in out
@@ -124,10 +121,10 @@ class TestZip:
             arg_types=[ListType(RealType(fp.FP64))] * 3,
         )
         assert 'fpy::list<std::tuple<double, double, double>>' in out
-        # Three iterables bound, three subscript reads in make_tuple.
-        assert 'auto&& _tmp1 = xs;' in out
-        assert 'auto&& _tmp2 = ys;' in out
-        assert 'auto&& _tmp3 = zs;' in out
+        # Three named iterables, so three direct subscript reads in make_tuple.
+        assert 'auto&&' not in out
+        assert 'std::make_tuple((*xs)[' in out
+        assert '(*ys)[' in out and '(*zs)[' in out
 
     def test_zip_optimized_skips_tuple_vector(self):
         """Default ``CppCompiler()`` has ``optimize=True``, so

--- a/tests/unit/backend/cpp/test_emit_builtins.py
+++ b/tests/unit/backend/cpp/test_emit_builtins.py
@@ -11,7 +11,7 @@ lists that lower to standard C++ idioms:
 - ``zip(xs, ys, ...)`` → a ``std::vector<std::tuple<T1, T2, ...>>``
   populated similarly.
 
-The temporaries the emitter allocates use ``__cpp_tmpN`` names.
+The temporaries the emitter allocates use ``_tmpN`` names.
 """
 
 import fpy2 as fp
@@ -65,8 +65,8 @@ class TestEnumerate:
         assert 'std::vector<std::tuple<int64_t, double>>' in out
         # Loop populates the result with (size_t-cast index, source elt).
         assert (
-            'std::make_tuple(static_cast<int64_t>(__cpp_tmp3), '
-            '__cpp_tmp1[__cpp_tmp3]);'
+            'std::make_tuple(static_cast<int64_t>(_tmp3), '
+            '_tmp1[_tmp3]);'
         ) in out
         # Then the outer for-loop destructures into ``i``/``x``.
         assert 'int64_t i = std::get<0>' in out
@@ -97,12 +97,12 @@ class TestZip:
             ],
         )
         # Both iterables bound to temps.
-        assert 'auto&& __cpp_tmp1 = xs;' in out
-        assert 'auto&& __cpp_tmp2 = ys;' in out
+        assert 'auto&& _tmp1 = xs;' in out
+        assert 'auto&& _tmp2 = ys;' in out
         # Per-element tuple draws from both temps.
         assert (
-            'std::make_tuple(__cpp_tmp1[__cpp_tmp4], '
-            '__cpp_tmp2[__cpp_tmp4]);'
+            'std::make_tuple(_tmp1[_tmp4], '
+            '_tmp2[_tmp4]);'
         ) in out
         # Loop body destructures back to ``x``/``y``.
         assert 'double x = std::get<0>' in out
@@ -125,9 +125,9 @@ class TestZip:
         )
         assert 'std::vector<std::tuple<double, double, double>>' in out
         # Three iterables bound, three subscript reads in make_tuple.
-        assert 'auto&& __cpp_tmp1 = xs;' in out
-        assert 'auto&& __cpp_tmp2 = ys;' in out
-        assert 'auto&& __cpp_tmp3 = zs;' in out
+        assert 'auto&& _tmp1 = xs;' in out
+        assert 'auto&& _tmp2 = ys;' in out
+        assert 'auto&& _tmp3 = zs;' in out
 
     def test_zip_optimized_skips_tuple_vector(self):
         """Default ``CppCompiler()`` has ``optimize=True``, so

--- a/tests/unit/backend/cpp/test_emit_builtins.py
+++ b/tests/unit/backend/cpp/test_emit_builtins.py
@@ -6,9 +6,9 @@ lists that lower to standard C++ idioms:
 
 - ``sum(xs)`` → ``std::accumulate`` with the result type inferred
   by format inference.
-- ``enumerate(xs)`` → a ``std::vector<std::tuple<I, T>>`` populated
+- ``enumerate(xs)`` → a ``fpy::list<std::tuple<I, T>>`` populated
   by an indexed for-loop.
-- ``zip(xs, ys, ...)`` → a ``std::vector<std::tuple<T1, T2, ...>>``
+- ``zip(xs, ys, ...)`` → a ``fpy::list<std::tuple<T1, T2, ...>>``
   populated similarly.
 
 The temporaries the emitter allocates use ``_tmpN`` names.
@@ -38,12 +38,12 @@ class TestSum:
         # ``accumulate`` then folds over that binding.
         assert 'auto&& ' in out and '= xs;' in out
         assert 'std::accumulate(' in out
-        assert '.begin(), ' in out
-        assert '.end(), static_cast<double>(0))' in out
+        assert '->begin(), ' in out
+        assert '->end(), static_cast<double>(0))' in out
 
 
 class TestEnumerate:
-    """``enumerate(xs)`` builds a ``std::vector<std::tuple<I, T>>``."""
+    """``enumerate(xs)`` builds a ``fpy::list<std::tuple<I, T>>``."""
 
     def test_enumerate_in_for_loop(self):
         @fp.fpy
@@ -62,11 +62,11 @@ class TestEnumerate:
             arg_types=[ListType(RealType(fp.FP64))],
         )
         # Result-vector type and per-element tuple shape.
-        assert 'std::vector<std::tuple<int64_t, double>>' in out
+        assert 'fpy::list<std::tuple<int64_t, double>>' in out
         # Loop populates the result with (size_t-cast index, source elt).
         assert (
             'std::make_tuple(static_cast<int64_t>(_tmp3), '
-            '_tmp1[_tmp3]);'
+            '(*_tmp1)[_tmp3]);'
         ) in out
         # Then the outer for-loop destructures into ``i``/``x``.
         assert 'int64_t i = std::get<0>' in out
@@ -74,7 +74,7 @@ class TestEnumerate:
 
 
 class TestZip:
-    """``zip(xs, ys, ...)`` lowers to a ``std::vector<std::tuple<...>>``
+    """``zip(xs, ys, ...)`` lowers to a ``fpy::list<std::tuple<...>>``
     by default when optimizations are disabled.  With the default
     ``optimize=True``, :class:`ZipElim` rewrites the pattern to a
     plain indexed loop instead — see :meth:`test_zip_optimized_skips_tuple_vector`.
@@ -101,8 +101,8 @@ class TestZip:
         assert 'auto&& _tmp2 = ys;' in out
         # Per-element tuple draws from both temps.
         assert (
-            'std::make_tuple(_tmp1[_tmp4], '
-            '_tmp2[_tmp4]);'
+            'std::make_tuple((*_tmp1)[_tmp4], '
+            '(*_tmp2)[_tmp4]);'
         ) in out
         # Loop body destructures back to ``x``/``y``.
         assert 'double x = std::get<0>' in out
@@ -123,7 +123,7 @@ class TestZip:
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64))] * 3,
         )
-        assert 'std::vector<std::tuple<double, double, double>>' in out
+        assert 'fpy::list<std::tuple<double, double, double>>' in out
         # Three iterables bound, three subscript reads in make_tuple.
         assert 'auto&& _tmp1 = xs;' in out
         assert 'auto&& _tmp2 = ys;' in out
@@ -133,7 +133,7 @@ class TestZip:
         """Default ``CppCompiler()`` has ``optimize=True``, so
         :class:`ZipElim` runs first and ``for ... in zip(...)``
         lowers to a plain indexed loop — no intermediate
-        ``std::vector<std::tuple<...>>``."""
+        ``fpy::list<std::tuple<...>>``."""
 
         @fp.fpy
         def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:

--- a/tests/unit/backend/cpp/test_emit_context.py
+++ b/tests/unit/backend/cpp/test_emit_context.py
@@ -95,7 +95,7 @@ class TestStaticResolution:
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64))],
         )
-        assert 'return xs[' in out
+        assert 'return (*xs)[' in out
 
 
 class TestDefaultRmIsImplicit:

--- a/tests/unit/backend/cpp/test_emit_for.py
+++ b/tests/unit/backend/cpp/test_emit_for.py
@@ -119,5 +119,5 @@ class TestForRange:
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64))],
         )
-        assert 'for (double x : xs) {' in out
+        assert 'for (double x : *xs) {' in out
         assert 'acc = (acc + x);' in out

--- a/tests/unit/backend/cpp/test_emit_indexed_assign.py
+++ b/tests/unit/backend/cpp/test_emit_indexed_assign.py
@@ -39,12 +39,19 @@ class TestIndexedAssign:
         # No copy temp inside the loop body.
         assert '_tmp' not in out
 
-    def test_alias_rebind_is_still_in_place(self):
-        """``ys = xs; ys[0] = 99`` mutates ``ys`` in place after the
-        copy — ``ys[0] = 99`` is a direct subscript-store on ``ys``.
-        (C++ value semantics means the prior ``ys = xs;`` already
-        copies, so ``xs`` is unaffected — no second copy is
-        introduced for the mutation itself.)"""
+    def test_alias_then_mutate_is_observable_through_the_original(self):
+        """``ys = xs`` aliases in FPy, so ``ys[0] = 99`` is observable through
+        ``xs`` — and now through the generated C++ too.
+
+        ``ys`` binds a ``const`` reference to the *handle*: it cannot be
+        rebound, but the elements it points at are mutable, so the
+        subscript-store lands on the list ``xs`` also names.  The parameter
+        stays ``const&`` for the same reason — ``const`` applies to the handle,
+        not the elements.
+
+        Executed end to end by ``_regression_alias_then_mutate`` in the infra
+        corpus; this only pins the shape.
+        """
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> list[fp.Real]:
@@ -57,10 +64,12 @@ class TestIndexedAssign:
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64))],
         )
-        assert 'fpy::list<double> ys = xs;' in out
+        assert 'const fpy::list<double>& xs' in out
+        assert 'const auto& ys = xs;' in out
         assert '(*ys)[static_cast<size_t>(0)] = 99;' in out
-        # No copy temp for the mutation.
+        # Nothing is copied: no temp, and no fresh list.
         assert '_tmp' not in out
+        assert 'make_list' not in out
 
     def test_sequential_mutations_in_place(self):
         """Sequential mutations of a freshly-built list reuse the

--- a/tests/unit/backend/cpp/test_emit_indexed_assign.py
+++ b/tests/unit/backend/cpp/test_emit_indexed_assign.py
@@ -33,8 +33,8 @@ class TestIndexedAssign:
             arg_types=[ListType(RealType(fp.FP64))],
         )
         assert (
-            'xs[static_cast<size_t>(i)] = '
-            '(xs[static_cast<size_t>(i)] * static_cast<double>(2));'
+            '(*xs)[static_cast<size_t>(i)] = '
+            '((*xs)[static_cast<size_t>(i)] * static_cast<double>(2));'
         ) in out
         # No copy temp inside the loop body.
         assert '_tmp' not in out
@@ -57,8 +57,8 @@ class TestIndexedAssign:
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64))],
         )
-        assert 'std::vector<double> ys = xs;' in out
-        assert 'ys[static_cast<size_t>(0)] = 99;' in out
+        assert 'fpy::list<double> ys = xs;' in out
+        assert '(*ys)[static_cast<size_t>(0)] = 99;' in out
         # No copy temp for the mutation.
         assert '_tmp' not in out
 
@@ -76,8 +76,8 @@ class TestIndexedAssign:
 
         out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[])
         # Single ``xs`` declaration; both mutations are direct stores.
-        assert 'xs[static_cast<size_t>(0)] = 5;' in out
-        assert 'xs[static_cast<size_t>(1)] = 10;' in out
+        assert '(*xs)[static_cast<size_t>(0)] = 5;' in out
+        assert '(*xs)[static_cast<size_t>(1)] = 10;' in out
         # No suffixed copy variables.
         assert 'xs_1' not in out
         assert 'xs_2' not in out
@@ -102,8 +102,8 @@ class TestIndexedAssign:
                 RealType(fp.FP64),
             ],
         )
-        assert 'xs[static_cast<size_t>(i)] = v;' in out
-        assert 'return xs[static_cast<size_t>(0)];' in out
+        assert '(*xs)[static_cast<size_t>(i)] = v;' in out
+        assert 'return (*xs)[static_cast<size_t>(0)];' in out
         # No SSA-suffix variable, no copy temp.
         assert 'xs_1' not in out
         assert '_tmp' not in out

--- a/tests/unit/backend/cpp/test_emit_indexed_assign.py
+++ b/tests/unit/backend/cpp/test_emit_indexed_assign.py
@@ -37,7 +37,7 @@ class TestIndexedAssign:
             '(xs[static_cast<size_t>(i)] * static_cast<double>(2));'
         ) in out
         # No copy temp inside the loop body.
-        assert '__cpp_tmp' not in out
+        assert '_tmp' not in out
 
     def test_alias_rebind_is_still_in_place(self):
         """``ys = xs; ys[0] = 99`` mutates ``ys`` in place after the
@@ -60,7 +60,7 @@ class TestIndexedAssign:
         assert 'std::vector<double> ys = xs;' in out
         assert 'ys[static_cast<size_t>(0)] = 99;' in out
         # No copy temp for the mutation.
-        assert '__cpp_tmp' not in out
+        assert '_tmp' not in out
 
     def test_sequential_mutations_in_place(self):
         """Sequential mutations of a freshly-built list reuse the
@@ -81,7 +81,7 @@ class TestIndexedAssign:
         # No suffixed copy variables.
         assert 'xs_1' not in out
         assert 'xs_2' not in out
-        assert '__cpp_tmp' not in out
+        assert '_tmp' not in out
 
     def test_indexed_assign_arg(self):
         """A function-arg list mutated directly compiles to a direct
@@ -106,4 +106,4 @@ class TestIndexedAssign:
         assert 'return xs[static_cast<size_t>(0)];' in out
         # No SSA-suffix variable, no copy temp.
         assert 'xs_1' not in out
-        assert '__cpp_tmp' not in out
+        assert '_tmp' not in out

--- a/tests/unit/backend/cpp/test_emit_list.py
+++ b/tests/unit/backend/cpp/test_emit_list.py
@@ -198,12 +198,11 @@ class TestListSlice:
                 return ys[0]
 
         out = _compile_list_arg(f)
-        # Value bound to a reference (no copy), then both endpoints emit as
-        # iterator arithmetic with size_t casts.
-        assert 'auto&& _tmp1 = xs;' in out
+        # A named operand needs no temp; both endpoints emit as iterator
+        # arithmetic with size_t casts.
         assert (
-            '_tmp1->begin() + static_cast<size_t>(1), '
-            '_tmp1->begin() + static_cast<size_t>(4)'
+            'xs->begin() + static_cast<size_t>(1), '
+            'xs->begin() + static_cast<size_t>(4)'
         ) in out
 
     def test_open_stop(self):
@@ -217,8 +216,8 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '_tmp1->begin() + static_cast<size_t>(2), '
-            '_tmp1->begin() + _tmp1->size()'
+            'xs->begin() + static_cast<size_t>(2), '
+            'xs->begin() + xs->size()'
         ) in out
 
     def test_open_start(self):
@@ -232,8 +231,8 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '_tmp1->begin() + 0, '
-            '_tmp1->begin() + static_cast<size_t>(3)'
+            'xs->begin() + 0, '
+            'xs->begin() + static_cast<size_t>(3)'
         ) in out
 
     def test_full_slice(self):
@@ -247,6 +246,6 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '_tmp1->begin() + 0, '
-            '_tmp1->begin() + _tmp1->size()'
+            'xs->begin() + 0, '
+            'xs->begin() + xs->size()'
         ) in out

--- a/tests/unit/backend/cpp/test_emit_list.py
+++ b/tests/unit/backend/cpp/test_emit_list.py
@@ -26,7 +26,7 @@ class TestListLiteral:
                 return xs[0]
 
         out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[])
-        assert 'std::vector<uint8_t>' in out
+        assert 'fpy::list<uint8_t>' in out
         assert '{1, 2, 3}' in out
 
     def test_list_passed_through_args(self):
@@ -40,7 +40,7 @@ class TestListLiteral:
 
         out = _compile_list_arg(f)
         # read-only aggregate parameter -> passed by const reference
-        assert out.startswith('double f(const std::vector<double>& xs)')
+        assert out.startswith('double f(const fpy::list<double>& xs)')
 
 
 class TestListRef:
@@ -53,8 +53,8 @@ class TestListRef:
                 return xs[0] + xs[1]
 
         out = _compile_list_arg(f)
-        assert 'xs[static_cast<size_t>(0)]' in out
-        assert 'xs[static_cast<size_t>(1)]' in out
+        assert '(*xs)[static_cast<size_t>(0)]' in out
+        assert '(*xs)[static_cast<size_t>(1)]' in out
 
     def test_variable_index(self):
         @fp.fpy
@@ -67,7 +67,7 @@ class TestListRef:
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64)), RealType(fp.FP64)],
         )
-        assert 'xs[static_cast<size_t>(i)]' in out
+        assert '(*xs)[static_cast<size_t>(i)]' in out
 
 
 class TestLen:
@@ -90,7 +90,7 @@ class TestLen:
             arg_types=[ListType(RealType(fp.FP64))],
         )
         # ``len`` lowers to ``size()`` cast to the inferred integer type.
-        assert 'static_cast<int64_t>(xs.size())' in out
+        assert 'static_cast<int64_t>(xs->size())' in out
 
 
 class TestListComp:
@@ -107,8 +107,8 @@ class TestListComp:
                 return ys[0]
 
         out = _compile_list_arg(f)
-        assert 'for (double x : xs) {' in out
-        assert '.push_back((x + static_cast<double>(1)));' in out
+        assert 'for (double x : *xs) {' in out
+        assert '->push_back((x + static_cast<double>(1)));' in out
 
     def test_range_iterable(self):
         """``range(...)`` in a comprehension expands to a counter loop.
@@ -128,7 +128,7 @@ class TestListComp:
             f, ctx=fp.FP64, arg_types=[],
         )
         assert 'for (int8_t i = 0; i < 5; ++i) {' in out
-        assert '.push_back((static_cast<int64_t>(i) * static_cast<int64_t>(i)));' in out
+        assert '->push_back((static_cast<int64_t>(i) * static_cast<int64_t>(i)));' in out
 
     def test_range2_iterable(self):
         @fp.fpy
@@ -158,10 +158,10 @@ class TestListComp:
         )
         # Inner loop nested directly inside outer loop's body.
         assert (
-            'for (double x : xs) {\n'
-            '        for (double y : ys) {'
+            'for (double x : *xs) {\n'
+            '        for (double y : *ys) {'
         ) in out
-        assert '.push_back((x * y));' in out
+        assert '->push_back((x * y));' in out
 
     def test_tuple_binding_target(self):
         """Tuple-binding targets in the for-clause destructure each
@@ -184,7 +184,7 @@ class TestListComp:
         )
         assert 'std::get<0>' in out
         assert 'std::get<1>' in out
-        assert '.push_back((a + b));' in out
+        assert '->push_back((a + b));' in out
 
 
 class TestListSlice:
@@ -202,12 +202,12 @@ class TestListSlice:
         # iterator arithmetic with size_t casts.
         assert 'auto&& _tmp1 = xs;' in out
         assert (
-            '_tmp1.begin() + static_cast<size_t>(1), '
-            '_tmp1.begin() + static_cast<size_t>(4)'
+            '_tmp1->begin() + static_cast<size_t>(1), '
+            '_tmp1->begin() + static_cast<size_t>(4)'
         ) in out
 
     def test_open_stop(self):
-        """``xs[a:]`` defaults the stop endpoint to ``__tmp.size()``."""
+        """``xs[a:]`` defaults the stop endpoint to ``__tmp->size()``."""
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:
@@ -217,8 +217,8 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '_tmp1.begin() + static_cast<size_t>(2), '
-            '_tmp1.begin() + _tmp1.size()'
+            '_tmp1->begin() + static_cast<size_t>(2), '
+            '_tmp1->begin() + _tmp1->size()'
         ) in out
 
     def test_open_start(self):
@@ -232,8 +232,8 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '_tmp1.begin() + 0, '
-            '_tmp1.begin() + static_cast<size_t>(3)'
+            '_tmp1->begin() + 0, '
+            '_tmp1->begin() + static_cast<size_t>(3)'
         ) in out
 
     def test_full_slice(self):
@@ -247,6 +247,6 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '_tmp1.begin() + 0, '
-            '_tmp1.begin() + _tmp1.size()'
+            '_tmp1->begin() + 0, '
+            '_tmp1->begin() + _tmp1->size()'
         ) in out

--- a/tests/unit/backend/cpp/test_emit_list.py
+++ b/tests/unit/backend/cpp/test_emit_list.py
@@ -200,10 +200,10 @@ class TestListSlice:
         out = _compile_list_arg(f)
         # Value bound to a reference (no copy), then both endpoints emit as
         # iterator arithmetic with size_t casts.
-        assert 'auto&& __cpp_tmp1 = xs;' in out
+        assert 'auto&& _tmp1 = xs;' in out
         assert (
-            '__cpp_tmp1.begin() + static_cast<size_t>(1), '
-            '__cpp_tmp1.begin() + static_cast<size_t>(4)'
+            '_tmp1.begin() + static_cast<size_t>(1), '
+            '_tmp1.begin() + static_cast<size_t>(4)'
         ) in out
 
     def test_open_stop(self):
@@ -217,8 +217,8 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '__cpp_tmp1.begin() + static_cast<size_t>(2), '
-            '__cpp_tmp1.begin() + __cpp_tmp1.size()'
+            '_tmp1.begin() + static_cast<size_t>(2), '
+            '_tmp1.begin() + _tmp1.size()'
         ) in out
 
     def test_open_start(self):
@@ -232,8 +232,8 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '__cpp_tmp1.begin() + 0, '
-            '__cpp_tmp1.begin() + static_cast<size_t>(3)'
+            '_tmp1.begin() + 0, '
+            '_tmp1.begin() + static_cast<size_t>(3)'
         ) in out
 
     def test_full_slice(self):
@@ -247,6 +247,6 @@ class TestListSlice:
 
         out = _compile_list_arg(f)
         assert (
-            '__cpp_tmp1.begin() + 0, '
-            '__cpp_tmp1.begin() + __cpp_tmp1.size()'
+            '_tmp1.begin() + 0, '
+            '_tmp1.begin() + _tmp1.size()'
         ) in out

--- a/tests/unit/backend/cpp/test_emit_round.py
+++ b/tests/unit/backend/cpp/test_emit_round.py
@@ -63,13 +63,13 @@ class TestRoundExact:
             arg_types=[RealType(fp.FP64)],
         )
         # Cast bound to a temp.
-        assert 'float __cpp_tmp1 = static_cast<float>(x);' in out
+        assert 'float _tmp1 = static_cast<float>(x);' in out
         # FP comparison includes the NaN guard.
         assert (
-            'assert(x == __cpp_tmp1 || '
-            '(std::isnan(x) && std::isnan(__cpp_tmp1)));'
+            'assert(x == _tmp1 || '
+            '(std::isnan(x) && std::isnan(_tmp1)));'
         ) in out
-        assert 'return __cpp_tmp1;' in out
+        assert 'return _tmp1;' in out
 
     def test_int_round_exact_skips_nan_guard(self):
         """Integer operand pairs don't need ``std::isnan`` — int
@@ -84,10 +84,10 @@ class TestRoundExact:
             f, ctx=fp.SINT8,
             arg_types=[RealType(fp.INTEGER)],
         )
-        assert 'int8_t __cpp_tmp1 = static_cast<int8_t>(x);' in out
+        assert 'int8_t _tmp1 = static_cast<int8_t>(x);' in out
         # No std::isnan call.
         assert 'std::isnan' not in out
-        assert 'assert(x == __cpp_tmp1);' in out
+        assert 'assert(x == _tmp1);' in out
 
     def test_round_exact_same_type_is_noop(self):
         """Casting to the same type is guaranteed lossless — no
@@ -137,12 +137,12 @@ class TestCast:
             arg_types=[RealType(fp.FP64)],
         )
         # Lossy-capable cast → cast bound to a temp + NaN-aware assert.
-        assert 'float __cpp_tmp1 = static_cast<float>(x);' in out
+        assert 'float _tmp1 = static_cast<float>(x);' in out
         assert (
-            'assert(x == __cpp_tmp1 || '
-            '(std::isnan(x) && std::isnan(__cpp_tmp1)));'
+            'assert(x == _tmp1 || '
+            '(std::isnan(x) && std::isnan(_tmp1)));'
         ) in out
-        assert 'return __cpp_tmp1;' in out
+        assert 'return _tmp1;' in out
 
 
 class TestRoundElimIntegration:

--- a/tests/unit/backend/cpp/test_emit_tuple.py
+++ b/tests/unit/backend/cpp/test_emit_tuple.py
@@ -137,7 +137,7 @@ class TestTupleDestructure:
             f, ctx=fp.FP64,
             arg_types=[ListType(TupleType(RealType(fp.FP64), RealType(fp.FP64)))],
         )
-        assert 'for (const auto& _tmp1 : xs) {' in out
+        assert 'for (const auto& _tmp1 : *xs) {' in out
         assert '        double a = std::get<0>(_tmp1);' in out
         assert '        double b = std::get<1>(_tmp1);' in out
         assert 'acc = (acc + (a * b));' in out
@@ -156,10 +156,10 @@ class TestTupleDestructure:
         )
         # Comprehension iterates a tuple-typed temp, destructures, then
         # ``push_back``s the element expression.
-        assert 'for (const auto& _tmp2 : xs) {' in out
+        assert 'for (const auto& _tmp2 : *xs) {' in out
         assert '        double a = std::get<0>(_tmp2);' in out
         assert '        double b = std::get<1>(_tmp2);' in out
-        assert '.push_back((a + b));' in out
+        assert '->push_back((a + b));' in out
 
 
 

--- a/tests/unit/backend/cpp/test_emit_tuple.py
+++ b/tests/unit/backend/cpp/test_emit_tuple.py
@@ -82,9 +82,9 @@ class TestTupleDestructure:
         )
         # The rhs binds to a temp once, then each NamedId is extracted
         # with ``std::get<i>``.
-        assert 'auto&& __cpp_tmp1 = p;' in out
-        assert 'double a = std::get<0>(__cpp_tmp1);' in out
-        assert 'double b = std::get<1>(__cpp_tmp1);' in out
+        assert 'auto&& _tmp1 = p;' in out
+        assert 'double a = std::get<0>(_tmp1);' in out
+        assert 'double b = std::get<1>(_tmp1);' in out
         assert 'return (a + b);' in out
 
     def test_assign_with_underscore(self):
@@ -101,7 +101,7 @@ class TestTupleDestructure:
             arg_types=[TupleType(RealType(fp.FP64), RealType(fp.FP64))],
         )
         assert 'std::get<0>' not in out
-        assert 'double b = std::get<1>(__cpp_tmp1);' in out
+        assert 'double b = std::get<1>(_tmp1);' in out
 
     def test_nested_destructure(self):
         """Nested tuple bindings recurse via fresh temps."""
@@ -117,11 +117,11 @@ class TestTupleDestructure:
         out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[outer])
         # Outer temp binds the rhs; a fresh inner temp captures the
         # nested tuple slot.
-        assert 'auto&& __cpp_tmp1 = p;' in out
-        assert 'auto&& __cpp_tmp2 = std::get<0>(__cpp_tmp1);' in out
-        assert 'double a = std::get<0>(__cpp_tmp2);' in out
-        assert 'double b = std::get<1>(__cpp_tmp2);' in out
-        assert 'double c = std::get<1>(__cpp_tmp1);' in out
+        assert 'auto&& _tmp1 = p;' in out
+        assert 'auto&& _tmp2 = std::get<0>(_tmp1);' in out
+        assert 'double a = std::get<0>(_tmp2);' in out
+        assert 'double b = std::get<1>(_tmp2);' in out
+        assert 'double c = std::get<1>(_tmp1);' in out
 
     def test_for_over_list_of_tuples(self):
         @fp.fpy
@@ -137,9 +137,9 @@ class TestTupleDestructure:
             f, ctx=fp.FP64,
             arg_types=[ListType(TupleType(RealType(fp.FP64), RealType(fp.FP64)))],
         )
-        assert 'for (const auto& __cpp_tmp1 : xs) {' in out
-        assert '        double a = std::get<0>(__cpp_tmp1);' in out
-        assert '        double b = std::get<1>(__cpp_tmp1);' in out
+        assert 'for (const auto& _tmp1 : xs) {' in out
+        assert '        double a = std::get<0>(_tmp1);' in out
+        assert '        double b = std::get<1>(_tmp1);' in out
         assert 'acc = (acc + (a * b));' in out
 
     def test_comp_tuple_target(self):
@@ -156,9 +156,9 @@ class TestTupleDestructure:
         )
         # Comprehension iterates a tuple-typed temp, destructures, then
         # ``push_back``s the element expression.
-        assert 'for (const auto& __cpp_tmp2 : xs) {' in out
-        assert '        double a = std::get<0>(__cpp_tmp2);' in out
-        assert '        double b = std::get<1>(__cpp_tmp2);' in out
+        assert 'for (const auto& _tmp2 : xs) {' in out
+        assert '        double a = std::get<0>(_tmp2);' in out
+        assert '        double b = std::get<1>(_tmp2);' in out
         assert '.push_back((a + b));' in out
 
 


### PR DESCRIPTION
This PR fixes the C++ compiler by compiling lists to `std::shared_ptr<std::vector<T>>` to mirror the semantics of FPy (which inherits from Python). A single list can be wrapped by a tuple/list without copying. Thus, a shared pointer is required.