### PR TITLE
Enumerate elimination

### DIFF
--- a/docs/source/dev/ast.rst
+++ b/docs/source/dev/ast.rst
@@ -106,6 +106,10 @@ Transformations
    :members:
    :show-inheritance:
 
+.. autoclass:: fpy2.transform.EnumerateElim
+   :members:
+   :show-inheritance:
+
 .. autoclass:: fpy2.transform.ForBundling
    :members:
    :show-inheritance:

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -22,6 +22,7 @@ from ...function import Function
 from ...module import Module
 from ...number import Context
 from ...transform import (
+    EnumerateElim,
     FreeVarElim,
     ReduceFusion,
     RoundElim,
@@ -83,6 +84,15 @@ class CppCompiler(Backend):
             transformations to each :class:`FuncDef` before the rest
             of the pipeline runs:
 
+            - :class:`fpy2.transform.EnumerateElim` (pre-monomorphize):
+              skips materializing intermediate
+              ``std::vector<std::tuple<...>>``s for ``enumerate``
+              iterables.  Runs before ``ZipElim`` because it also
+              handles ``enumerate(zip(...))``, where both intermediate
+              vectors collapse into direct indexing at once — a
+              ``zip`` left on the right-hand side of the
+              ``_src0 = zip(...)`` binding an ``enumerate`` rewrite
+              would produce is out of ``ZipElim``'s reach.
             - :class:`fpy2.transform.ZipElim` (pre-monomorphize):
               skips materializing intermediate
               ``std::vector<std::tuple<...>>``s for ``zip`` iterables.
@@ -162,8 +172,8 @@ class CppCompiler(Backend):
         """Compile a :class:`~fpy2.Module` to a single C++ translation unit.
 
         Pipeline:
-          1. **Pre-spec optimizations** (``ZipElim``, ``ReduceFusion``) on
-             every function in the module via ``map``.
+          1. **Pre-spec optimizations** (``EnumerateElim``, ``ZipElim``,
+             ``ReduceFusion``) on every function in the module via ``map``.
           2. **Specialize** the module: each ``(FuncDef, ctx, arg_fmts)``
              becomes one entry; cross-function calls rewire to the
              appropriate spec.
@@ -179,8 +189,11 @@ class CppCompiler(Backend):
         module = module.map(lambda _m, fd: FreeVarElim.apply(fd))
 
         if self._optimize:
+            # before ZipElim: `enumerate(zip(...))` must be matched while the
+            # `zip` is still in an iterable position
+            module = module.map(lambda _m, fd: EnumerateElim.apply(fd))
             module = module.map(lambda _m, fd: ZipElim.apply(fd))
-            # after ZipElim, so a `zip` comp is already an indexed comp
+            # after both, so a `zip`/`enumerate` comp is already an indexed comp
             module = module.map(lambda _m, fd: ReduceFusion.apply(fd))
 
         # Translate ``Monomorphize``'s bare ``RuntimeError`` (e.g. arg-type

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -87,12 +87,10 @@ class CppCompiler(Backend):
             - :class:`fpy2.transform.EnumerateElim` (pre-monomorphize):
               skips materializing intermediate
               ``std::vector<std::tuple<...>>``s for ``enumerate``
-              iterables.  Runs before ``ZipElim`` because it also
-              handles ``enumerate(zip(...))``, where both intermediate
-              vectors collapse into direct indexing at once — a
-              ``zip`` left on the right-hand side of the
-              ``_src0 = zip(...)`` binding an ``enumerate`` rewrite
-              would produce is out of ``ZipElim``'s reach.
+              iterables.  Must run before ``ZipElim``: it also handles
+              ``enumerate(zip(...))``, collapsing both intermediate
+              vectors at once, which ``ZipElim`` could no longer do
+              once the ``zip`` sits in an assignment.
             - :class:`fpy2.transform.ZipElim` (pre-monomorphize):
               skips materializing intermediate
               ``std::vector<std::tuple<...>>``s for ``zip`` iterables.

--- a/fpy2/transform/__init__.py
+++ b/fpy2/transform/__init__.py
@@ -5,6 +5,7 @@ This module defines compiler transforms over FPy IR.
 from .const_fold import ConstFold
 from .copy_propagate import CopyPropagate
 from .dead_code import DeadCodeEliminate
+from .enumerate_elim import EnumerateElim
 from .for_bundling import ForBundling
 from .for_unpack import ForUnpack
 from .for_unroll import ForUnroll, ForUnrollStrategy

--- a/fpy2/transform/enumerate_elim.py
+++ b/fpy2/transform/enumerate_elim.py
@@ -1,126 +1,81 @@
 """
 Rewrite ``enumerate(...)`` iterables into indexed loops over the source
-vector, removing the need for any backend to materialize an intermediate
-list of ``(index, element)`` tuples.
-
-Two patterns are recognized:
+vector, so no backend has to materialize an intermediate list of
+``(index, element)`` tuples.
 
 1. **For-loop over enumerate.**
 
    .. code-block:: python
 
-      for i, x in enumerate(xs):
-          BODY
+      for i, x in enumerate(xs):   ->   _src0 = xs
+          BODY                          for i in range(len(_src0)):
+                                            x = _src0[i]
+                                            BODY
 
-   is rewritten to::
-
-      _src0 = xs
-      for i in range(len(_src0)):
-          x = _src0[i]
-          BODY
-
-   The index slot needs no per-iteration assignment: ``enumerate`` yields
-   exactly the counter ``range(len(...))`` already produces, so the user's
-   own name becomes the loop variable.  The source temporary preserves
-   "evaluate the iterable exactly once" semantics and keeps the loop bound
-   from being re-read through a name the body rebinds.  An underscore
-   element slot emits no assignment, but its source is still bound to a temp
-   so any side-effect in it fires exactly once.
+   The index slot gets no assignment: ``enumerate``'s index and
+   ``range(len(...))``'s counter are the same value, so the user's own name
+   becomes the loop variable.  The ``_src0`` temp evaluates the iterable
+   exactly once and keeps the loop bound out of reach of a body that rebinds
+   the source name.  A discarded element slot emits no assignment, but its
+   source is still bound so any side-effect fires once.
 
 2. **List comp over enumerate**, when the source is an access path.
 
    .. code-block:: python
 
-      [elt for i, x in enumerate(xs)]
+      [elt for i, x in enumerate(xs)]   ->   [elt[x -> xs[i]] for i in range(len(xs))]
 
-   is rewritten to::
+   The substitution is scope-aware: a nested comprehension that re-binds
+   ``x`` shadows it, and those uses are left alone.
 
-      [elt[x -> xs[i]] for i in range(len(xs))]
-
-   The substitution is scope-aware: if ``elt`` contains a nested
-   comprehension that re-binds ``x``, the shadowed uses are not rewritten.
-
-   Restriction: the ``enumerate`` argument must be an access path (a ``Var``
-   or a pure O(1) projection/index chain over one).  A list comprehension is
-   an expression with no statement-level "preamble" to host the
-   ``_src0 = ...`` binding, so the source is inlined and re-evaluated once
-   per iteration — sound only when that is free of side effects and O(1).
-   Comps over a non-access-path source are left alone for the backend to
-   materialize.
+   A comprehension is an expression with no statement slot to host the
+   ``_src0 = ...`` binding, so the source is inlined and re-evaluated per
+   iteration.  That is only sound for an ``is_access_path`` — pure and O(1);
+   anything else is left for the backend to materialize.
 
 Composing with ``zip``
 ----------------------
 
-``enumerate(zip(...))`` is the case worth special-casing: lowered naively it
-builds *two* intermediate lists, the ``zip``'s list of tuples and the
-``enumerate``'s list of ``(index, tuple)`` pairs.  When the element slot
-destructures the ``zip`` positionally, both disappear at once — the transform
-indexes the ``zip``'s own arguments directly:
+``enumerate(zip(...))`` lowered naively builds *two* lists: the ``zip``'s
+tuples and the ``enumerate``'s ``(index, tuple)`` pairs.  Indexing the
+``zip``'s own arguments removes both at once:
 
 .. code-block:: python
 
-   for i, (a, b) in enumerate(zip(xs, ys)):
-       BODY
+   for i, (a, b) in enumerate(zip(xs, ys)):   ->   _src0 = xs
+       BODY                                        _src1 = ys
+                                                   for i in range(len(_src0)):
+                                                       a = _src0[i]
+                                                       b = _src1[i]
+                                                       BODY
 
-becomes::
+This has to happen here rather than in :class:`fpy2.transform.ZipElim`, which
+matches a ``zip`` in *iterable* position: after a plain ``enumerate`` rewrite
+the ``zip`` sits on the right-hand side of ``_src0 = zip(xs, ys)``, out of its
+reach.  Taking the bound from the first argument matches ``ZipElim`` and is
+faithful because FPy's ``zip`` is strict.
 
-   _src0 = xs
-   _src1 = ys
-   for i in range(len(_src0)):
-       a = _src0[i]
-       b = _src1[i]
-       BODY
+A slot bound to the *whole* tuple gets it rebuilt per iteration instead —
+``p = (_src0[i], _src1[i])``, one stack tuple rather than a list of them — and
+the comp path substitutes ``p -> (xs[i], ys[i])``.  Neither inlines the
+``zip`` itself, only one access path per source plus a tuple construction, so
+both stay pure and O(1) per element.
 
-This has to happen here rather than being left to
-:class:`fpy2.transform.ZipElim`: that transform matches a ``zip`` in an
-*iterable* position, and after a plain ``enumerate`` rewrite the ``zip`` sits
-on the right-hand side of ``_src0 = zip(xs, ys)``, where nothing reaches it.
-Taking the length from the first ``zip`` argument matches ``ZipElim`` and is
-faithful because FPy's ``zip`` is strict — it requires every input to have
-the same length.
+The one shape left materialized is an element slot whose arity *disagrees*
+with the ``zip``'s.  That program is already ill-typed, and keeping the
+``zip`` keeps its diagnostic rather than trading it for an arity-mismatched
+destructure.
 
-An element slot bound to the *whole* tuple keeps the same treatment — the
-tuple is simply rebuilt per iteration from the indexed sources, which costs
-one stack tuple instead of an n-element list of them::
-
-   for i, p in enumerate(zip(xs, ys)):   ->   _src0 = xs
-       BODY                                   _src1 = ys
-                                              for i in range(len(_src0)):
-                                                  p = (_src0[i], _src1[i])
-                                                  BODY
-
-and when the slot is a discard there is nothing to rebuild at all: the
-sources stay bound for their side-effects and their length, and the loop body
-is untouched.  The comp path does the same by substituting
-``p -> (xs[i], ys[i])``.  Note this never inlines the ``zip`` itself — it
-inlines one access path per source plus a tuple construction, so it stays
-pure and O(1) per element.
-
-The one shape left materialized is an element slot that is a
-``TupleBinding`` of arity *different* from the ``zip``'s: only the
-``enumerate`` is eliminated and ``_src0 = zip(xs, ys)`` survives.  Such a
-program is already ill-typed, and keeping the ``zip`` keeps its diagnostic
-rather than trading it for an arity-mismatched destructure.
-
-Nested binding slots
---------------------
-
-An element slot may itself be a nested ``TupleBinding``, e.g.
-``for i, (a, b) in enumerate(pairs)``.  In the for-loop path it lowers to a
-destructuring assignment ``(a, b) = _src0[i]`` of any arity.  In the comp
-path — which has no statement context — each leaf is reached by an
-``fst``/``snd`` chain, which is pair-only, so such a slot is rewritten only
-when it (and anything nested within it) is a pair; see
+A slot may also be a nested ``TupleBinding`` (``for i, (a, b) in
+enumerate(pairs)``).  The for-loop path lowers it to a destructuring assign of
+any arity; the comp path reaches its leaves by ``fst``/``snd``, which is
+pair-only — see
 :func:`fpy2.transform.iter_elim.comp_binding_is_pairs`.
 
-Ordering note: run :class:`EnumerateElim` *before*
-:class:`fpy2.transform.ForUnpack`, for the same reason as ``ZipElim`` —
-``ForUnpack`` rewrites ``for (i, x) in iter:`` into
-``for t in iter: i, x = t``, whose :class:`NamedId` target defeats this
-transform's guard.
-
-See :mod:`fpy2.transform.iter_elim` for the machinery this shares with
-:class:`fpy2.transform.ZipElim`.
+Ordering: run this *before* :class:`fpy2.transform.ForUnpack`, which rewrites
+``for (i, x) in iter:`` into ``for t in iter: i, x = t``, whose ``NamedId``
+target defeats the guard below.  See :mod:`fpy2.transform.iter_elim` for the
+machinery shared with :class:`fpy2.transform.ZipElim`.
 """
 
 import dataclasses
@@ -185,37 +140,28 @@ def _split_target(
 
 @dataclasses.dataclass
 class _Plan:
-    """How each iteration's element is reached from the indexed sources.
+    """Which sources to index, and which bindings read them.
 
-    ``args`` are the expressions to index; ``args[0]`` also supplies the loop
-    bound.  ``slots`` are the bindings to assign.  Two shapes:
-
-    * ``tupled=False`` — one slot per source, read as ``args[k][i]``.  Covers
-      plain ``enumerate(xs)`` (one source, one slot) and an
-      ``enumerate(zip(...))`` whose element slot destructures the ``zip``
-      positionally (N of each).
-    * ``tupled=True`` — a single slot reading the whole element, rebuilt per
-      iteration as ``(args[0][i], ..., args[n][i])``.
+    ``args[0]`` also supplies the loop bound.  With ``tupled``, one slot reads
+    the whole element — rebuilt as ``(args[0][i], ..., args[n][i])``; without
+    it, each slot reads its own ``args[k][i]``.
     """
     args: list[Expr]
     slots: list[_Slot]
     tupled: bool
 
     def __post_init__(self):
-        assert self.args, 'a plan needs a source to take the bound from'
+        assert self.args, 'need a source for the bound'
         assert len(self.slots) == (1 if self.tupled else len(self.args))
 
 
 def _plan(src: Expr, elt: _Slot) -> _Plan:
     """How to reach the element bound by *elt* when iterating ``enumerate(src)``.
 
-    For ``enumerate(zip(a, b))`` the sources are the ``zip``'s own arguments,
-    so neither intermediate list is built: an element slot that destructures
-    the ``zip`` positionally reads one source each, and a slot bound to the
-    whole tuple has it rebuilt per iteration.  Otherwise the source is the
-    ``enumerate`` argument itself, read by the element slot as a whole.
+    A ``zip`` source decomposes into its own arguments, so neither
+    intermediate list is built.  Anything else is indexed whole.
     """
-    # ``zip()`` has no source to take the length from.
+    # ``zip()`` has no source to take the bound from.
     if isinstance(src, Zip) and src.args:
         if (
             isinstance(elt, TupleBinding)
@@ -227,20 +173,14 @@ def _plan(src: Expr, elt: _Slot) -> _Plan:
         ):
             return _Plan(list(src.args), list(elt.elts), tupled=False)
         if isinstance(elt, (NamedId, UnderscoreId)):
-            # One name (or a discard) standing for the whole zipped tuple.
-            # A `TupleBinding` of *mismatched* arity deliberately falls
-            # through instead: that program is already ill-typed, and
-            # materializing the `zip` keeps its diagnostic rather than
-            # trading it for an arity-mismatched destructure.
             return _Plan(list(src.args), [elt], tupled=True)
+        # A `TupleBinding` of mismatched arity falls through: see the module
+        # docstring on why the `zip` is left materialized.
     return _Plan([src], [elt], tupled=False)
 
 
 class _EnumerateElimInstance(DefaultTransformVisitor):
     """Single-use visitor that drives the rewrite."""
-
-    func: FuncDef
-    gensym: Gensym
 
     def __init__(self, func: FuncDef, def_use: DefineUseAnalysis):
         super().__init__()
@@ -251,10 +191,8 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
         return self._visit_function(self.func, None)
 
     def _index_name(self, idx: Id) -> NamedId:
-        """The counter standing in for the index slot.  A named slot *is* the
-        counter — ``enumerate``'s index and ``range(len(...))``'s counter are
-        the same value — so no copy is needed; a discarded slot gets a fresh
-        name nothing reads."""
+        """The counter standing in for the index slot: a named slot *is* the
+        counter, a discarded one gets a fresh name nothing reads."""
         if isinstance(idx, NamedId):
             return idx
         return self.gensym.fresh('_i')
@@ -263,9 +201,7 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
     # Block walk with stmt → stmts expansion
 
     def _visit_block(self, block: StmtBlock, ctx: Any):
-        # Local Ctx so each block has its own preamble buffer; the outer
-        # caller's ctx (if any) is irrelevant — preambles always belong to
-        # the block introducing them.
+        # A local Ctx per block: preambles belong to the block introducing them.
         block_ctx = Ctx.default()
         for stmt in block.stmts:
             new_stmt, _ = self._visit_statement(stmt, block_ctx)
@@ -295,9 +231,8 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
         idx_slot, elt_slot = split
         plan = _plan(stmt.iterable.arg, elt_slot)
 
-        # Bind each source to a fresh ``_srcK`` before the loop.  Even a
-        # discarded slot's source gets a temp, so any side-effect in it fires
-        # exactly once.
+        # Bind each source to a fresh `_srcK` before the loop — a discarded
+        # slot's source too, so any side-effect in it still fires once.
         src_names: list[NamedId] = []
         for arg in plan.args:
             src = self.gensym.fresh('_src')
@@ -305,50 +240,23 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
             src_names.append(src)
 
         idx = self._index_name(idx_slot)
+        # A tupled plan feeds every source into one slot; otherwise each slot
+        # reads its own.  `plan.tupled` is the discriminator, not the source
+        # count: `zip(xs)` is tupled over one source and still yields 1-tuples.
+        groups = [src_names] if plan.tupled else [[s] for s in src_names]
         per_iter: list[Stmt] = []
-        if plan.tupled:
-            # One slot for the whole zipped element: rebuild it per iteration
-            # from the indexed sources, so the list of tuples is never built.
-            # A discard reads nothing — the sources stay bound only for their
-            # side-effects and their length.
-            slot = plan.slots[0]
-            if isinstance(slot, NamedId):
-                elts = [
-                    ListRef(Var(src, None), Var(idx, None), None)
-                    for src in src_names
-                ]
-                per_iter.append(Assign(slot, None, TupleExpr(elts, None), None))
-        else:
-            # One per-iteration assignment per non-discarded slot.
-            for slot, src in zip(plan.slots, src_names):
-                match slot:
-                    case UnderscoreId():
-                        continue
-                    case NamedId() | TupleBinding():
-                        # ``NamedId`` -> ``x = src[i]``; a nested
-                        # ``TupleBinding`` -> ``(a, b) = src[i]``, whose
-                        # destructuring the backends already lower (a statement
-                        # context needs no ``fst``/``snd``).
-                        per_iter.append(
-                            Assign(
-                                slot, None,
-                                ListRef(Var(src, None), Var(idx, None), None),
-                                None,
-                            )
-                        )
-                    case _:
-                        # Ruled out by `_split_target` / `_plan`, but stay
-                        # defensive.
-                        raise RuntimeError(
-                            'unexpected binding element in enumerate target: '
-                            f'{slot!r}'
-                        )
+        for slot, srcs in zip(plan.slots, groups):
+            if isinstance(slot, UnderscoreId):
+                continue
+            refs = [ListRef(Var(s, None), Var(idx, None), None) for s in srcs]
+            # A nested slot becomes `(a, b) = src[i]` — the backends already
+            # destructure, so a statement context needs no `fst`/`snd`.
+            value = TupleExpr(refs, None) if plan.tupled else refs[0]
+            per_iter.append(Assign(slot, None, value, None))
 
-        # Iterable: ``range(len(_src0))``.
-        size_expr = Len(None, Var(src_names[0], None), None)
         return ForStmt(
             idx,
-            Range1(None, size_expr, None),
+            Range1(None, Len(None, Var(src_names[0], None), None), None),
             StmtBlock(per_iter + list(new_body.stmts)),
             stmt.loc,
         )
@@ -357,10 +265,6 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
     # List comprehensions
 
     def _visit_list_comp(self, e: ListComp, ctx: Any):
-        # Walk the comp's (target, iterable) pairs, rewriting every enumerate
-        # stage whose sources are access paths.  Non-matching stages pass
-        # through.  Accumulated substitutions apply to the ``elt`` and to any
-        # later stage's iterable.
         new_targets: list[Id | TupleBinding] = []
         new_iterables: list[Expr] = []
         subst: dict[NamedId, Expr] = {}
@@ -368,7 +272,7 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
         for target, iterable in zip(e.targets, e.iterables):
             new_iter = self._visit_expr(iterable, ctx)
             # A later stage's iterable may reference an earlier stage's target
-            # (``[... for i, x in enumerate(xs) for y in x]``), whose name no
+            # (`[... for i, x in enumerate(xs) for y in x]`), whose name no
             # longer exists once that stage is rewritten.
             if subst:
                 new_iter = SubstNames(subst)._visit_expr(new_iter, ctx)
@@ -381,8 +285,8 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
                 new_targets.append(new_target)
                 new_iterables.append(new_iterable)
 
-        # Substitute names in ``elt`` after walking it normally (so nested
-        # enumerate patterns inside the elt are also rewritten).
+        # Walk `elt` normally first, so nested enumerate patterns inside it are
+        # rewritten too, then substitute.
         new_elt = self._visit_expr(e.elt, ctx)
         if subst:
             new_elt = SubstNames(subst)._visit_expr(new_elt, ctx)
@@ -404,41 +308,30 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
         idx_slot, elt_slot = split
         plan = _plan(iterable.arg, elt_slot)
 
-        # Every source is inlined into the comp body and re-evaluated per
-        # iteration (no preamble to bind it once), so it must be pure and
-        # O(1).  This is also what rules out a `zip` source that `_plan` left
-        # un-decomposed: inlining it would rebuild the whole list per element.
+        # Sources are inlined and re-evaluated per iteration, so each must be
+        # pure and O(1).  This is also what rules out a `zip` source `_plan`
+        # left whole: inlining it would rebuild the list per element.
         if not all(is_access_path(a) for a in plan.args):
             return None
 
         idx = self._index_name(idx_slot)
         if plan.tupled:
-            # The whole zipped element, rebuilt per iteration.  This is *not*
-            # inlining the `zip` — it is a tuple over one access path per
-            # source, so it stays pure and O(1).  `comp_binding_is_pairs` has
-            # nothing to say here: a whole-element slot is a name or a discard,
-            # reached without any `fst`/`snd` chain.
+            # A whole-element slot is a name or a discard, so no `fst`/`snd`
+            # chain is involved and `comp_binding_is_pairs` has nothing to say.
             slot = plan.slots[0]
             if isinstance(slot, NamedId):
                 subst[slot] = TupleExpr(
                     [index_access(arg, idx)() for arg in plan.args], None,
                 )
         else:
-            # ``fst``/``snd`` are pair-only, so a destructuring slot of
-            # arity != 2 can't be reached by the comp path's accessor chains;
-            # leave the stage alone rather than emit an ill-typed
-            # ``snd``-of-non-pair.
+            # `fst`/`snd` are pair-only, so a destructuring slot of arity != 2
+            # can't be reached; leave the stage rather than emit an ill-typed
+            # `snd`-of-non-pair.
             if not all(comp_binding_is_pairs(slot) for slot in plan.slots):
                 return None
-            # Substitute each element slot with an accessor into its source:
-            # ``name -> arg[idx]`` for a plain slot, and the ``fst``/``snd``
-            # chain for a nested tuple binding (whose element is itself a
-            # tuple).
             for slot, arg in zip(plan.slots, plan.args):
                 destructure_subst(slot, index_access(arg, idx), subst)
-        # New target/iterable: ``i in range(len(arg0))``.
-        len_expr = Len(None, clone(plan.args[0]), None)
-        return idx, Range1(None, len_expr, None)
+        return idx, Range1(None, Len(None, clone(plan.args[0]), None), None)
 
 
 class EnumerateElim:

--- a/fpy2/transform/enumerate_elim.py
+++ b/fpy2/transform/enumerate_elim.py
@@ -79,13 +79,28 @@ Taking the length from the first ``zip`` argument matches ``ZipElim`` and is
 faithful because FPy's ``zip`` is strict — it requires every input to have
 the same length.
 
-When the element slot does *not* destructure the ``zip`` positionally — it is
-a single name bound to the whole tuple, or a binding of mismatched arity —
-only the ``enumerate`` is eliminated (``_src0 = zip(xs, ys)``) and the
-``zip``'s list is still materialized.  That is no worse than before:
-``ZipElim`` does not fire on such a pattern either.  The comp path skips the
-fallback entirely, since a ``zip`` is not an access path and inlining it
-would make every iteration rebuild the whole list.
+An element slot bound to the *whole* tuple keeps the same treatment — the
+tuple is simply rebuilt per iteration from the indexed sources, which costs
+one stack tuple instead of an n-element list of them::
+
+   for i, p in enumerate(zip(xs, ys)):   ->   _src0 = xs
+       BODY                                   _src1 = ys
+                                              for i in range(len(_src0)):
+                                                  p = (_src0[i], _src1[i])
+                                                  BODY
+
+and when the slot is a discard there is nothing to rebuild at all: the
+sources stay bound for their side-effects and their length, and the loop body
+is untouched.  The comp path does the same by substituting
+``p -> (xs[i], ys[i])``.  Note this never inlines the ``zip`` itself — it
+inlines one access path per source plus a tuple construction, so it stays
+pure and O(1) per element.
+
+The one shape left materialized is an element slot that is a
+``TupleBinding`` of arity *different* from the ``zip``'s: only the
+``enumerate`` is eliminated and ``_src0 = zip(xs, ys)`` survives.  Such a
+program is already ill-typed, and keeping the ``zip`` keeps its diagnostic
+rather than trading it for an arity-mismatched destructure.
 
 Nested binding slots
 --------------------
@@ -108,6 +123,7 @@ See :mod:`fpy2.transform.iter_elim` for the machinery this shares with
 :class:`fpy2.transform.ZipElim`.
 """
 
+import dataclasses
 from typing import Any
 
 from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
@@ -125,6 +141,7 @@ from ..ast.fpyast import (
     Stmt,
     StmtBlock,
     TupleBinding,
+    TupleExpr,
     UnderscoreId,
     Var,
     Zip,
@@ -166,27 +183,57 @@ def _split_target(
     return idx, elt
 
 
-def _sources(src: Expr, elt: _Slot) -> tuple[list[Expr], list[_Slot]]:
-    """The per-slot sources to index, paired with the slots reading them.
+@dataclasses.dataclass
+class _Plan:
+    """How each iteration's element is reached from the indexed sources.
 
-    For ``enumerate(zip(a, b))`` whose element slot destructures the ``zip``
-    positionally, these are the ``zip``'s own arguments — so neither
-    intermediate list is built.  Otherwise it is the ``enumerate`` argument
-    itself, read by the element slot as a whole.
+    ``args`` are the expressions to index; ``args[0]`` also supplies the loop
+    bound.  ``slots`` are the bindings to assign.  Two shapes:
+
+    * ``tupled=False`` — one slot per source, read as ``args[k][i]``.  Covers
+      plain ``enumerate(xs)`` (one source, one slot) and an
+      ``enumerate(zip(...))`` whose element slot destructures the ``zip``
+      positionally (N of each).
+    * ``tupled=True`` — a single slot reading the whole element, rebuilt per
+      iteration as ``(args[0][i], ..., args[n][i])``.
     """
-    if (
-        isinstance(src, Zip)
-        # ``zip()`` has no source to take the length from.
-        and src.args
-        and isinstance(elt, TupleBinding)
-        and len(elt.elts) == len(src.args)
-        and all(
-            isinstance(e, (NamedId, UnderscoreId, TupleBinding))
-            for e in elt.elts
-        )
-    ):
-        return list(src.args), list(elt.elts)
-    return [src], [elt]
+    args: list[Expr]
+    slots: list[_Slot]
+    tupled: bool
+
+    def __post_init__(self):
+        assert self.args, 'a plan needs a source to take the bound from'
+        assert len(self.slots) == (1 if self.tupled else len(self.args))
+
+
+def _plan(src: Expr, elt: _Slot) -> _Plan:
+    """How to reach the element bound by *elt* when iterating ``enumerate(src)``.
+
+    For ``enumerate(zip(a, b))`` the sources are the ``zip``'s own arguments,
+    so neither intermediate list is built: an element slot that destructures
+    the ``zip`` positionally reads one source each, and a slot bound to the
+    whole tuple has it rebuilt per iteration.  Otherwise the source is the
+    ``enumerate`` argument itself, read by the element slot as a whole.
+    """
+    # ``zip()`` has no source to take the length from.
+    if isinstance(src, Zip) and src.args:
+        if (
+            isinstance(elt, TupleBinding)
+            and len(elt.elts) == len(src.args)
+            and all(
+                isinstance(e, (NamedId, UnderscoreId, TupleBinding))
+                for e in elt.elts
+            )
+        ):
+            return _Plan(list(src.args), list(elt.elts), tupled=False)
+        if isinstance(elt, (NamedId, UnderscoreId)):
+            # One name (or a discard) standing for the whole zipped tuple.
+            # A `TupleBinding` of *mismatched* arity deliberately falls
+            # through instead: that program is already ill-typed, and
+            # materializing the `zip` keeps its diagnostic rather than
+            # trading it for an arity-mismatched destructure.
+            return _Plan(list(src.args), [elt], tupled=True)
+    return _Plan([src], [elt], tupled=False)
 
 
 class _EnumerateElimInstance(DefaultTransformVisitor):
@@ -246,43 +293,56 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
     ) -> ForStmt:
         assert isinstance(stmt.iterable, Enumerate)
         idx_slot, elt_slot = split
-        args, slots = _sources(stmt.iterable.arg, elt_slot)
+        plan = _plan(stmt.iterable.arg, elt_slot)
 
         # Bind each source to a fresh ``_srcK`` before the loop.  Even a
         # discarded slot's source gets a temp, so any side-effect in it fires
         # exactly once.
         src_names: list[NamedId] = []
-        for arg in args:
+        for arg in plan.args:
             src = self.gensym.fresh('_src')
             ctx.stmts.append(Assign(src, None, arg, None))
             src_names.append(src)
 
         idx = self._index_name(idx_slot)
-        # One per-iteration assignment per non-discarded slot.
         per_iter: list[Stmt] = []
-        for slot, src in zip(slots, src_names):
-            match slot:
-                case UnderscoreId():
-                    continue
-                case NamedId() | TupleBinding():
-                    # ``NamedId`` -> ``x = src[i]``; a nested ``TupleBinding``
-                    # -> ``(a, b) = src[i]``, whose destructuring the backends
-                    # already lower (a statement context needs no
-                    # ``fst``/``snd``).
-                    per_iter.append(
-                        Assign(
-                            slot, None,
-                            ListRef(Var(src, None), Var(idx, None), None),
-                            None,
+        if plan.tupled:
+            # One slot for the whole zipped element: rebuild it per iteration
+            # from the indexed sources, so the list of tuples is never built.
+            # A discard reads nothing — the sources stay bound only for their
+            # side-effects and their length.
+            slot = plan.slots[0]
+            if isinstance(slot, NamedId):
+                elts = [
+                    ListRef(Var(src, None), Var(idx, None), None)
+                    for src in src_names
+                ]
+                per_iter.append(Assign(slot, None, TupleExpr(elts, None), None))
+        else:
+            # One per-iteration assignment per non-discarded slot.
+            for slot, src in zip(plan.slots, src_names):
+                match slot:
+                    case UnderscoreId():
+                        continue
+                    case NamedId() | TupleBinding():
+                        # ``NamedId`` -> ``x = src[i]``; a nested
+                        # ``TupleBinding`` -> ``(a, b) = src[i]``, whose
+                        # destructuring the backends already lower (a statement
+                        # context needs no ``fst``/``snd``).
+                        per_iter.append(
+                            Assign(
+                                slot, None,
+                                ListRef(Var(src, None), Var(idx, None), None),
+                                None,
+                            )
                         )
-                    )
-                case _:
-                    # Ruled out by `_split_target` / `_sources`, but stay
-                    # defensive.
-                    raise RuntimeError(
-                        'unexpected binding element in enumerate target: '
-                        f'{slot!r}'
-                    )
+                    case _:
+                        # Ruled out by `_split_target` / `_plan`, but stay
+                        # defensive.
+                        raise RuntimeError(
+                            'unexpected binding element in enumerate target: '
+                            f'{slot!r}'
+                        )
 
         # Iterable: ``range(len(_src0))``.
         size_expr = Len(None, Var(src_names[0], None), None)
@@ -342,28 +402,42 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
             return None
         assert isinstance(iterable, Enumerate)
         idx_slot, elt_slot = split
-        args, slots = _sources(iterable.arg, elt_slot)
+        plan = _plan(iterable.arg, elt_slot)
 
         # Every source is inlined into the comp body and re-evaluated per
         # iteration (no preamble to bind it once), so it must be pure and
-        # O(1).  This also rules out the ``enumerate(zip(...))`` fallback,
-        # whose single source is the ``zip`` itself.
-        if not all(is_access_path(a) for a in args):
-            return None
-        # ``fst``/``snd`` are pair-only, so a destructuring slot of arity != 2
-        # can't be reached by the comp path's accessor chains; leave the stage
-        # alone rather than emit an ill-typed ``snd``-of-non-pair.
-        if not all(comp_binding_is_pairs(slot) for slot in slots):
+        # O(1).  This is also what rules out a `zip` source that `_plan` left
+        # un-decomposed: inlining it would rebuild the whole list per element.
+        if not all(is_access_path(a) for a in plan.args):
             return None
 
         idx = self._index_name(idx_slot)
-        # Substitute each element slot with an accessor into its source:
-        # ``name -> arg[idx]`` for a plain slot, and the ``fst``/``snd`` chain
-        # for a nested tuple binding (whose element is itself a tuple).
-        for slot, arg in zip(slots, args):
-            destructure_subst(slot, index_access(arg, idx), subst)
+        if plan.tupled:
+            # The whole zipped element, rebuilt per iteration.  This is *not*
+            # inlining the `zip` — it is a tuple over one access path per
+            # source, so it stays pure and O(1).  `comp_binding_is_pairs` has
+            # nothing to say here: a whole-element slot is a name or a discard,
+            # reached without any `fst`/`snd` chain.
+            slot = plan.slots[0]
+            if isinstance(slot, NamedId):
+                subst[slot] = TupleExpr(
+                    [index_access(arg, idx)() for arg in plan.args], None,
+                )
+        else:
+            # ``fst``/``snd`` are pair-only, so a destructuring slot of
+            # arity != 2 can't be reached by the comp path's accessor chains;
+            # leave the stage alone rather than emit an ill-typed
+            # ``snd``-of-non-pair.
+            if not all(comp_binding_is_pairs(slot) for slot in plan.slots):
+                return None
+            # Substitute each element slot with an accessor into its source:
+            # ``name -> arg[idx]`` for a plain slot, and the ``fst``/``snd``
+            # chain for a nested tuple binding (whose element is itself a
+            # tuple).
+            for slot, arg in zip(plan.slots, plan.args):
+                destructure_subst(slot, index_access(arg, idx), subst)
         # New target/iterable: ``i in range(len(arg0))``.
-        len_expr = Len(None, clone(args[0]), None)
+        len_expr = Len(None, clone(plan.args[0]), None)
         return idx, Range1(None, len_expr, None)
 
 

--- a/fpy2/transform/enumerate_elim.py
+++ b/fpy2/transform/enumerate_elim.py
@@ -1,0 +1,386 @@
+"""
+Rewrite ``enumerate(...)`` iterables into indexed loops over the source
+vector, removing the need for any backend to materialize an intermediate
+list of ``(index, element)`` tuples.
+
+Two patterns are recognized:
+
+1. **For-loop over enumerate.**
+
+   .. code-block:: python
+
+      for i, x in enumerate(xs):
+          BODY
+
+   is rewritten to::
+
+      _src0 = xs
+      for i in range(len(_src0)):
+          x = _src0[i]
+          BODY
+
+   The index slot needs no per-iteration assignment: ``enumerate`` yields
+   exactly the counter ``range(len(...))`` already produces, so the user's
+   own name becomes the loop variable.  The source temporary preserves
+   "evaluate the iterable exactly once" semantics and keeps the loop bound
+   from being re-read through a name the body rebinds.  An underscore
+   element slot emits no assignment, but its source is still bound to a temp
+   so any side-effect in it fires exactly once.
+
+2. **List comp over enumerate**, when the source is an access path.
+
+   .. code-block:: python
+
+      [elt for i, x in enumerate(xs)]
+
+   is rewritten to::
+
+      [elt[x -> xs[i]] for i in range(len(xs))]
+
+   The substitution is scope-aware: if ``elt`` contains a nested
+   comprehension that re-binds ``x``, the shadowed uses are not rewritten.
+
+   Restriction: the ``enumerate`` argument must be an access path (a ``Var``
+   or a pure O(1) projection/index chain over one).  A list comprehension is
+   an expression with no statement-level "preamble" to host the
+   ``_src0 = ...`` binding, so the source is inlined and re-evaluated once
+   per iteration — sound only when that is free of side effects and O(1).
+   Comps over a non-access-path source are left alone for the backend to
+   materialize.
+
+Composing with ``zip``
+----------------------
+
+``enumerate(zip(...))`` is the case worth special-casing: lowered naively it
+builds *two* intermediate lists, the ``zip``'s list of tuples and the
+``enumerate``'s list of ``(index, tuple)`` pairs.  When the element slot
+destructures the ``zip`` positionally, both disappear at once — the transform
+indexes the ``zip``'s own arguments directly:
+
+.. code-block:: python
+
+   for i, (a, b) in enumerate(zip(xs, ys)):
+       BODY
+
+becomes::
+
+   _src0 = xs
+   _src1 = ys
+   for i in range(len(_src0)):
+       a = _src0[i]
+       b = _src1[i]
+       BODY
+
+This has to happen here rather than being left to
+:class:`fpy2.transform.ZipElim`: that transform matches a ``zip`` in an
+*iterable* position, and after a plain ``enumerate`` rewrite the ``zip`` sits
+on the right-hand side of ``_src0 = zip(xs, ys)``, where nothing reaches it.
+Taking the length from the first ``zip`` argument matches ``ZipElim`` and is
+faithful because FPy's ``zip`` is strict — it requires every input to have
+the same length.
+
+When the element slot does *not* destructure the ``zip`` positionally — it is
+a single name bound to the whole tuple, or a binding of mismatched arity —
+only the ``enumerate`` is eliminated (``_src0 = zip(xs, ys)``) and the
+``zip``'s list is still materialized.  That is no worse than before:
+``ZipElim`` does not fire on such a pattern either.  The comp path skips the
+fallback entirely, since a ``zip`` is not an access path and inlining it
+would make every iteration rebuild the whole list.
+
+Nested binding slots
+--------------------
+
+An element slot may itself be a nested ``TupleBinding``, e.g.
+``for i, (a, b) in enumerate(pairs)``.  In the for-loop path it lowers to a
+destructuring assignment ``(a, b) = _src0[i]`` of any arity.  In the comp
+path — which has no statement context — each leaf is reached by an
+``fst``/``snd`` chain, which is pair-only, so such a slot is rewritten only
+when it (and anything nested within it) is a pair; see
+:func:`fpy2.transform.iter_elim.comp_binding_is_pairs`.
+
+Ordering note: run :class:`EnumerateElim` *before*
+:class:`fpy2.transform.ForUnpack`, for the same reason as ``ZipElim`` —
+``ForUnpack`` rewrites ``for (i, x) in iter:`` into
+``for t in iter: i, x = t``, whose :class:`NamedId` target defeats this
+transform's guard.
+
+See :mod:`fpy2.transform.iter_elim` for the machinery this shares with
+:class:`fpy2.transform.ZipElim`.
+"""
+
+from typing import Any
+
+from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
+from ..ast.fpyast import (
+    Assign,
+    Enumerate,
+    Expr,
+    ForStmt,
+    FuncDef,
+    Len,
+    ListComp,
+    ListRef,
+    NamedId,
+    Range1,
+    Stmt,
+    StmtBlock,
+    TupleBinding,
+    UnderscoreId,
+    Var,
+    Zip,
+)
+from ..ast.visitor import DefaultTransformVisitor
+from ..utils import Gensym, Id
+from .iter_elim import (
+    Ctx,
+    SubstNames,
+    clone,
+    comp_binding_is_pairs,
+    destructure_subst,
+    index_access,
+    is_access_path,
+)
+
+# An element binding slot: a name, a discard, or a nested destructure.
+_Slot = Id | TupleBinding
+
+
+def _split_target(
+    target: Id | TupleBinding, iterable: Expr,
+) -> tuple[Id, _Slot] | None:
+    """Split ``for i, x in enumerate(src)``'s target into its index and
+    element slots, or ``None`` if *target* / *iterable* aren't that pattern.
+
+    The index slot must be a plain name or a discard: ``enumerate`` yields an
+    integer there, so a destructuring slot would be ill-typed.
+    """
+    if not isinstance(iterable, Enumerate):
+        return None
+    if not isinstance(target, TupleBinding) or len(target.elts) != 2:
+        return None
+    idx, elt = target.elts
+    if not isinstance(idx, (NamedId, UnderscoreId)):
+        return None
+    if not isinstance(elt, (NamedId, UnderscoreId, TupleBinding)):
+        return None
+    return idx, elt
+
+
+def _sources(src: Expr, elt: _Slot) -> tuple[list[Expr], list[_Slot]]:
+    """The per-slot sources to index, paired with the slots reading them.
+
+    For ``enumerate(zip(a, b))`` whose element slot destructures the ``zip``
+    positionally, these are the ``zip``'s own arguments — so neither
+    intermediate list is built.  Otherwise it is the ``enumerate`` argument
+    itself, read by the element slot as a whole.
+    """
+    if (
+        isinstance(src, Zip)
+        # ``zip()`` has no source to take the length from.
+        and src.args
+        and isinstance(elt, TupleBinding)
+        and len(elt.elts) == len(src.args)
+        and all(
+            isinstance(e, (NamedId, UnderscoreId, TupleBinding))
+            for e in elt.elts
+        )
+    ):
+        return list(src.args), list(elt.elts)
+    return [src], [elt]
+
+
+class _EnumerateElimInstance(DefaultTransformVisitor):
+    """Single-use visitor that drives the rewrite."""
+
+    func: FuncDef
+    gensym: Gensym
+
+    def __init__(self, func: FuncDef, def_use: DefineUseAnalysis):
+        super().__init__()
+        self.func = func
+        self.gensym = Gensym(reserved=def_use.names())
+
+    def apply(self) -> FuncDef:
+        return self._visit_function(self.func, None)
+
+    def _index_name(self, idx: Id) -> NamedId:
+        """The counter standing in for the index slot.  A named slot *is* the
+        counter — ``enumerate``'s index and ``range(len(...))``'s counter are
+        the same value — so no copy is needed; a discarded slot gets a fresh
+        name nothing reads."""
+        if isinstance(idx, NamedId):
+            return idx
+        return self.gensym.fresh('_i')
+
+    # ------------------------------------------------------------------
+    # Block walk with stmt → stmts expansion
+
+    def _visit_block(self, block: StmtBlock, ctx: Any):
+        # Local Ctx so each block has its own preamble buffer; the outer
+        # caller's ctx (if any) is irrelevant — preambles always belong to
+        # the block introducing them.
+        block_ctx = Ctx.default()
+        for stmt in block.stmts:
+            new_stmt, _ = self._visit_statement(stmt, block_ctx)
+            block_ctx.stmts.append(new_stmt)
+        return StmtBlock(block_ctx.stmts), ctx
+
+    # ------------------------------------------------------------------
+    # For loops
+
+    def _visit_for(self, stmt: ForStmt, ctx: Ctx):
+        split = _split_target(stmt.target, stmt.iterable)
+        if split is None:
+            return super()._visit_for(stmt, ctx)
+        # Recursively rewrite the body first, in case it contains nested
+        # enumerate patterns.
+        body, _ = self._visit_block(stmt.body, ctx)
+        return self._rewrite_for(stmt, split, body, ctx), ctx
+
+    def _rewrite_for(
+        self,
+        stmt: ForStmt,
+        split: tuple[Id, _Slot],
+        new_body: StmtBlock,
+        ctx: Ctx,
+    ) -> ForStmt:
+        assert isinstance(stmt.iterable, Enumerate)
+        idx_slot, elt_slot = split
+        args, slots = _sources(stmt.iterable.arg, elt_slot)
+
+        # Bind each source to a fresh ``_srcK`` before the loop.  Even a
+        # discarded slot's source gets a temp, so any side-effect in it fires
+        # exactly once.
+        src_names: list[NamedId] = []
+        for arg in args:
+            src = self.gensym.fresh('_src')
+            ctx.stmts.append(Assign(src, None, arg, None))
+            src_names.append(src)
+
+        idx = self._index_name(idx_slot)
+        # One per-iteration assignment per non-discarded slot.
+        per_iter: list[Stmt] = []
+        for slot, src in zip(slots, src_names):
+            match slot:
+                case UnderscoreId():
+                    continue
+                case NamedId() | TupleBinding():
+                    # ``NamedId`` -> ``x = src[i]``; a nested ``TupleBinding``
+                    # -> ``(a, b) = src[i]``, whose destructuring the backends
+                    # already lower (a statement context needs no
+                    # ``fst``/``snd``).
+                    per_iter.append(
+                        Assign(
+                            slot, None,
+                            ListRef(Var(src, None), Var(idx, None), None),
+                            None,
+                        )
+                    )
+                case _:
+                    # Ruled out by `_split_target` / `_sources`, but stay
+                    # defensive.
+                    raise RuntimeError(
+                        'unexpected binding element in enumerate target: '
+                        f'{slot!r}'
+                    )
+
+        # Iterable: ``range(len(_src0))``.
+        size_expr = Len(None, Var(src_names[0], None), None)
+        return ForStmt(
+            idx,
+            Range1(None, size_expr, None),
+            StmtBlock(per_iter + list(new_body.stmts)),
+            stmt.loc,
+        )
+
+    # ------------------------------------------------------------------
+    # List comprehensions
+
+    def _visit_list_comp(self, e: ListComp, ctx: Any):
+        # Walk the comp's (target, iterable) pairs, rewriting every enumerate
+        # stage whose sources are access paths.  Non-matching stages pass
+        # through.  Accumulated substitutions apply to the ``elt`` and to any
+        # later stage's iterable.
+        new_targets: list[Id | TupleBinding] = []
+        new_iterables: list[Expr] = []
+        subst: dict[NamedId, Expr] = {}
+
+        for target, iterable in zip(e.targets, e.iterables):
+            new_iter = self._visit_expr(iterable, ctx)
+            # A later stage's iterable may reference an earlier stage's target
+            # (``[... for i, x in enumerate(xs) for y in x]``), whose name no
+            # longer exists once that stage is rewritten.
+            if subst:
+                new_iter = SubstNames(subst)._visit_expr(new_iter, ctx)
+            rewritten = self._rewrite_comp_stage(target, new_iter, subst)
+            if rewritten is None:
+                new_targets.append(self._visit_binding(target, ctx))
+                new_iterables.append(new_iter)
+            else:
+                new_target, new_iterable = rewritten
+                new_targets.append(new_target)
+                new_iterables.append(new_iterable)
+
+        # Substitute names in ``elt`` after walking it normally (so nested
+        # enumerate patterns inside the elt are also rewritten).
+        new_elt = self._visit_expr(e.elt, ctx)
+        if subst:
+            new_elt = SubstNames(subst)._visit_expr(new_elt, ctx)
+        return ListComp(new_targets, new_iterables, new_elt, e.loc)
+
+    def _rewrite_comp_stage(
+        self,
+        target: Id | TupleBinding,
+        iterable: Expr,
+        subst: dict[NamedId, Expr],
+    ) -> tuple[Id, Expr] | None:
+        """The rewritten ``(target, iterable)`` for one comprehension stage,
+        extending *subst* with the accessors its element slot needs; ``None``
+        to leave the stage as it is."""
+        split = _split_target(target, iterable)
+        if split is None:
+            return None
+        assert isinstance(iterable, Enumerate)
+        idx_slot, elt_slot = split
+        args, slots = _sources(iterable.arg, elt_slot)
+
+        # Every source is inlined into the comp body and re-evaluated per
+        # iteration (no preamble to bind it once), so it must be pure and
+        # O(1).  This also rules out the ``enumerate(zip(...))`` fallback,
+        # whose single source is the ``zip`` itself.
+        if not all(is_access_path(a) for a in args):
+            return None
+        # ``fst``/``snd`` are pair-only, so a destructuring slot of arity != 2
+        # can't be reached by the comp path's accessor chains; leave the stage
+        # alone rather than emit an ill-typed ``snd``-of-non-pair.
+        if not all(comp_binding_is_pairs(slot) for slot in slots):
+            return None
+
+        idx = self._index_name(idx_slot)
+        # Substitute each element slot with an accessor into its source:
+        # ``name -> arg[idx]`` for a plain slot, and the ``fst``/``snd`` chain
+        # for a nested tuple binding (whose element is itself a tuple).
+        for slot, arg in zip(slots, args):
+            destructure_subst(slot, index_access(arg, idx), subst)
+        # New target/iterable: ``i in range(len(arg0))``.
+        len_expr = Len(None, clone(args[0]), None)
+        return idx, Range1(None, len_expr, None)
+
+
+class EnumerateElim:
+    """Rewrite ``enumerate(...)`` iterables into indexed loops over the
+    source vector, including the ``enumerate(zip(...))`` case where both
+    intermediate lists collapse into direct indexing.  See the module
+    docstring for the patterns recognized and the ordering constraint with
+    :class:`fpy2.transform.ForUnpack`."""
+
+    @staticmethod
+    def apply(func: FuncDef) -> FuncDef:
+        """Apply the transformation to a :class:`FuncDef`.  Returns a new
+        ``FuncDef``; the input is not mutated."""
+        if not isinstance(func, FuncDef):
+            raise TypeError(f"expected a 'FuncDef', got `{func}`")
+        def_use = DefineUse.analyze(func)
+        out = _EnumerateElimInstance(func, def_use).apply()
+        SyntaxCheck.check(out, ignore_unknown=True)
+        return out

--- a/fpy2/transform/iter_elim.py
+++ b/fpy2/transform/iter_elim.py
@@ -1,0 +1,214 @@
+"""
+Machinery shared by the *iterable-elimination* transforms —
+:class:`fpy2.transform.ZipElim` and :class:`fpy2.transform.EnumerateElim`.
+
+Both rewrite iteration over a *derived* sequence (``zip(...)``,
+``enumerate(...)``) into an indexed traversal of the underlying source
+vectors, so no backend has to materialize the intermediate list of tuples.
+They differ only in which pattern they match and which sources they index;
+everything below is common to both.
+
+Two shapes of rewrite show up in each transform, and they have different
+capabilities:
+
+*Statement (for-loop) path.*  There is a statement slot before the loop, so
+each source can be bound to a fresh ``_srcK`` temporary — evaluated exactly
+once, and immune to the loop body rebinding the name it came from.  A binding
+slot of any arity lowers to a destructuring assignment ``(a, b) = _srcK[_i]``,
+which the backends already handle.  :class:`Ctx` is the accumulator that lets
+a statement visitor emit that preamble.
+
+*Expression (comprehension) path.*  A comprehension has no statement slot, so
+every source is instead *inlined* into the element expression and re-evaluated
+once per iteration.  That forces two restrictions: a source must be an
+:func:`is_access_path` (pure and O(1), so re-evaluation is neither observable
+nor asymptotically costly), and a binding slot that destructures is reached by
+an ``fst``/``snd`` chain — pair-only accessors, hence
+:func:`comp_binding_is_pairs`.  :func:`destructure_subst` builds the
+substitution and :class:`SubstNames` applies it scope-aware.
+
+Anything failing a guard is left alone for the backend to materialize.
+"""
+
+import dataclasses
+from collections.abc import Callable
+from typing import Any
+
+from ..ast.fpyast import (
+    Expr,
+    Fst,
+    Integer,
+    ListComp,
+    ListRef,
+    NamedId,
+    Snd,
+    Stmt,
+    TupleBinding,
+    UnderscoreId,
+    Var,
+)
+from ..ast.visitor import DefaultTransformVisitor
+from ..utils import Id
+
+
+@dataclasses.dataclass
+class Ctx:
+    """Block-walk accumulator.  When a statement visitor decides to rewrite a
+    statement, it appends the ``_srcK = ...`` preamble assignments to ``stmts``
+    and returns the rewritten statement; the block visitor then appends that,
+    producing one-to-many statement expansion without a custom statement
+    visitor."""
+    stmts: list[Stmt]
+
+    @staticmethod
+    def default() -> 'Ctx':
+        return Ctx(stmts=[])
+
+
+def is_access_path(e: Expr) -> bool:
+    """Whether *e* is safe to inline into a comprehension body (re-evaluated
+    once per iteration, since a comp has no preamble to bind it once).
+
+    True for a ``Var`` or a pure, O(1) projection/index chain rooted at one
+    (``fst``/``snd``/``arg[i]``): no side effects, same value each time.
+    Excludes allocating/expensive args (slices, calls, a nested ``zip``) whose
+    re-evaluation would turn O(n) into O(n^2); those are left for the backend
+    to materialize.
+    """
+    match e:
+        case Var():
+            return True
+        case Fst() | Snd():
+            return is_access_path(e.arg)
+        case ListRef():
+            return is_access_path(e.value) and is_access_path(e.index)
+        case Integer():                       # a constant index in ``arg[i]``
+            return True
+        case _:
+            return False
+
+
+def clone(e: Expr) -> Expr:
+    """A structurally fresh copy of *e* (no AST shared between substituted
+    occurrences); ``DefaultTransformVisitor`` rebuilds every node."""
+    return DefaultTransformVisitor()._visit_expr(e, None)
+
+
+def index_access(arg: Expr, idx: NamedId) -> Callable[[], Expr]:
+    """A thunk building ``arg[idx]`` with a fresh copy of ``arg`` each call.
+
+    *arg* must be an :func:`is_access_path` (safe to re-evaluate per call)."""
+    return lambda: ListRef(clone(arg), Var(idx, None), None)
+
+
+def fst(arg: Expr) -> Expr:
+    """Build ``fst(arg)``."""
+    return Fst(None, arg, None)
+
+
+def snd(arg: Expr) -> Expr:
+    """Build ``snd(arg)``."""
+    return Snd(None, arg, None)
+
+
+def comp_binding_is_pairs(binding: Id | TupleBinding) -> bool:
+    """Whether the comprehension path can lower the binding *slot* *binding*.
+
+    A slot's own value is reached by direct indexing (``srcK[_i]``), but a slot
+    that *destructures* has its leaves reached by an ``fst``/``snd`` chain (see
+    :func:`destructure_subst`), and those accessors are pair-only.  So a
+    ``TupleBinding`` slot — and every binding nested within it — must have
+    arity 2.  A plain name or an underscore needs no accessor at all.
+
+    The enclosing target is not a slot and is exempt: its elements *are* the
+    slots, each reached by its own ``srcK[_i]``.
+    """
+    match binding:
+        case TupleBinding():
+            return (
+                len(binding.elts) == 2
+                and all(comp_binding_is_pairs(e) for e in binding.elts)
+            )
+        case _:
+            return True
+
+
+def destructure_subst(
+    binding: Id | TupleBinding,
+    make_access: Callable[[], Expr],
+    subst: dict[NamedId, Expr],
+) -> None:
+    """Map every :class:`NamedId` in *binding* to an accessor expression.
+
+    *make_access* builds a *fresh* expression for the value bound to
+    *binding* (the per-iteration source element).  It is invoked once per
+    leaf, so no AST node is shared between substitutions.
+    """
+    match binding:
+        case NamedId():
+            subst[binding] = make_access()
+        case UnderscoreId():
+            pass
+        case TupleBinding():
+            # The comp path only reaches a nested slot that is a pair
+            # (guaranteed by `comp_binding_is_pairs`); `fst`/`snd` are its two
+            # projections.
+            assert len(binding.elts) == 2, 'comp-path nested slot must be a pair'
+            head, tail = binding.elts
+            destructure_subst(head, lambda: fst(make_access()), subst)
+            destructure_subst(tail, lambda: snd(make_access()), subst)
+        case _:
+            raise RuntimeError(f'unexpected binding element: {binding!r}')
+
+
+class SubstNames(DefaultTransformVisitor):
+    """Replace every :class:`Var` reference to a name in *subst*
+    with the corresponding expression.  Scope-aware: comprehension
+    targets that shadow a substituted name disable the substitution
+    inside that comprehension's ``elt`` (the inner uses bind to the
+    shadowing iteration variable, not to the outer one).
+    """
+
+    def __init__(self, subst: dict[NamedId, Expr]):
+        super().__init__()
+        # Active substitutions; `_visit_list_comp` shadows/restores entries
+        # around a nested comp that rebinds a substituted name.
+        self._subst = dict(subst)
+
+    def _visit_var(self, e: Var, ctx: Any):
+        # Substitution targets are ``NamedId``s, keyed by structural equality.
+        replacement = self._subst.get(e.name)
+        if replacement is not None:
+            return replacement
+        return super()._visit_var(e, ctx)
+
+    def _visit_list_comp(self, e: ListComp, ctx: Any):
+        # A target NamedId inside this comp shadows any outer
+        # substitution for the same name.  Save the shadowed entries,
+        # disable them, recurse, then restore.
+        shadowed: dict[NamedId, Expr] = {}
+        for target in e.targets:
+            for name in binding_names(target):
+                if name in self._subst:
+                    shadowed[name] = self._subst.pop(name)
+        try:
+            return super()._visit_list_comp(e, ctx)
+        finally:
+            self._subst.update(shadowed)
+
+
+def binding_names(target: Id | TupleBinding) -> list[NamedId]:
+    """Flatten a binding into the named identifiers it binds.  Underscore
+    slots and nested bindings contribute zero or more names."""
+    match target:
+        case NamedId():
+            return [target]
+        case UnderscoreId():
+            return []
+        case TupleBinding():
+            out: list[NamedId] = []
+            for elt in target.elts:
+                out.extend(binding_names(elt))
+            return out
+        case _:
+            return []

--- a/fpy2/transform/iter_elim.py
+++ b/fpy2/transform/iter_elim.py
@@ -1,31 +1,24 @@
 """
 Machinery shared by the *iterable-elimination* transforms —
 :class:`fpy2.transform.ZipElim` and :class:`fpy2.transform.EnumerateElim`.
-
 Both rewrite iteration over a *derived* sequence (``zip(...)``,
-``enumerate(...)``) into an indexed traversal of the underlying source
-vectors, so no backend has to materialize the intermediate list of tuples.
-They differ only in which pattern they match and which sources they index;
-everything below is common to both.
+``enumerate(...)``) into an indexed traversal of the underlying source vectors,
+differing only in which pattern they match and which sources they index.
 
-Two shapes of rewrite show up in each transform, and they have different
-capabilities:
+Each has two paths, with different capabilities:
 
-*Statement (for-loop) path.*  There is a statement slot before the loop, so
-each source can be bound to a fresh ``_srcK`` temporary — evaluated exactly
-once, and immune to the loop body rebinding the name it came from.  A binding
-slot of any arity lowers to a destructuring assignment ``(a, b) = _srcK[_i]``,
-which the backends already handle.  :class:`Ctx` is the accumulator that lets
-a statement visitor emit that preamble.
+*Statement (for-loop) path.*  A statement slot exists before the loop, so each
+source binds to a fresh ``_srcK`` temp — evaluated once, and immune to the body
+rebinding the name it came from.  A binding slot of any arity lowers to a
+destructuring assign the backends already handle.  :class:`Ctx` is what lets a
+statement visitor emit that preamble.
 
-*Expression (comprehension) path.*  A comprehension has no statement slot, so
-every source is instead *inlined* into the element expression and re-evaluated
-once per iteration.  That forces two restrictions: a source must be an
-:func:`is_access_path` (pure and O(1), so re-evaluation is neither observable
-nor asymptotically costly), and a binding slot that destructures is reached by
-an ``fst``/``snd`` chain — pair-only accessors, hence
+*Expression (comprehension) path.*  No statement slot, so sources are *inlined*
+into the element expression and re-evaluated per iteration.  Hence two
+restrictions: a source must be an :func:`is_access_path`, and a destructuring
+slot is reached by a pair-only ``fst``/``snd`` chain — see
 :func:`comp_binding_is_pairs`.  :func:`destructure_subst` builds the
-substitution and :class:`SubstNames` applies it scope-aware.
+substitution, :class:`SubstNames` applies it scope-aware.
 
 Anything failing a guard is left alone for the backend to materialize.
 """
@@ -53,11 +46,10 @@ from ..utils import Id
 
 @dataclasses.dataclass
 class Ctx:
-    """Block-walk accumulator.  When a statement visitor decides to rewrite a
-    statement, it appends the ``_srcK = ...`` preamble assignments to ``stmts``
-    and returns the rewritten statement; the block visitor then appends that,
-    producing one-to-many statement expansion without a custom statement
-    visitor."""
+    """Block-walk accumulator: a rewriting statement visitor appends its
+    ``_srcK = ...`` preamble here and returns the rewritten statement, which
+    the block visitor then appends — one-to-many statement expansion without a
+    custom statement visitor."""
     stmts: list[Stmt]
 
     @staticmethod
@@ -66,14 +58,13 @@ class Ctx:
 
 
 def is_access_path(e: Expr) -> bool:
-    """Whether *e* is safe to inline into a comprehension body (re-evaluated
-    once per iteration, since a comp has no preamble to bind it once).
+    """Whether *e* is safe to inline into a comprehension body, which
+    re-evaluates it once per iteration.
 
-    True for a ``Var`` or a pure, O(1) projection/index chain rooted at one
-    (``fst``/``snd``/``arg[i]``): no side effects, same value each time.
-    Excludes allocating/expensive args (slices, calls, a nested ``zip``) whose
-    re-evaluation would turn O(n) into O(n^2); those are left for the backend
-    to materialize.
+    True for a ``Var`` or a pure, O(1) projection/index chain rooted at one: no
+    side effects, same value each time.  Excludes allocating arguments (slices,
+    calls, a nested ``zip``) whose re-evaluation would turn O(n) into O(n^2);
+    those are left for the backend to materialize.
     """
     match e:
         case Var():
@@ -101,27 +92,16 @@ def index_access(arg: Expr, idx: NamedId) -> Callable[[], Expr]:
     return lambda: ListRef(clone(arg), Var(idx, None), None)
 
 
-def fst(arg: Expr) -> Expr:
-    """Build ``fst(arg)``."""
-    return Fst(None, arg, None)
-
-
-def snd(arg: Expr) -> Expr:
-    """Build ``snd(arg)``."""
-    return Snd(None, arg, None)
-
-
 def comp_binding_is_pairs(binding: Id | TupleBinding) -> bool:
-    """Whether the comprehension path can lower the binding *slot* *binding*.
+    """Whether the comprehension path can lower the binding slot *binding*.
 
     A slot's own value is reached by direct indexing (``srcK[_i]``), but a slot
-    that *destructures* has its leaves reached by an ``fst``/``snd`` chain (see
-    :func:`destructure_subst`), and those accessors are pair-only.  So a
-    ``TupleBinding`` slot — and every binding nested within it — must have
-    arity 2.  A plain name or an underscore needs no accessor at all.
+    that *destructures* has its leaves reached by a pair-only ``fst``/``snd``
+    chain (see :func:`destructure_subst`), so it — and everything nested within
+    it — must have arity 2.  A name or underscore needs no accessor at all.
 
-    The enclosing target is not a slot and is exempt: its elements *are* the
-    slots, each reached by its own ``srcK[_i]``.
+    The enclosing target is exempt: its elements *are* the slots, each reached
+    by its own ``srcK[_i]``.
     """
     match binding:
         case TupleBinding():
@@ -150,65 +130,55 @@ def destructure_subst(
         case UnderscoreId():
             pass
         case TupleBinding():
-            # The comp path only reaches a nested slot that is a pair
-            # (guaranteed by `comp_binding_is_pairs`); `fst`/`snd` are its two
-            # projections.
+            # Guaranteed a pair by `comp_binding_is_pairs`; `fst`/`snd` are its
+            # two projections.
             assert len(binding.elts) == 2, 'comp-path nested slot must be a pair'
             head, tail = binding.elts
-            destructure_subst(head, lambda: fst(make_access()), subst)
-            destructure_subst(tail, lambda: snd(make_access()), subst)
+            destructure_subst(head, lambda: Fst(None, make_access(), None), subst)
+            destructure_subst(tail, lambda: Snd(None, make_access(), None), subst)
         case _:
             raise RuntimeError(f'unexpected binding element: {binding!r}')
 
 
+def _binding_names(target: Id | TupleBinding) -> list[NamedId]:
+    """The named identifiers *target* binds; underscores contribute none."""
+    match target:
+        case NamedId():
+            return [target]
+        case TupleBinding():
+            out: list[NamedId] = []
+            for elt in target.elts:
+                out.extend(_binding_names(elt))
+            return out
+        case _:
+            return []
+
+
 class SubstNames(DefaultTransformVisitor):
-    """Replace every :class:`Var` reference to a name in *subst*
-    with the corresponding expression.  Scope-aware: comprehension
-    targets that shadow a substituted name disable the substitution
-    inside that comprehension's ``elt`` (the inner uses bind to the
-    shadowing iteration variable, not to the outer one).
+    """Replace every :class:`Var` reference to a name in *subst* with the
+    corresponding expression.  Scope-aware: a comprehension target that shadows
+    a substituted name disables the substitution inside that comprehension, so
+    the inner uses bind to the shadowing iteration variable.
     """
 
     def __init__(self, subst: dict[NamedId, Expr]):
         super().__init__()
-        # Active substitutions; `_visit_list_comp` shadows/restores entries
-        # around a nested comp that rebinds a substituted name.
         self._subst = dict(subst)
 
     def _visit_var(self, e: Var, ctx: Any):
-        # Substitution targets are ``NamedId``s, keyed by structural equality.
         replacement = self._subst.get(e.name)
         if replacement is not None:
             return replacement
         return super()._visit_var(e, ctx)
 
     def _visit_list_comp(self, e: ListComp, ctx: Any):
-        # A target NamedId inside this comp shadows any outer
-        # substitution for the same name.  Save the shadowed entries,
-        # disable them, recurse, then restore.
+        # Disable any substitution this comp's targets shadow, then restore.
         shadowed: dict[NamedId, Expr] = {}
         for target in e.targets:
-            for name in binding_names(target):
+            for name in _binding_names(target):
                 if name in self._subst:
                     shadowed[name] = self._subst.pop(name)
         try:
             return super()._visit_list_comp(e, ctx)
         finally:
             self._subst.update(shadowed)
-
-
-def binding_names(target: Id | TupleBinding) -> list[NamedId]:
-    """Flatten a binding into the named identifiers it binds.  Underscore
-    slots and nested bindings contribute zero or more names."""
-    match target:
-        case NamedId():
-            return [target]
-        case UnderscoreId():
-            return []
-        case TupleBinding():
-            out: list[NamedId] = []
-            for elt in target.elts:
-                out.extend(binding_names(elt))
-            return out
-        case _:
-            return []

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -27,7 +27,7 @@ Two patterns are recognized:
    assignment but their source is still bound to a temp so its
    side-effects fire exactly once.
 
-2. **List comp over zip** *with* ``Var`` arguments only.
+2. **List comp over zip**, when every argument is an access path.
 
    .. code-block:: python
 
@@ -41,12 +41,13 @@ Two patterns are recognized:
    comprehension or other construct that re-binds ``a`` or ``b``,
    the shadowed uses are not rewritten.
 
-   Restriction: every ``zip`` argument must be a :class:`Var`.  A
-   list comprehension is an expression and has no statement-level
-   "preamble" to host the ``_srcK = ...`` bindings, so we can't
-   safely cache a non-pure ``zip`` argument across iterations.
-   The transform leaves non-``Var``-argument zip comps alone; the
-   cpp backend's emit-time fast path still optimizes them.
+   Restriction: every ``zip`` argument must be an
+   :func:`fpy2.transform.iter_elim.is_access_path` — a ``Var`` or a pure,
+   O(1) index/projection chain over one.  A list comprehension is an
+   expression with no statement-level "preamble" to host the
+   ``_srcK = ...`` bindings, so arguments are inlined and re-evaluated
+   per iteration, which is only sound when they are pure and cheap.
+   Comps with any other argument are left alone.
 
 A binding slot may itself be a nested ``TupleBinding`` (e.g.
 ``for (a, b), c in zip(pairs, xs)``).  In the for-loop path the nested
@@ -60,7 +61,7 @@ is left unchanged for the backend to materialize (see
 :func:`fpy2.transform.iter_elim.comp_binding_is_pairs`).
 
 Patterns that don't match the guards (range iterables, mismatched
-arity, non-``Var`` list-comp zip args) are left unchanged.
+arity, non-access-path list-comp zip args) are left unchanged.
 
 Ordering note: run :class:`ZipElim` *before*
 :class:`fpy2.transform.ForUnpack`.  ``ForUnpack`` rewrites

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -57,7 +57,7 @@ each leaf name is reached by an ``fst``/``snd`` chain over ``argK[_i]``
 pair-only, the comp path rewrites a nested slot only when it (and any
 binding nested within it) is a pair; a comp with a nested slot of arity != 2
 is left unchanged for the backend to materialize (see
-:func:`_comp_nesting_is_pairs`).
+:func:`fpy2.transform.iter_elim.comp_binding_is_pairs`).
 
 Patterns that don't match the guards (range iterables, mismatched
 arity, non-``Var`` list-comp zip args) are left unchanged.
@@ -67,27 +67,25 @@ Ordering note: run :class:`ZipElim` *before*
 ``for (a, b) in iter:`` into ``for t in iter: a, b = t``, which
 turns the ``ForStmt``'s target into a :class:`NamedId` and thereby
 defeats this transform's guard.
+
+See :mod:`fpy2.transform.iter_elim` for the machinery this shares with
+:class:`fpy2.transform.EnumerateElim`, which handles the analogous
+``enumerate(...)`` patterns.
 """
 
-import dataclasses
-from collections.abc import Callable
 from typing import Any
 
 from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
 from ..ast.fpyast import (
     Assign,
-    Attribute,
     Expr,
     ForStmt,
-    Fst,
     FuncDef,
-    Integer,
     Len,
     ListComp,
     ListRef,
     NamedId,
     Range1,
-    Snd,
     Stmt,
     StmtBlock,
     TupleBinding,
@@ -97,20 +95,15 @@ from ..ast.fpyast import (
 )
 from ..ast.visitor import DefaultTransformVisitor
 from ..utils import Gensym, Id
-
-
-@dataclasses.dataclass
-class _Ctx:
-    """Block-walk accumulator.  When :meth:`_visit_for` decides to
-    rewrite a for-loop, it appends the ``_srcK = ...`` preamble
-    assignments to ``stmts`` and returns the rewritten ``ForStmt``;
-    :meth:`_visit_block` then appends that, producing one-to-many
-    statement expansion without a custom statement visitor."""
-    stmts: list[Stmt]
-
-    @staticmethod
-    def default() -> '_Ctx':
-        return _Ctx(stmts=[])
+from .iter_elim import (
+    Ctx,
+    SubstNames,
+    clone,
+    comp_binding_is_pairs,
+    destructure_subst,
+    index_access,
+    is_access_path,
+)
 
 
 def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
@@ -125,6 +118,9 @@ def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
     """
     if not isinstance(iterable, Zip):
         return False
+    if not iterable.args:
+        # ``zip()`` has no source to take the length from.
+        return False
     if not isinstance(target, TupleBinding):
         return False
     if len(iterable.args) != len(target.elts):
@@ -133,152 +129,6 @@ def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
         isinstance(e, (NamedId, UnderscoreId, TupleBinding))
         for e in target.elts
     )
-
-
-def _is_access_path(e: Expr) -> bool:
-    """Whether *e* is safe to inline into the comp body (re-evaluated once per
-    iteration, since a comp has no preamble to bind it once).
-
-    True for a ``Var`` or a pure, O(1) projection/index chain rooted at one
-    (``fst``/``snd``/``arg[i]``): no side effects, same value each time.
-    Excludes allocating/expensive args (slices, calls) whose re-evaluation
-    would turn O(n) into O(n^2); those are left for the backend to materialize.
-    """
-    match e:
-        case Var():
-            return True
-        case Fst() | Snd():
-            return _is_access_path(e.arg)
-        case ListRef():
-            return _is_access_path(e.value) and _is_access_path(e.index)
-        case Integer():                       # a constant index in ``arg[i]``
-            return True
-        case _:
-            return False
-
-
-def _clone(e: Expr) -> Expr:
-    """A structurally fresh copy of *e* (no AST shared between substituted
-    occurrences); ``DefaultTransformVisitor`` rebuilds every node."""
-    return DefaultTransformVisitor()._visit_expr(e, None)
-
-
-def _index_access(arg: Expr, idx: NamedId) -> Callable[[], Expr]:
-    """A thunk building ``arg[idx]`` with a fresh copy of ``arg`` each call.
-
-    *arg* must be an :func:`_is_access_path` (safe to re-evaluate per call)."""
-    return lambda: ListRef(_clone(arg), Var(idx, None), None)
-
-
-def _fst(arg: Expr) -> Expr:
-    """Build ``fst(arg)``."""
-    return Fst(None, arg, None)
-
-
-def _snd(arg: Expr) -> Expr:
-    """Build ``snd(arg)``."""
-    return Snd(None, arg, None)
-
-
-def _comp_nesting_is_pairs(target: TupleBinding) -> bool:
-    """Whether *target*'s nested bindings can be lowered by the comp path.
-
-    The comp path reaches a nested ``TupleBinding``'s leaves with ``fst``/``snd``
-    (see :func:`_destructure_subst`), which are pair-only, so every nested slot
-    must have arity 2.  The top-level target is exempt — its slots are reached
-    by direct ``argK[_i]`` indexing, not ``fst``/``snd``.
-    """
-    def check(binding: Id | TupleBinding, *, top: bool) -> bool:
-        match binding:
-            case TupleBinding():
-                if not top and len(binding.elts) != 2:
-                    return False
-                return all(check(e, top=False) for e in binding.elts)
-            case _:
-                return True
-    return check(target, top=True)
-
-
-def _destructure_subst(
-    binding: Id | TupleBinding,
-    make_access: Callable[[], Expr],
-    subst: dict[NamedId, Expr],
-) -> None:
-    """Map every :class:`NamedId` in *binding* to an accessor expression.
-
-    *make_access* builds a *fresh* expression for the value bound to
-    *binding* (the per-iteration source element).  It is invoked once per
-    leaf, so no AST node is shared between substitutions.
-    """
-    match binding:
-        case NamedId():
-            subst[binding] = make_access()
-        case UnderscoreId():
-            pass
-        case TupleBinding():
-            # The comp path only reaches a nested slot that is a pair
-            # (guaranteed by `_comp_nesting_is_pairs`); `fst`/`snd` are its two
-            # projections.
-            assert len(binding.elts) == 2, 'comp-path nested slot must be a pair'
-            head, tail = binding.elts
-            _destructure_subst(head, lambda: _fst(make_access()), subst)
-            _destructure_subst(tail, lambda: _snd(make_access()), subst)
-        case _:
-            raise RuntimeError(f'unexpected zip binding element: {binding!r}')
-
-
-class _SubstNames(DefaultTransformVisitor):
-    """Replace every :class:`Var` reference to a name in *subst*
-    with the corresponding expression.  Scope-aware: comprehension
-    targets that shadow a substituted name disable the substitution
-    inside that comprehension's ``elt`` (the inner uses bind to the
-    shadowing iteration variable, not to the outer one).
-    """
-
-    def __init__(self, subst: dict[NamedId, Expr]):
-        super().__init__()
-        # Active substitutions; `_visit_list_comp` shadows/restores entries
-        # around a nested comp that rebinds a substituted name.
-        self._subst = dict(subst)
-
-    def _visit_var(self, e: Var, ctx: Any):
-        # Substitution targets are ``NamedId``s, keyed by structural equality.
-        replacement = self._subst.get(e.name)
-        if replacement is not None:
-            return replacement
-        return super()._visit_var(e, ctx)
-
-    def _visit_list_comp(self, e: ListComp, ctx: Any):
-        # A target NamedId inside this comp shadows any outer
-        # substitution for the same name.  Save the shadowed entries,
-        # disable them, recurse, then restore.
-        shadowed: dict[NamedId, Expr] = {}
-        for target in e.targets:
-            for name in self._binding_names(target):
-                if name in self._subst:
-                    shadowed[name] = self._subst.pop(name)
-        try:
-            return super()._visit_list_comp(e, ctx)
-        finally:
-            self._subst.update(shadowed)
-
-    @staticmethod
-    def _binding_names(target) -> list[NamedId]:
-        """Flatten a comprehension target into the named identifiers
-        it binds.  Underscore slots and nested bindings contribute
-        zero or more names."""
-        match target:
-            case NamedId():
-                return [target]
-            case UnderscoreId():
-                return []
-            case TupleBinding():
-                out: list[NamedId] = []
-                for elt in target.elts:
-                    out.extend(_SubstNames._binding_names(elt))
-                return out
-            case _:
-                return []
 
 
 class _ZipElimInstance(DefaultTransformVisitor):
@@ -296,10 +146,10 @@ class _ZipElimInstance(DefaultTransformVisitor):
     # Block walk with stmt → stmts expansion
 
     def _visit_block(self, block: StmtBlock, ctx: Any):
-        # Local _Ctx so each block has its own preamble buffer; the
+        # Local Ctx so each block has its own preamble buffer; the
         # outer caller's ctx (if any) is irrelevant — preambles
         # always belong to the block introducing them.
-        block_ctx = _Ctx.default()
+        block_ctx = Ctx.default()
         for stmt in block.stmts:
             new_stmt, _ = self._visit_statement(stmt, block_ctx)
             block_ctx.stmts.append(new_stmt)
@@ -308,7 +158,7 @@ class _ZipElimInstance(DefaultTransformVisitor):
     # ------------------------------------------------------------------
     # For loops
 
-    def _visit_for(self, stmt: ForStmt, ctx: _Ctx):
+    def _visit_for(self, stmt: ForStmt, ctx: Ctx):
         if not _is_zip_tuple_binding(stmt.target, stmt.iterable):
             return super()._visit_for(stmt, ctx)
         # Recursively rewrite the body first, in case it contains
@@ -317,7 +167,7 @@ class _ZipElimInstance(DefaultTransformVisitor):
         return self._rewrite_for(stmt, body, ctx), ctx
 
     def _rewrite_for(
-        self, stmt: ForStmt, new_body: StmtBlock, ctx: _Ctx,
+        self, stmt: ForStmt, new_body: StmtBlock, ctx: Ctx,
     ) -> ForStmt:
         assert isinstance(stmt.iterable, Zip)
         assert isinstance(stmt.target, TupleBinding)
@@ -394,6 +244,11 @@ class _ZipElimInstance(DefaultTransformVisitor):
 
         for target, iterable in zip(e.targets, e.iterables):
             new_iter = self._visit_expr(iterable, ctx)
+            # A later stage's iterable may reference an earlier stage's
+            # target (``[... for a, b in zip(xs, ys) for c in a]``), whose
+            # name no longer exists once that stage is rewritten.
+            if subst:
+                new_iter = SubstNames(subst)._visit_expr(new_iter, ctx)
             if (
                 _is_zip_tuple_binding(target, new_iter)
                 and isinstance(new_iter, Zip)
@@ -401,12 +256,12 @@ class _ZipElimInstance(DefaultTransformVisitor):
                 # Each arg is inlined into the comp body (re-evaluated per
                 # iteration, since a comp has no preamble to bind it once), so it
                 # must be a pure, re-evaluable access path.
-                and all(_is_access_path(a) for a in new_iter.args)
+                and all(is_access_path(a) for a in new_iter.args)
                 # `fst`/`snd` are pair-only, so a nested slot of arity != 2 can't
                 # be reached by the comp path's accessor chains; leave such a
                 # `zip` in place (the backends materialize it) rather than emit
                 # ill-typed `snd`-of-non-pair.
-                and _comp_nesting_is_pairs(target)
+                and all(comp_binding_is_pairs(elt) for elt in target.elts)
             ):
                 idx = self.gensym.fresh('_i')
                 # Substitute each binding slot with an accessor into its
@@ -414,13 +269,13 @@ class _ZipElimInstance(DefaultTransformVisitor):
                 # ``fst``/``snd`` chain for a nested tuple binding (whose
                 # per-iteration element is itself a tuple).
                 for binding, arg in zip(target.elts, new_iter.args):
-                    _destructure_subst(
-                        binding, _index_access(arg, idx), subst,
+                    destructure_subst(
+                        binding, index_access(arg, idx), subst,
                     )
                 # New target/iterable: ``_i in range(len(arg0))``.
                 len_expr = Len(
                     None,
-                    _clone(new_iter.args[0]),
+                    clone(new_iter.args[0]),
                     None,
                 )
                 new_targets.append(idx)
@@ -435,7 +290,7 @@ class _ZipElimInstance(DefaultTransformVisitor):
         # (so nested zip patterns inside the elt are also rewritten).
         new_elt = self._visit_expr(e.elt, ctx)
         if subst:
-            new_elt = _SubstNames(subst)._visit_expr(new_elt, ctx)
+            new_elt = SubstNames(subst)._visit_expr(new_elt, ctx)
         return ListComp(new_targets, new_iterables, new_elt, e.loc)
 
 

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -1321,15 +1321,12 @@ def _regression_one_list_two_indices(xs: list[fp.Real]) -> fp.Real:
 @fp.fpy
 def _regression_enumerate_row_write(xss: list[list[fp.Real]]) -> fp.Real:
     """Route: a row aliased out of an `enumerate` and written through.  Both
-    lowerings have to keep that write visible in `xss`, for different reasons,
-    so this pins the pair rather than one code path:
-
-    - `optimize=False`: `enumerate` materializes a `vector<tuple<I, T>>`, and
-      the row reaches it through a synthesized copy that appears nowhere in
-      the AST.  A `fpy::list` is a handle, so the copy shares elements.
-    - `optimize=True` (the default): `EnumerateElim` rewrites this to
-      `row = _src0[i]`, an ordinary assignment whose handle copy must share
-      the same way.
+    lowerings must keep that write visible in `xss`, for different reasons, so
+    this pins the pair rather than one code path: `optimize=False` materializes
+    a `vector<tuple<I, T>>` and reaches the row through a copy synthesized by
+    codegen that appears nowhere in the AST, while `optimize=True` (the
+    default) rewrites to an ordinary `row = _src0[i]`.  A `fpy::list` is a
+    handle, so both copies share elements.
     """
     with fp.FP64:
         if len(xss) == 0:

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -1320,9 +1320,17 @@ def _regression_one_list_two_indices(xs: list[fp.Real]) -> fp.Real:
 
 @fp.fpy
 def _regression_enumerate_row_write(xss: list[list[fp.Real]]) -> fp.Real:
-    """Route: `enumerate` lowers to a materialized `vector<tuple<I, T>>`, which
-    deep-copies every row.  Notable because that copy site is synthesized by
-    codegen and appears nowhere in the AST."""
+    """Route: a row aliased out of an `enumerate` and written through.  Both
+    lowerings have to keep that write visible in `xss`, for different reasons,
+    so this pins the pair rather than one code path:
+
+    - `optimize=False`: `enumerate` materializes a `vector<tuple<I, T>>`, and
+      the row reaches it through a synthesized copy that appears nowhere in
+      the AST.  A `fpy::list` is a handle, so the copy shares elements.
+    - `optimize=True` (the default): `EnumerateElim` rewrites this to
+      `row = _src0[i]`, an ordinary assignment whose handle copy must share
+      the same way.
+    """
     with fp.FP64:
         if len(xss) == 0:
             return 0

--- a/tests/unit/backend/cpp/test_emit_builtins.py
+++ b/tests/unit/backend/cpp/test_emit_builtins.py
@@ -44,9 +44,14 @@ class TestSum:
 
 
 class TestEnumerate:
-    """``enumerate(xs)`` builds a ``fpy::list<std::tuple<I, T>>``."""
+    """``enumerate(xs)`` lowers to a ``fpy::list<std::tuple<I, T>>``
+    by default when optimizations are disabled.  With the default
+    ``optimize=True``, :class:`EnumerateElim` rewrites the pattern to a
+    plain indexed loop instead — see
+    :meth:`test_enumerate_optimized_skips_tuple_vector`.
+    """
 
-    def test_enumerate_in_for_loop(self):
+    def test_enumerate_in_for_loop_unoptimized(self):
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:
             with fp.FP64:
@@ -58,7 +63,7 @@ class TestEnumerate:
                     acc = acc + x
                 return acc
 
-        out = CppCompiler().compile(
+        out = CppCompiler(optimize=False).compile(
             f, ctx=fp.FP64,
             arg_types=[ListType(RealType(fp.FP64))],
         )
@@ -72,6 +77,90 @@ class TestEnumerate:
         # Then the outer for-loop destructures into ``i``/``x``.
         assert 'int64_t i = std::get<0>' in out
         assert 'double x = std::get<1>' in out
+
+    def test_enumerate_optimized_skips_tuple_vector(self):
+        """Default ``CppCompiler()`` has ``optimize=True``, so
+        :class:`EnumerateElim` runs first and ``for i, x in enumerate(...)``
+        lowers to a plain indexed loop — no intermediate
+        ``fpy::list<std::tuple<...>>``, and the user's ``i`` becomes the
+        loop counter rather than a destructured tuple element."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, x in enumerate(xs):
+                    acc = acc + x
+                return acc
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64,
+            arg_types=[ListType(RealType(fp.FP64))],
+        )
+        # No tuple machinery at all.
+        assert 'std::tuple' not in out
+        assert 'std::make_tuple' not in out
+        # The source is bound to a read-only ``_src`` alias (a const
+        # reference — no copy) and indexed directly.
+        assert 'const auto& _src' in out
+        # ``i`` is the loop counter itself.
+        assert 'for (int64_t i = 0;' in out
+
+    def test_enumerate_of_zip_optimized_skips_both_vectors(self):
+        """``enumerate(zip(...))`` materializes *two* vectors unoptimized —
+        the zip's tuples and the enumerate's (index, tuple) pairs.
+        :class:`EnumerateElim` collapses both into direct indexing of the
+        zip's own arguments, which is why it must run before
+        :class:`ZipElim` (which cannot reach a ``zip`` that an enumerate
+        rewrite has already moved into an assignment)."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, (a, b) in enumerate(zip(xs, ys)):
+                    acc = acc + a * b
+                return acc
+
+        arg_types = [ListType(RealType(fp.FP64))] * 2
+        unopt = CppCompiler(optimize=False).compile(
+            f, ctx=fp.FP64, arg_types=arg_types,
+        )
+        # Unoptimized: both intermediate vectors, the outer one nesting the
+        # inner tuple type.
+        assert 'fpy::list<std::tuple<double, double>>' in unopt
+        assert (
+            'fpy::list<std::tuple<int64_t, std::tuple<double, double>>>'
+        ) in unopt
+
+        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=arg_types)
+        # Optimized: neither vector, and both sources indexed directly.
+        assert 'std::tuple' not in out
+        assert 'std::make_tuple' not in out
+        assert 'for (int64_t i = 0;' in out
+        assert out.count('const auto& _src') == 2
+
+    def test_enumerate_of_zip_whole_tuple_slot(self):
+        """An element slot bound to the whole zipped tuple still avoids both
+        vectors: the tuple is rebuilt per iteration from the indexed
+        sources, so only a stack tuple is ever constructed."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, p in enumerate(zip(xs, ys)):
+                    acc = acc + fp.fst(p) * fp.snd(p)
+                return acc
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[ListType(RealType(fp.FP64))] * 2,
+        )
+        # No list-of-tuples anywhere ...
+        assert 'fpy::list<std::tuple' not in out
+        # ... just the one per-iteration tuple.
+        assert out.count('std::make_tuple') == 1
+        assert 'for (int64_t i = 0;' in out
 
 
 class TestZip:

--- a/tests/unit/backend/cpp/test_emit_builtins.py
+++ b/tests/unit/backend/cpp/test_emit_builtins.py
@@ -44,11 +44,9 @@ class TestSum:
 
 
 class TestEnumerate:
-    """``enumerate(xs)`` lowers to a ``fpy::list<std::tuple<I, T>>``
-    by default when optimizations are disabled.  With the default
-    ``optimize=True``, :class:`EnumerateElim` rewrites the pattern to a
-    plain indexed loop instead — see
-    :meth:`test_enumerate_optimized_skips_tuple_vector`.
+    """``enumerate(xs)`` lowers to a ``fpy::list<std::tuple<I, T>>`` when
+    optimizations are disabled.  With the default ``optimize=True``,
+    :class:`EnumerateElim` rewrites it to a plain indexed loop instead.
     """
 
     def test_enumerate_in_for_loop_unoptimized(self):
@@ -79,11 +77,10 @@ class TestEnumerate:
         assert 'double x = std::get<1>' in out
 
     def test_enumerate_optimized_skips_tuple_vector(self):
-        """Default ``CppCompiler()`` has ``optimize=True``, so
-        :class:`EnumerateElim` runs first and ``for i, x in enumerate(...)``
-        lowers to a plain indexed loop — no intermediate
-        ``fpy::list<std::tuple<...>>``, and the user's ``i`` becomes the
-        loop counter rather than a destructured tuple element."""
+        """With the default ``optimize=True``, :class:`EnumerateElim` lowers
+        this to a plain indexed loop: no intermediate
+        ``fpy::list<std::tuple<...>>``, and ``i`` becomes the loop counter
+        rather than a destructured tuple element."""
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:
@@ -107,12 +104,10 @@ class TestEnumerate:
         assert 'for (int64_t i = 0;' in out
 
     def test_enumerate_of_zip_optimized_skips_both_vectors(self):
-        """``enumerate(zip(...))`` materializes *two* vectors unoptimized —
-        the zip's tuples and the enumerate's (index, tuple) pairs.
-        :class:`EnumerateElim` collapses both into direct indexing of the
-        zip's own arguments, which is why it must run before
-        :class:`ZipElim` (which cannot reach a ``zip`` that an enumerate
-        rewrite has already moved into an assignment)."""
+        """Unoptimized this materializes *two* vectors — the zip's tuples and
+        the enumerate's (index, tuple) pairs.  :class:`EnumerateElim` collapses
+        both into direct indexing of the zip's own arguments, which is why it
+        must run before :class:`ZipElim`."""
 
         @fp.fpy
         def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:

--- a/tests/unit/transform/test_enumerate_elim.py
+++ b/tests/unit/transform/test_enumerate_elim.py
@@ -3,23 +3,15 @@ Unit tests for the :class:`fpy2.transform.EnumerateElim` transform.
 
 Structured like ``test_zip_elim.py``, and for the same reason: the rewrite
 mints fresh ``_srcK`` / ``_iK`` names via ``Gensym``, whose suffix counts
-depend on the existing in-scope names, so an ``is_equiv`` comparison against a
-hand-written golden AST is too brittle.  Each positive test instead asserts
+depend on the existing in-scope names, so comparing against a hand-written
+golden AST is too brittle.  Each positive test instead asserts both the
+**structural shape** of the output (did the rewrite fire, and is it
+well-formed?) and **semantic equivalence** via the FPy interpreter on sample
+inputs (which catches errors that pass the shape checks).  For the negative
+tests, ``is_equiv`` against the original AST is sufficient and stable.
 
-1. **Structural shape** of the rewritten AST (the iterable became a
-   ``range(len(...))``, the body opens with the expected per-iteration
-   assigns, no ``Enumerate`` / ``Zip`` survives) — "did the rewrite fire and
-   is it well-formed?"
-2. **Semantic equivalence** via the FPy interpreter on concrete sample
-   inputs — this catches subtle errors that pass the shape checks.
-
-For the negative tests (unchanged inputs), ``is_equiv`` against the original
-AST is sufficient and stable.
-
-One case is deliberately shape-only: an element slot whose arity disagrees
-with the ``zip``'s is already ill-typed, so it cannot be evaluated.  The
-transform is asserted to leave the ``zip`` in place rather than trade the
-type error for an arity-mismatched destructure.
+One case is shape-only of necessity: an element slot whose arity disagrees
+with the ``zip``'s is already ill-typed, so it cannot be evaluated.
 """
 
 import fpy2 as fp

--- a/tests/unit/transform/test_enumerate_elim.py
+++ b/tests/unit/transform/test_enumerate_elim.py
@@ -1,0 +1,605 @@
+"""
+Unit tests for the :class:`fpy2.transform.EnumerateElim` transform.
+
+Structured like ``test_zip_elim.py``, and for the same reason: the rewrite
+mints fresh ``_srcK`` / ``_iK`` names via ``Gensym``, whose suffix counts
+depend on the existing in-scope names, so an ``is_equiv`` comparison against a
+hand-written golden AST is too brittle.  Each positive test instead asserts
+
+1. **Structural shape** of the rewritten AST (the iterable became a
+   ``range(len(...))``, the body opens with the expected per-iteration
+   assigns, no ``Enumerate`` / ``Zip`` survives) — "did the rewrite fire and
+   is it well-formed?"
+2. **Semantic equivalence** via the FPy interpreter on concrete sample
+   inputs — this catches subtle errors that pass the shape checks.
+
+For the negative tests (unchanged inputs), ``is_equiv`` against the original
+AST is sufficient and stable.
+
+One case is deliberately shape-only: an element slot whose arity disagrees
+with the ``zip``'s is already ill-typed, so it cannot be evaluated.  The
+transform is asserted to leave the ``zip`` in place rather than trade the
+type error for an arity-mismatched destructure.
+"""
+
+import fpy2 as fp
+
+from fpy2.ast.fpyast import (
+    Assign, Enumerate, ForStmt, Fst, Len, ListComp, ListRef, NamedId, Range1,
+    Snd, TupleBinding, TupleExpr, Var, Zip,
+)
+from fpy2.ast.visitor import DefaultVisitor
+from fpy2.transform import EnumerateElim
+
+
+def _find_for(ast: fp.ast.FuncDef) -> ForStmt:
+    """Return the first ``ForStmt`` reachable inside *ast.body*, descending
+    into ``ContextStmt`` blocks.  Used to inspect the rewritten loop."""
+    def walk(stmts):
+        for s in stmts:
+            if isinstance(s, ForStmt):
+                return s
+            body = getattr(s, 'body', None)
+            if body is not None and hasattr(body, 'stmts'):
+                hit = walk(body.stmts)
+                if hit is not None:
+                    return hit
+        return None
+    return walk(ast.body.stmts)
+
+
+def _find_listcomp(ast: fp.ast.FuncDef) -> ListComp:
+    """Return the first ``ListComp`` reachable in *ast*."""
+    found: list[ListComp] = []
+
+    class _C(DefaultVisitor):
+        def _visit_list_comp(self, e, ctx):
+            found.append(e)
+            super()._visit_list_comp(e, ctx)
+
+    _C()._visit_function(ast, None)
+    return found[0] if found else None
+
+
+def _contains(ast: fp.ast.FuncDef, types) -> bool:
+    """True iff any sub-expression of *ast* is an instance of *types*."""
+    hits: list = []
+
+    class _C(DefaultVisitor):
+        def _visit_expr(self, e, ctx):
+            if isinstance(e, types):
+                hits.append(e)
+            return super()._visit_expr(e, ctx)
+
+    _C()._visit_function(ast, None)
+    return bool(hits)
+
+
+def _count_fors(ast: fp.ast.FuncDef) -> int:
+    """How many ``ForStmt``s the function contains, at any depth."""
+    n = 0
+
+    class _C(DefaultVisitor):
+        def _visit_for(self, stmt, ctx):
+            nonlocal n
+            n += 1
+            super()._visit_for(stmt, ctx)
+
+    _C()._visit_function(ast, None)
+    return n
+
+
+def _eval(ast: fp.ast.FuncDef, fn: fp.Function, *args):
+    """Evaluate *ast* via the FPy interpreter using *fn*'s env."""
+    return fn.with_ast(ast)(*args)
+
+
+def _ref_assigns(loop: ForStmt) -> int:
+    """Per-iteration ``x = src[i]`` assignments at the top of *loop*'s body."""
+    return sum(
+        1 for s in loop.body.stmts
+        if isinstance(s, Assign) and isinstance(s.expr, ListRef)
+    )
+
+
+def _assert_same(new_ast, f, *args):
+    """The rewrite preserves the interpreter's result on *args*."""
+    before, after = f(*args), _eval(new_ast, f, *args)
+    if hasattr(before, '__len__'):
+        assert list(after) == list(before)
+    else:
+        assert after == before
+
+
+# Sample inputs, reused across tests.
+_XS = [1.0, 2.0, 3.0, 4.0]
+_YS = [10.0, 20.0, 30.0, 40.0]
+_ZS = [2.0, 2.0, 2.0, 2.0]
+_PAIRS = [(1.0, 2.0), (3.0, 4.0)]
+_ROWS = [[1.0, 2.0], [3.0, 4.0]]
+
+
+class TestForLoopRewrite:
+    """For-loops over ``enumerate`` become range-indexed loops."""
+
+    def test_rewritten_to_indexed_loop(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, x in enumerate(xs):
+                    acc = acc + x
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # The index slot became the loop counter itself, keeping its name.
+        assert isinstance(loop.target, NamedId)
+        assert loop.target.base == 'i'
+        # The iterable is range(len(_src0)).
+        assert isinstance(loop.iterable, Range1)
+        assert isinstance(loop.iterable.arg, Len)
+        # One per-iteration assign, for the element slot only — the index
+        # needs none, since range() already produces it.
+        assert _ref_assigns(loop) == 1
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_index_read_in_body(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, x in enumerate(xs):
+                    if i > 1:
+                        acc = acc + x
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_discarded_index_gets_fresh_counter(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for _, x in enumerate(xs):
+                    acc = acc + x
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # An underscore index slot can't name the counter, so one is minted.
+        assert isinstance(loop.target, NamedId)
+        assert _ref_assigns(loop) == 1
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_discarded_element_emits_no_assign(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, _ in enumerate(xs):
+                    acc = acc + 1
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # Nothing reads the element, so no per-iteration assign is emitted;
+        # the source is still bound before the loop for its length.
+        assert _ref_assigns(loop) == 0
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_nested_element_slot_destructures(self):
+        @fp.fpy
+        def f(ps: list[tuple[fp.Real, fp.Real]]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, (a, b) in enumerate(ps):
+                    acc = acc + a * b
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # The nested slot lowers to a destructuring assign; a statement
+        # context needs no fst/snd.
+        assert any(
+            isinstance(s, Assign) and isinstance(s.target, TupleBinding)
+            for s in loop.body.stmts
+        )
+        assert not _contains(new_ast, (Enumerate, Fst, Snd))
+        _assert_same(new_ast, f, _PAIRS)
+
+    def test_non_var_source_is_bound_once(self):
+        """A slice source is evaluated once into the preamble temp, not
+        re-evaluated per iteration."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, x in enumerate(xs[1:]):
+                    acc = acc + x
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_body_rebinding_source_keeps_original_bound(self):
+        """The loop bound comes from the preamble temp, so a body that
+        rebinds the source name cannot change the iteration count."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, x in enumerate(xs):
+                    acc = acc + x
+                    xs = [1.0]
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # The bound reads a name the body never touches.
+        assert isinstance(loop.iterable, Range1)
+        assert isinstance(loop.iterable.arg, Len)
+        assert isinstance(loop.iterable.arg.arg, Var)
+        assert loop.iterable.arg.arg.name.base == '_src'
+        _assert_same(new_ast, f, _XS)
+
+    def test_nested_loops_both_rewritten(self):
+        @fp.fpy
+        def f(xss: list[list[fp.Real]]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, row in enumerate(xss):
+                    for j, x in enumerate(row):
+                        acc = acc + x
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert not _contains(new_ast, Enumerate)
+        assert _count_fors(new_ast) == 2
+        _assert_same(new_ast, f, _ROWS)
+
+    def test_non_enumerate_iterable_unchanged(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for x in xs:
+                    acc = acc + x
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert new_ast.is_equiv(f.ast)
+
+
+class TestEnumerateOfZip:
+    """``enumerate(zip(...))`` collapses *both* intermediate lists at once.
+
+    This is why the transform can't defer to :class:`fpy2.transform.ZipElim`:
+    after a plain enumerate rewrite the ``zip`` sits on the right-hand side of
+    ``_src0 = zip(...)``, where a transform matching ``zip`` in *iterable*
+    position can no longer reach it.
+    """
+
+    def test_two_arg_zip_fully_eliminated(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, (a, b) in enumerate(zip(xs, ys)):
+                    acc = acc + a * b
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        assert isinstance(loop.target, NamedId)
+        assert isinstance(loop.iterable, Range1)
+        # One assign per zip argument, indexing that argument directly.
+        assert _ref_assigns(loop) == 2
+        # Neither derived sequence survives.
+        assert not _contains(new_ast, (Enumerate, Zip))
+        _assert_same(new_ast, f, _XS, _YS)
+
+    def test_three_arg_zip_fully_eliminated(self):
+        @fp.fpy
+        def f(
+            xs: list[fp.Real], ys: list[fp.Real], zs: list[fp.Real]
+        ) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, (a, b, c) in enumerate(zip(xs, ys, zs)):
+                    acc = acc + a * b * c
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert _ref_assigns(_find_for(new_ast)) == 3
+        assert not _contains(new_ast, (Enumerate, Zip))
+        _assert_same(new_ast, f, _XS, _YS, _ZS)
+
+    def test_discarded_slot_inside_zip(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, (a, _) in enumerate(zip(xs, ys)):
+                    acc = acc + a
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        # Only the read slot gets an assign; both sources stay bound.
+        assert _ref_assigns(_find_for(new_ast)) == 1
+        assert not _contains(new_ast, (Enumerate, Zip))
+        _assert_same(new_ast, f, _XS, _YS)
+
+    def test_mismatched_arity_keeps_the_zip(self):
+        """Shape-only: the program is ill-typed (a 2-slot binding over a
+        3-argument ``zip``), so it can't be evaluated.  Keeping the ``zip``
+        keeps its diagnostic instead of trading it for an arity-mismatched
+        destructure."""
+
+        @fp.fpy
+        def f(
+            xs: list[fp.Real], ys: list[fp.Real], zs: list[fp.Real]
+        ) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, (a, b) in enumerate(zip(xs, ys, zs)):
+                    acc = acc + a * b
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        # The enumerate still goes; only the zip is left materialized.
+        assert not _contains(new_ast, Enumerate)
+        assert _contains(new_ast, Zip)
+
+
+class TestWholeTupleSlot:
+    """An element slot bound to the whole zipped tuple rebuilds it per
+    iteration instead of materializing a list of them."""
+
+    def test_for_loop_builds_tuple_per_iteration(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, p in enumerate(zip(xs, ys)):
+                    acc = acc + fp.fst(p) * fp.snd(p)
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # ``p = (_src0[i], _src1[i])`` — a tuple expression, not a ListRef.
+        first = loop.body.stmts[0]
+        assert isinstance(first, Assign)
+        assert isinstance(first.expr, TupleExpr)
+        assert len(first.expr.elts) == 2
+        assert all(isinstance(e, ListRef) for e in first.expr.elts)
+        assert not _contains(new_ast, (Enumerate, Zip))
+        _assert_same(new_ast, f, _XS, _YS)
+
+    def test_discarded_whole_slot_builds_nothing(self):
+        """Previously this materialized the entire zip list purely to ask
+        its length."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, _ in enumerate(zip(xs, ys)):
+                    acc = acc + 1
+                return acc
+
+        new_ast = EnumerateElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        assert _ref_assigns(loop) == 0
+        assert not _contains(new_ast, (Enumerate, Zip, TupleExpr))
+        _assert_same(new_ast, f, _XS, _YS)
+
+    def test_list_comp_substitutes_a_tuple(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [fp.fst(p) * fp.snd(p) for i, p in enumerate(zip(xs, ys))]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        comp = _find_listcomp(new_ast)
+        assert isinstance(comp.iterables[0], Range1)
+        # ``p`` was replaced by a tuple over one access path per source.  This
+        # is not inlining the zip: it stays pure and O(1) per element.
+        assert _contains(new_ast, TupleExpr)
+        assert not _contains(new_ast, (Enumerate, Zip))
+        _assert_same(new_ast, f, _XS, _YS)
+
+
+class TestListCompRewrite:
+    """List-comps over ``enumerate`` are rewritten when the sources are
+    access paths."""
+
+    def test_rewritten_to_indexed_comp(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [x * x for i, x in enumerate(xs)]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        comp = _find_listcomp(new_ast)
+        assert len(comp.targets) == 1
+        # The index slot keeps its name and becomes the comp's counter.
+        assert isinstance(comp.targets[0], NamedId)
+        assert comp.targets[0].base == 'i'
+        assert isinstance(comp.iterables[0], Range1)
+        assert isinstance(comp.iterables[0].arg, Len)
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_index_and_element_both_read(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [x + xs[i] for i, x in enumerate(xs)]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_element_read_twice(self):
+        """The substitution lands at every use of the bound name."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [x * x + x for i, x in enumerate(xs)]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_discarded_index(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [x * x for _, x in enumerate(xs)]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        comp = _find_listcomp(new_ast)
+        assert isinstance(comp.targets[0], NamedId)
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _XS)
+
+    def test_zip_destructured_in_comp(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [a * b for i, (a, b) in enumerate(zip(xs, ys))]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        comp = _find_listcomp(new_ast)
+        assert isinstance(comp.iterables[0], Range1)
+        assert not _contains(new_ast, (Enumerate, Zip))
+        _assert_same(new_ast, f, _XS, _YS)
+
+    def test_nested_slot_uses_fst_snd(self):
+        @fp.fpy
+        def f(ps: list[tuple[fp.Real, fp.Real]]) -> list[fp.Real]:
+            with fp.FP64:
+                return [a + b for i, (a, b) in enumerate(ps)]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        # A comp has no statement context, so the nested slot's leaves are
+        # reached by fst/snd chains over ``ps[i]``.
+        assert _contains(new_ast, (Fst, Snd))
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _PAIRS)
+
+    def test_non_access_path_source_unchanged(self):
+        """A slice source would be re-evaluated once per iteration, turning
+        O(n) into O(n^2), so the comp is left for the backend."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [x * x for i, x in enumerate(xs[1:])]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert new_ast.is_equiv(f.ast)
+        assert _contains(new_ast, Enumerate)
+
+    def test_shadowed_target_in_nested_comp(self):
+        """The inner comp re-binds ``x``; that reference must not be
+        substituted by the outer rewrite."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [sum([x for x in ys]) + x for i, x in enumerate(xs)]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        outer = _find_listcomp(new_ast)
+        assert isinstance(outer.iterables[0], Range1)
+
+        inner_found: list[ListComp] = []
+
+        class _C(DefaultVisitor):
+            def _visit_list_comp(self, e, ctx):
+                if e is not outer:
+                    inner_found.append(e)
+                super()._visit_list_comp(e, ctx)
+
+        _C()._visit_function(new_ast, None)
+        assert len(inner_found) == 1
+        inner = inner_found[0]
+        # The inner elt is still a bare ``Var`` to ``x`` — not rewritten.
+        assert isinstance(inner.elt, Var)
+        assert inner.elt.name.base == 'x'
+        assert isinstance(inner.iterables[0], Var)
+        _assert_same(new_ast, f, _XS, _YS)
+
+    def test_later_stage_iterable_references_rewritten_target(self):
+        """A multi-stage comp whose second iterable reads the first stage's
+        target: the substitution has to reach the iterable too, or the name
+        is left dangling and ``SyntaxCheck`` rejects the output."""
+
+        @fp.fpy
+        def f(xss: list[list[fp.Real]]) -> list[fp.Real]:
+            with fp.FP64:
+                return [y for i, row in enumerate(xss) for y in row]
+
+        new_ast = EnumerateElim.apply(f.ast)
+        assert not _contains(new_ast, Enumerate)
+        _assert_same(new_ast, f, _ROWS)
+
+
+class TestProperties:
+    """Cross-cutting properties of the transform."""
+
+    def test_idempotent(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, (a, b) in enumerate(zip(xs, ys)):
+                    acc = acc + a * b
+                return acc
+
+        once = EnumerateElim.apply(f.ast)
+        twice = EnumerateElim.apply(once)
+        assert once.is_equiv(twice)
+
+    def test_syntax_check_passes(self):
+        """``EnumerateElim.apply`` runs ``SyntaxCheck.check`` internally, so
+        ill-formed output would make ``apply`` itself raise.  This exercises a
+        representative mix of the shapes the transform emits."""
+
+        @fp.fpy
+        def f(
+            xs: list[fp.Real], ys: list[fp.Real],
+            ps: list[tuple[fp.Real, fp.Real]],
+        ) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for i, x in enumerate(xs):
+                    acc = acc + x
+                for j, (a, b) in enumerate(zip(xs, ys)):
+                    acc = acc + a * b
+                for k, p in enumerate(zip(xs, ys)):
+                    acc = acc + fp.fst(p)
+                for m, (c, d) in enumerate(ps):
+                    acc = acc + c + d
+                return acc + sum([z * z for n, z in enumerate(xs)])
+
+        # Should not raise.
+        out = EnumerateElim.apply(f.ast)
+        assert not _contains(out, (Enumerate, Zip))
+
+    def test_rejects_non_funcdef(self):
+        import pytest
+
+        with pytest.raises(TypeError):
+            EnumerateElim.apply('not a funcdef')  # type: ignore[arg-type]

--- a/tests/unit/transform/test_enumerate_elim.py
+++ b/tests/unit/transform/test_enumerate_elim.py
@@ -350,7 +350,9 @@ class TestEnumerateOfZip:
         ) -> fp.Real:
             with fp.FP64:
                 acc = 0
-                for i, (a, b) in enumerate(zip(xs, ys, zs)):
+                # The arity disagreement is the point of the test, so the
+                # type error below is deliberate.
+                for i, (a, b) in enumerate(zip(xs, ys, zs)):  # type: ignore[misc]
                     acc = acc + a * b
                 return acc
 


### PR DESCRIPTION
This PR adds a program transformation that eliminates `enumerate` uses in a for loop.

It rewrites
```
for i, x in enumerate(xs):
    ...
```
to
```
t = xs
for i in range(len(t)):
   x = t[i]
   ...
```