### PR TITLE
Extend zip elimination

### DIFF
--- a/fpy2/ast/fpyast.py
+++ b/fpy2/ast/fpyast.py
@@ -332,6 +332,17 @@ class ListTypeAnn(TypeAnn):
             and self.length == other.length
         )
 
+def _opt_is_equiv(a: "Expr | None", b: "Expr | None") -> bool:
+    """Structural equivalence for an optional sub-expression.
+
+    Both absent is equivalent; one absent is not.  Never use ``==`` for this:
+    ``Expr`` defines no ``__eq__``, so it compares by identity and two
+    structurally-equal expressions would be reported different.
+    """
+    if a is None or b is None:
+        return a is None and b is None
+    return a.is_equiv(b)
+
 class Expr(Ast):
     """FPy AST: expression"""
     __slots__ = ()
@@ -1406,17 +1417,12 @@ class ListSlice(Expr):
     def is_equiv(self, other) -> bool:
         if not isinstance(other, ListSlice):
             return False
-
         if not self.value.is_equiv(other.value):
             return False
-
-        match self.start, other.start:
-            case Expr(), Expr():
-                return self.start.is_equiv(other.start)
-            case None, None:
-                return True
-            case _:
-                return False
+        return (
+            _opt_is_equiv(self.start, other.start)
+            and _opt_is_equiv(self.stop, other.stop)
+        )
 
 
 class IfExpr(Expr):
@@ -1687,7 +1693,11 @@ class AssertStmt(Stmt):
         return (
             isinstance(other, AssertStmt)
             and self.test.is_equiv(other.test)
-            and self.msg == other.msg
+            # ``==`` on an ``Expr`` is identity, so structurally-equal messages
+            # on distinct objects would compare unequal — which every
+            # ``DefaultTransformVisitor`` pass produces, since it rebuilds
+            # every node.
+            and _opt_is_equiv(self.msg, other.msg)
         )
 
 class EffectStmt(Stmt):

--- a/fpy2/transform/enumerate_elim.py
+++ b/fpy2/transform/enumerate_elim.py
@@ -78,7 +78,6 @@ target defeats the guard below.  See :mod:`fpy2.transform.iter_elim` for the
 machinery shared with :class:`fpy2.transform.ZipElim`.
 """
 
-import dataclasses
 from typing import Any
 
 from ..analysis import DefineUse, DefineUseAnalysis, SyntaxCheck
@@ -105,21 +104,21 @@ from ..ast.visitor import DefaultTransformVisitor
 from ..utils import Gensym, Id
 from .iter_elim import (
     Ctx,
+    Plan,
+    Slot,
     SubstNames,
     clone,
     comp_binding_is_pairs,
     destructure_subst,
     index_access,
     is_access_path,
+    plan_for_zip,
 )
-
-# An element binding slot: a name, a discard, or a nested destructure.
-_Slot = Id | TupleBinding
 
 
 def _split_target(
     target: Id | TupleBinding, iterable: Expr,
-) -> tuple[Id, _Slot] | None:
+) -> tuple[Id, Slot] | None:
     """Split ``for i, x in enumerate(src)``'s target into its index and
     element slots, or ``None`` if *target* / *iterable* aren't that pattern.
 
@@ -138,45 +137,18 @@ def _split_target(
     return idx, elt
 
 
-@dataclasses.dataclass
-class _Plan:
-    """Which sources to index, and which bindings read them.
-
-    ``args[0]`` also supplies the loop bound.  With ``tupled``, one slot reads
-    the whole element — rebuilt as ``(args[0][i], ..., args[n][i])``; without
-    it, each slot reads its own ``args[k][i]``.
-    """
-    args: list[Expr]
-    slots: list[_Slot]
-    tupled: bool
-
-    def __post_init__(self):
-        assert self.args, 'need a source for the bound'
-        assert len(self.slots) == (1 if self.tupled else len(self.args))
-
-
-def _plan(src: Expr, elt: _Slot) -> _Plan:
+def _plan(src: Expr, elt: Slot) -> Plan:
     """How to reach the element bound by *elt* when iterating ``enumerate(src)``.
 
-    A ``zip`` source decomposes into its own arguments, so neither
-    intermediate list is built.  Anything else is indexed whole.
+    A ``zip`` source decomposes into its own arguments, so neither intermediate
+    list is built.  Anything else — including a ``zip`` whose slot arity
+    disagrees — is indexed whole.
     """
-    # ``zip()`` has no source to take the bound from.
-    if isinstance(src, Zip) and src.args:
-        if (
-            isinstance(elt, TupleBinding)
-            and len(elt.elts) == len(src.args)
-            and all(
-                isinstance(e, (NamedId, UnderscoreId, TupleBinding))
-                for e in elt.elts
-            )
-        ):
-            return _Plan(list(src.args), list(elt.elts), tupled=False)
-        if isinstance(elt, (NamedId, UnderscoreId)):
-            return _Plan(list(src.args), [elt], tupled=True)
-        # A `TupleBinding` of mismatched arity falls through: see the module
-        # docstring on why the `zip` is left materialized.
-    return _Plan([src], [elt], tupled=False)
+    if isinstance(src, Zip):
+        plan = plan_for_zip(list(src.args), elt)
+        if plan is not None:
+            return plan
+    return Plan([src], [elt], tupled=False)
 
 
 class _EnumerateElimInstance(DefaultTransformVisitor):
@@ -223,7 +195,7 @@ class _EnumerateElimInstance(DefaultTransformVisitor):
     def _rewrite_for(
         self,
         stmt: ForStmt,
-        split: tuple[Id, _Slot],
+        split: tuple[Id, Slot],
         new_body: StmtBlock,
         ctx: Ctx,
     ) -> ForStmt:

--- a/fpy2/transform/iter_elim.py
+++ b/fpy2/transform/iter_elim.py
@@ -57,6 +57,54 @@ class Ctx:
         return Ctx(stmts=[])
 
 
+# A binding slot: a name, a discard, or a nested destructure.
+Slot = Id | TupleBinding
+
+
+@dataclasses.dataclass
+class Plan:
+    """Which sources to index, and which bindings read them.
+
+    ``args[0]`` also supplies the loop bound.  With ``tupled``, one slot reads
+    the whole element — rebuilt as ``(args[0][i], ..., args[n][i])``; without
+    it, each slot reads its own ``args[k][i]``.
+    """
+    args: list[Expr]
+    slots: list[Slot]
+    tupled: bool
+
+    def __post_init__(self):
+        assert self.args, 'need a source for the bound'
+        assert len(self.slots) == (1 if self.tupled else len(self.args))
+
+
+def plan_for_zip(args: list[Expr], slot: Slot) -> Plan | None:
+    """How *slot* reads one element of ``zip(*args)`` while indexing *args*
+    directly, or ``None`` if it cannot.
+
+    A slot destructuring the tuple positionally reads one source each; a slot
+    bound to the whole tuple has it rebuilt per iteration.  ``None`` means the
+    slot's arity disagrees with the ``zip``'s — an already ill-typed program,
+    where leaving the ``zip`` in place keeps its diagnostic rather than trading
+    it for an arity-mismatched destructure.
+    """
+    if not args:
+        # ``zip()`` has no source to take the bound from.
+        return None
+    if (
+        isinstance(slot, TupleBinding)
+        and len(slot.elts) == len(args)
+        and all(
+            isinstance(e, (NamedId, UnderscoreId, TupleBinding))
+            for e in slot.elts
+        )
+    ):
+        return Plan(list(args), list(slot.elts), tupled=False)
+    if isinstance(slot, (NamedId, UnderscoreId)):
+        return Plan(list(args), [slot], tupled=True)
+    return None
+
+
 def is_access_path(e: Expr) -> bool:
     """Whether *e* is safe to inline into a comprehension body, which
     re-evaluates it once per iteration.

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -90,6 +90,7 @@ from ..ast.fpyast import (
     Stmt,
     StmtBlock,
     TupleBinding,
+    TupleExpr,
     UnderscoreId,
     Var,
     Zip,
@@ -98,38 +99,29 @@ from ..ast.visitor import DefaultTransformVisitor
 from ..utils import Gensym, Id
 from .iter_elim import (
     Ctx,
+    Plan,
     SubstNames,
     clone,
     comp_binding_is_pairs,
     destructure_subst,
     index_access,
     is_access_path,
+    plan_for_zip,
 )
 
 
-def _is_zip_tuple_binding(target: Id | TupleBinding, iterable: Expr) -> bool:
-    """Predicate for the for-loop / comp fast path.
+def _plan(target: Id | TupleBinding, iterable: Expr) -> Plan | None:
+    """How *target* reads one element of *iterable*, or ``None`` when this
+    transform does not apply.
 
-    Fires iff *iterable* is a :class:`Zip` and *target* is a
-    :class:`TupleBinding` of matching arity.  Each binding slot may be a
-    :class:`NamedId`, an :class:`UnderscoreId`, or a nested
-    :class:`TupleBinding` (the per-iteration element of a nested slot is
-    itself a tuple, destructured via the ``fst``/``snd`` accessors in the
-    comp path and via a destructuring assignment in the for-loop path).
+    Fires iff *iterable* is a :class:`Zip` whose element *target* can read by
+    indexing the ``zip``'s own arguments — either destructuring them
+    positionally, or binding the whole tuple to one name (rebuilt per
+    iteration).  See :func:`fpy2.transform.iter_elim.plan_for_zip`.
     """
     if not isinstance(iterable, Zip):
-        return False
-    if not iterable.args:
-        # ``zip()`` has no source to take the length from.
-        return False
-    if not isinstance(target, TupleBinding):
-        return False
-    if len(iterable.args) != len(target.elts):
-        return False
-    return all(
-        isinstance(e, (NamedId, UnderscoreId, TupleBinding))
-        for e in target.elts
-    )
+        return None
+    return plan_for_zip(list(iterable.args), target)
 
 
 class _ZipElimInstance(DefaultTransformVisitor):
@@ -160,73 +152,45 @@ class _ZipElimInstance(DefaultTransformVisitor):
     # For loops
 
     def _visit_for(self, stmt: ForStmt, ctx: Ctx):
-        if not _is_zip_tuple_binding(stmt.target, stmt.iterable):
+        plan = _plan(stmt.target, stmt.iterable)
+        if plan is None:
             return super()._visit_for(stmt, ctx)
         # Recursively rewrite the body first, in case it contains
         # nested zip patterns.
         body, _ = self._visit_block(stmt.body, ctx)
-        return self._rewrite_for(stmt, body, ctx), ctx
+        return self._rewrite_for(stmt, plan, body, ctx), ctx
 
     def _rewrite_for(
-        self, stmt: ForStmt, new_body: StmtBlock, ctx: Ctx,
+        self, stmt: ForStmt, plan: Plan, new_body: StmtBlock, ctx: Ctx,
     ) -> ForStmt:
-        assert isinstance(stmt.iterable, Zip)
-        assert isinstance(stmt.target, TupleBinding)
-
         # Bind each zip arg to a fresh ``_srcK`` before the loop.
         # Even ``UnderscoreId`` binding slots get a temp for the
         # source so any side-effect in the arg fires exactly once.
         src_names: list[NamedId] = []
-        for arg in stmt.iterable.args:
+        for arg in plan.args:
             src = self.gensym.fresh('_src')
             ctx.stmts.append(Assign(src, None, arg, None))
             src_names.append(src)
 
         idx = self.gensym.fresh('_i')
-        # Build the per-iteration assignments: one per non-underscore
-        # binding slot.  Underscore slots are skipped; their source
-        # remains bound for side-effect ordering but isn't read.
+        # A tupled plan feeds every source into one slot; otherwise each slot
+        # reads its own.  `plan.tupled` is the discriminator, not the source
+        # count: `zip(xs)` is tupled over one source and still yields 1-tuples.
+        groups = [src_names] if plan.tupled else [[s] for s in src_names]
         per_iter: list[Stmt] = []
-        for elt, src in zip(stmt.target.elts, src_names):
-            match elt:
-                case UnderscoreId():
-                    continue
-                case NamedId() | TupleBinding():
-                    # ``NamedId`` -> ``a = src[i]``; a nested
-                    # ``TupleBinding`` -> ``(a, b) = src[i]``, whose
-                    # destructuring the backends already lower (the
-                    # statement context needs no ``fst``/``snd``).
-                    per_iter.append(
-                        Assign(
-                            elt, None,
-                            ListRef(Var(src, None), Var(idx, None), None),
-                            None,
-                        )
-                    )
-                case _:
-                    # Should be ruled out by the guard, but stay
-                    # defensive.
-                    raise RuntimeError(
-                        f'unexpected binding element in zip target: {elt!r}'
-                    )
+        for slot, srcs in zip(plan.slots, groups):
+            if isinstance(slot, UnderscoreId):
+                continue
+            refs = [ListRef(Var(s, None), Var(idx, None), None) for s in srcs]
+            # A nested slot becomes `(a, b) = src[i]` — the backends already
+            # destructure, so a statement context needs no `fst`/`snd`.
+            value = TupleExpr(refs, None) if plan.tupled else refs[0]
+            per_iter.append(Assign(slot, None, value, None))
 
-        # New body: per-iteration assigns, then the original body.
-        new_body_stmts: list[Stmt] = per_iter + list(new_body.stmts)
-        # Iterable: ``range(len(_src0))``.
-        size_expr = Len(
-            None,
-            Var(src_names[0], None),
-            None,
-        )
-        range_expr = Range1(
-            None,
-            size_expr,
-            None,
-        )
         return ForStmt(
             idx,
-            range_expr,
-            StmtBlock(new_body_stmts),
+            Range1(None, Len(None, Var(src_names[0], None), None), None),
+            StmtBlock(per_iter + list(new_body.stmts)),
             stmt.loc,
         )
 
@@ -234,11 +198,6 @@ class _ZipElimInstance(DefaultTransformVisitor):
     # List comprehensions
 
     def _visit_list_comp(self, e: ListComp, ctx: Any):
-        # Walk the comp's (target, iterable) pairs, rewriting any
-        # zip-tuple-binding stage whose zip arguments are all
-        # ``Var``s.  Non-matching stages are passed through.  The
-        # ``elt`` expression has substitutions applied for every
-        # rewritten stage.
         new_targets: list[Id | TupleBinding] = []
         new_iterables: list[Expr] = []
         subst: dict[NamedId, Expr] = {}
@@ -250,49 +209,57 @@ class _ZipElimInstance(DefaultTransformVisitor):
             # name no longer exists once that stage is rewritten.
             if subst:
                 new_iter = SubstNames(subst)._visit_expr(new_iter, ctx)
-            if (
-                _is_zip_tuple_binding(target, new_iter)
-                and isinstance(new_iter, Zip)
-                and isinstance(target, TupleBinding)
-                # Each arg is inlined into the comp body (re-evaluated per
-                # iteration, since a comp has no preamble to bind it once), so it
-                # must be a pure, re-evaluable access path.
-                and all(is_access_path(a) for a in new_iter.args)
-                # `fst`/`snd` are pair-only, so a nested slot of arity != 2 can't
-                # be reached by the comp path's accessor chains; leave such a
-                # `zip` in place (the backends materialize it) rather than emit
-                # ill-typed `snd`-of-non-pair.
-                and all(comp_binding_is_pairs(elt) for elt in target.elts)
-            ):
-                idx = self.gensym.fresh('_i')
-                # Substitute each binding slot with an accessor into its
-                # source: ``name -> arg[idx]`` for a plain slot, and the
-                # ``fst``/``snd`` chain for a nested tuple binding (whose
-                # per-iteration element is itself a tuple).
-                for binding, arg in zip(target.elts, new_iter.args):
-                    destructure_subst(
-                        binding, index_access(arg, idx), subst,
-                    )
-                # New target/iterable: ``_i in range(len(arg0))``.
-                len_expr = Len(
-                    None,
-                    clone(new_iter.args[0]),
-                    None,
-                )
-                new_targets.append(idx)
-                new_iterables.append(
-                    Range1(None, len_expr, None)
-                )
-            else:
+            rewritten = self._rewrite_comp_stage(target, new_iter, subst)
+            if rewritten is None:
                 new_targets.append(self._visit_binding(target, ctx))
                 new_iterables.append(new_iter)
+            else:
+                new_target, new_iterable = rewritten
+                new_targets.append(new_target)
+                new_iterables.append(new_iterable)
 
-        # Substitute names in ``elt`` after walking it normally
-        # (so nested zip patterns inside the elt are also rewritten).
+        # Walk `elt` normally first, so nested zip patterns inside it are
+        # rewritten too, then substitute.
         new_elt = self._visit_expr(e.elt, ctx)
         if subst:
             new_elt = SubstNames(subst)._visit_expr(new_elt, ctx)
         return ListComp(new_targets, new_iterables, new_elt, e.loc)
+
+    def _rewrite_comp_stage(
+        self,
+        target: Id | TupleBinding,
+        iterable: Expr,
+        subst: dict[NamedId, Expr],
+    ) -> tuple[Id, Expr] | None:
+        """The rewritten ``(target, iterable)`` for one comprehension stage,
+        extending *subst* with the accessors its slots need; ``None`` to leave
+        the stage as it is."""
+        plan = _plan(target, iterable)
+        if plan is None:
+            return None
+        # Sources are inlined and re-evaluated per iteration (a comp has no
+        # preamble to bind them once), so each must be pure and O(1).
+        if not all(is_access_path(a) for a in plan.args):
+            return None
+
+        idx = self.gensym.fresh('_i')
+        if plan.tupled:
+            # A whole-element slot is a name or a discard, so no `fst`/`snd`
+            # chain is involved and `comp_binding_is_pairs` has nothing to say.
+            slot = plan.slots[0]
+            if isinstance(slot, NamedId):
+                subst[slot] = TupleExpr(
+                    [index_access(arg, idx)() for arg in plan.args], None,
+                )
+        else:
+            # `fst`/`snd` are pair-only, so a destructuring slot of arity != 2
+            # can't be reached; leave the stage rather than emit an ill-typed
+            # `snd`-of-non-pair.
+            if not all(comp_binding_is_pairs(slot) for slot in plan.slots):
+                return None
+            for slot, arg in zip(plan.slots, plan.args):
+                destructure_subst(slot, index_access(arg, idx), subst)
+        return idx, Range1(None, Len(None, clone(plan.args[0]), None), None)
 
 
 class ZipElim:

--- a/fpy2/transform/zip_elim.py
+++ b/fpy2/transform/zip_elim.py
@@ -3,7 +3,8 @@ Rewrite ``zip(...)`` iterables into indexed loops over the source
 vectors, removing the need for any backend to materialize an
 intermediate list of tuples.
 
-Two patterns are recognized:
+Two positions are recognized — a ``for``-loop iterable and a comprehension
+iterable:
 
 1. **For-loop over zip.**
 
@@ -49,6 +50,29 @@ Two patterns are recognized:
    per iteration, which is only sound when they are pure and cheap.
    Comps with any other argument are left alone.
 
+Whole-tuple targets
+-------------------
+
+A target need not destructure.  Bound to one name, the tuple is rebuilt per
+iteration from the indexed sources — one stack tuple rather than an n-element
+list of them::
+
+   for p in zip(xs, ys):   ->   _src0 = xs
+       BODY                     _src1 = ys
+                                for _i in range(len(_src0)):
+                                    p = (_src0[_i], _src1[_i])
+                                    BODY
+
+and the comp path substitutes ``p -> (xs[_i], ys[_i])``.  A discarded target
+(``for _ in zip(xs, ys)``) builds nothing at all — its sources stay bound only
+for their side-effects and their length.
+
+Note ``zip(xs)`` yields *1-tuples*, so the decision to build a tuple keys on
+the plan rather than on the number of sources.
+
+Nested binding slots
+--------------------
+
 A binding slot may itself be a nested ``TupleBinding`` (e.g.
 ``for (a, b), c in zip(pairs, xs)``).  In the for-loop path the nested
 slot lowers to a destructuring assignment ``(a, b) = _srcK[_i]`` (any arity;
@@ -60,8 +84,10 @@ binding nested within it) is a pair; a comp with a nested slot of arity != 2
 is left unchanged for the backend to materialize (see
 :func:`fpy2.transform.iter_elim.comp_binding_is_pairs`).
 
-Patterns that don't match the guards (range iterables, mismatched
-arity, non-access-path list-comp zip args) are left unchanged.
+Patterns that don't match the guards are left unchanged: a range iterable, a
+destructuring target whose arity disagrees with the ``zip``'s (already
+ill-typed, so keeping the ``zip`` keeps its diagnostic), and non-access-path
+arguments in the comp path.
 
 Ordering note: run :class:`ZipElim` *before*
 :class:`fpy2.transform.ForUnpack`.  ``ForUnpack`` rewrites

--- a/tests/unit/ast/test_is_equiv.py
+++ b/tests/unit/ast/test_is_equiv.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for ``Ast.is_equiv`` — structural equivalence of AST nodes.
+
+``is_equiv`` is load-bearing beyond its own tests: every transform suite uses
+it to assert "this pass left the function alone", so a node that compares
+sloppily silently weakens those assertions.  Two shapes have gone wrong here:
+
+- comparing an optional sub-expression with ``==``, which is *identity* for an
+  ``Expr`` and so reports structurally-equal nodes as different (a false
+  negative — the pass looks like it changed something when it didn't); and
+- forgetting a field entirely, which reports different nodes as equivalent (a
+  false positive — the more dangerous direction, since a negative test then
+  passes even when a pass mangled that field).
+
+Both are covered below.  See ``_opt_is_equiv`` in ``fpy2/ast/fpyast.py``.
+"""
+
+import fpy2 as fp
+
+from fpy2.ast.visitor import DefaultTransformVisitor
+
+
+def _last_expr(f: fp.Function):
+    """The expression returned by *f*'s final statement."""
+    return f.ast.body.stmts[-1].expr
+
+
+def _first_stmt(f: fp.Function):
+    return f.ast.body.stmts[0]
+
+
+class TestListSliceIsEquiv:
+    """A slice compares on *both* bounds.
+
+    ``stop`` used to be skipped: the method returned inside the ``start``
+    match, so ``xs[1:3]`` reported equivalent to ``xs[1:5]`` and to ``xs[1:]``.
+    """
+
+    def test_differing_stop_is_not_equivalent(self):
+        @fp.fpy
+        def a(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:3]
+
+        @fp.fpy
+        def b(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:5]
+
+        assert not _last_expr(a).is_equiv(_last_expr(b))
+
+    def test_absent_stop_is_not_equivalent_to_present(self):
+        @fp.fpy
+        def a(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:3]
+
+        @fp.fpy
+        def b(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:]
+
+        assert not _last_expr(a).is_equiv(_last_expr(b))
+        assert not _last_expr(b).is_equiv(_last_expr(a))
+
+    def test_absent_start_is_not_equivalent_to_present(self):
+        @fp.fpy
+        def a(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:3]
+
+        @fp.fpy
+        def b(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[:3]
+
+        assert not _last_expr(a).is_equiv(_last_expr(b))
+        assert not _last_expr(b).is_equiv(_last_expr(a))
+
+    def test_identical_slices_are_equivalent(self):
+        @fp.fpy
+        def a(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:3]
+
+        @fp.fpy
+        def b(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:3]
+
+        assert _last_expr(a).is_equiv(_last_expr(b))
+
+    def test_both_bounds_absent_are_equivalent(self):
+        @fp.fpy
+        def a(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[:]
+
+        @fp.fpy
+        def b(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[:]
+
+        assert _last_expr(a).is_equiv(_last_expr(b))
+
+    def test_survives_a_no_op_rebuild(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            return xs[1:3]
+
+        rebuilt = DefaultTransformVisitor()._visit_function(f.ast, None)
+        assert rebuilt.is_equiv(f.ast)
+
+
+class TestAssertStmtIsEquiv:
+    """An assertion compares its message structurally, not by identity.
+
+    ``self.msg == other.msg`` on an ``Expr`` is an identity check, so any
+    ``DefaultTransformVisitor`` pass — which rebuilds every node — reported a
+    message-carrying assert as changed even when it was untouched.
+    """
+
+    def test_survives_a_no_op_rebuild(self):
+        @fp.fpy
+        def f():
+            assert 0 == 0, "a message"
+            return 0
+
+        rebuilt = DefaultTransformVisitor()._visit_function(f.ast, None)
+        assert rebuilt.is_equiv(f.ast)
+
+    def test_differing_messages_are_not_equivalent(self):
+        @fp.fpy
+        def f():
+            assert 0 == 0, "one"
+            return 0
+
+        @fp.fpy
+        def g():
+            assert 0 == 0, "two"
+            return 0
+
+        assert not _first_stmt(f).is_equiv(_first_stmt(g))
+
+    def test_message_and_no_message_are_not_equivalent(self):
+        @fp.fpy
+        def f():
+            assert 0 == 0, "a message"
+            return 0
+
+        @fp.fpy
+        def g():
+            assert 0 == 0
+            return 0
+
+        assert not _first_stmt(f).is_equiv(_first_stmt(g))
+        assert not _first_stmt(g).is_equiv(_first_stmt(f))
+
+    def test_no_messages_are_equivalent(self):
+        @fp.fpy
+        def f():
+            assert 0 == 0
+            return 0
+
+        rebuilt = DefaultTransformVisitor()._visit_function(f.ast, None)
+        assert rebuilt.is_equiv(f.ast)

--- a/tests/unit/transform/test_zip_elim.py
+++ b/tests/unit/transform/test_zip_elim.py
@@ -22,7 +22,7 @@ import fpy2 as fp
 
 from fpy2.ast.fpyast import (
     Assign, ForStmt, Fst, Len, ListComp, ListRef, NamedId, Range1, Snd,
-    TupleBinding, Var, Zip,
+    TupleBinding, TupleExpr, Var, Zip,
 )
 from fpy2.transform import ZipElim
 
@@ -235,6 +235,113 @@ class TestListCompRewrite:
         before = list(f(xs, ys))
         after = list(_eval(new_ast, f, xs, ys))
         assert before == after
+
+
+class TestWholeTupleTarget:
+    """A target bound to the *whole* zipped tuple, rather than destructuring it.
+
+    Previously the guard required a ``TupleBinding`` of matching arity, so a
+    single-name target left the ``zip`` materialized.  The tuple is now rebuilt
+    per iteration from the indexed sources instead — one stack tuple rather than
+    an n-element list of them.
+    """
+
+    def test_for_loop_builds_tuple_per_iteration(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for p in zip(xs, ys):
+                    acc = acc + fp.fst(p) * fp.snd(p)
+                return acc
+
+        new_ast = ZipElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        assert isinstance(loop.target, NamedId)
+        assert isinstance(loop.iterable, Range1)
+        # ``p = (_src0[_i], _src1[_i])`` — a tuple expression, not a ListRef.
+        first = loop.body.stmts[0]
+        assert isinstance(first, Assign)
+        assert isinstance(first.expr, TupleExpr)
+        assert len(first.expr.elts) == 2
+        assert all(isinstance(x, ListRef) for x in first.expr.elts)
+        assert not _contains(new_ast, Zip)
+        xs, ys = [1.0, 2.0, 3.0], [10.0, 20.0, 30.0]
+        assert _eval(new_ast, f, xs, ys) == f(xs, ys)
+
+    def test_list_comp_substitutes_a_tuple(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return [fp.fst(p) * fp.snd(p) for p in zip(xs, ys)]
+
+        new_ast = ZipElim.apply(f.ast)
+        comp = _find_listcomp(new_ast)
+        assert isinstance(comp.targets[0], NamedId)
+        assert isinstance(comp.iterables[0], Range1)
+        assert _contains(new_ast, TupleExpr)
+        assert not _contains(new_ast, Zip)
+        xs, ys = [1.0, 2.0, 3.0], [10.0, 20.0, 30.0]
+        assert list(_eval(new_ast, f, xs, ys)) == list(f(xs, ys))
+
+    def test_discarded_target_builds_nothing(self):
+        """Nothing reads the element, so no tuple is constructed — previously
+        this materialized the whole ``zip`` list purely to ask its length."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real], ys: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for _ in zip(xs, ys):
+                    acc = acc + 1
+                return acc
+
+        new_ast = ZipElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        # Nothing prepended: the body is exactly the original statement.
+        assert len(loop.body.stmts) == len(_find_for(f.ast).body.stmts)
+        assert not _contains(new_ast, (Zip, TupleExpr))
+        xs, ys = [1.0, 2.0, 3.0], [10.0, 20.0, 30.0]
+        assert _eval(new_ast, f, xs, ys) == f(xs, ys)
+
+    def test_single_argument_zip_still_yields_a_one_tuple(self):
+        """``zip(xs)`` produces 1-tuples, so the whole-tuple slot must build a
+        1-element ``TupleExpr`` — not the bare element.  Keying the decision on
+        the source count rather than the plan would get this wrong."""
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for p in zip(xs):
+                    acc = acc + 1
+                return acc
+
+        new_ast = ZipElim.apply(f.ast)
+        loop = _find_for(new_ast)
+        first = loop.body.stmts[0]
+        assert isinstance(first, Assign)
+        assert isinstance(first.expr, TupleExpr)
+        assert len(first.expr.elts) == 1
+        assert not _contains(new_ast, Zip)
+        assert _eval(new_ast, f, [1.0, 2.0]) == f([1.0, 2.0])
+
+    def test_mismatched_arity_keeps_the_zip(self):
+        """Shape-only: a 2-slot binding over a 3-argument ``zip`` is ill-typed,
+        so it cannot be evaluated.  Leaving the ``zip`` keeps its diagnostic
+        rather than trading it for an arity-mismatched destructure."""
+
+        @fp.fpy
+        def f(
+            xs: list[fp.Real], ys: list[fp.Real], zs: list[fp.Real]
+        ) -> fp.Real:
+            with fp.FP64:
+                acc = 0
+                for a, b in zip(xs, ys, zs):  # type: ignore[misc]
+                    acc = acc + a * b
+                return acc
+
+        assert ZipElim.apply(f.ast).is_equiv(f.ast)
 
 
 class TestProperties:


### PR DESCRIPTION
Extends zip elimination to cases that enumerate elimination. Also fixes an unrelated issue with the `is_equiv()` method for certain AST nodes