### PR TITLE
Add escape analysis

### DIFF
--- a/fpy2/analysis/__init__.py
+++ b/fpy2/analysis/__init__.py
@@ -20,6 +20,7 @@ from .context_use import (
 )
 from .define_use import DefCtx, DefineUse, DefineUseAnalysis, UseSite
 from .defs import DefAnalysis
+from .escape import Escape, EscapeSummary
 from .format_infer import FormatAnalysis, FormatInfer
 from .live_vars import LiveVars
 from .partial_eval import PartialEval, PartialEvalInfo

--- a/fpy2/analysis/alias.py
+++ b/fpy2/analysis/alias.py
@@ -438,6 +438,15 @@ class AliasAnalysis:
         cell = self._site_cell.get(site)
         return None if cell is None else self._cells.find(cell)
 
+    def escapes_at(self, region: Region) -> bool:
+        """Whether *region* is held by something outside while this function
+        still holds it — handed to a call, or to an unmodelled operation."""
+        return self._cells.is_shared_out(region)
+
+    def returned_at(self, region: Region) -> bool:
+        """Whether *region* is handed to the caller by a ``return``."""
+        return self._cells.is_returned(region)
+
     def sites_at(self, region: Region | None) -> frozenset[AllocSite]:
         """The allocations that may live in *region*."""
         return frozenset() if region is None else self._cells.sites_at(region)

--- a/fpy2/analysis/alias.py
+++ b/fpy2/analysis/alias.py
@@ -61,7 +61,7 @@ rather than soundness.
 """
 
 from dataclasses import dataclass
-from typing import Literal, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from ..ast import (
     Argument,
@@ -92,11 +92,17 @@ from ..ast import (
     Var,
     Zip,
 )
+from ..function import Function
 from ..types import ListType, TupleType, Type
 from ..utils import Unionfind
 from .define_use import DefineUse, DefineUseAnalysis
 from .reaching_defs import AssignDef, Definition, PhiDef
 from .type_infer import TypeAnalysis, TypeInfer
+
+if TYPE_CHECKING:
+    # `escape` builds on this module; the dependency only goes the other way
+    # at type-check time
+    from .escape import EscapeSummary
 
 ELTS = None
 """Part key for the elements of a list.
@@ -406,6 +412,14 @@ class AliasAnalysis:
             pending.extend(self._cells._parts.get(root, {}).values())
         return frozenset(seen)
 
+    def all_defs(self) -> frozenset[Definition]:
+        """Every definition the analysis gave a cell to."""
+        return frozenset(self._cell_of)
+
+    def region_at(self, region: Region, depth: int = 1) -> Region | None:
+        """The region *depth* levels inside *region*."""
+        return self._walk(region, depth)
+
     def defs_in(self, region: Region) -> frozenset[Definition]:
         """Every definition whose value may live in *region*."""
         out = {
@@ -520,10 +534,12 @@ class _Builder(DefaultVisitor):
     """
 
     def __init__(self, func: FuncDef, def_use: DefineUseAnalysis,
-                 type_info: TypeAnalysis):
+                 type_info: TypeAnalysis,
+                 summaries: 'dict[FuncDef, EscapeSummary]'):
         self.func = func
         self.def_use = def_use
         self.types = type_info
+        self.summaries = summaries
         self.cells = _Cells()
         self.sites: list[AllocSite] = []
         self.cell_of: dict[Definition, _Cell] = {}
@@ -742,9 +758,21 @@ class _Builder(DefaultVisitor):
                     self._bind(elt, self._part(cell, i), site)
 
     def _escape_args(self, e: Call) -> None:
-        for a in e.args:
+        """A list handed to a call may be kept by the callee.
+
+        Unless its summary says otherwise: a callee that only reads or writes
+        its argument holds nothing once it returns, so the caller's list is no
+        more shared than before the call.  No summary — a foreign function, or
+        one not yet analyzed — means the conservative answer.
+        """
+        summary = None
+        if isinstance(e.fn, Function):
+            summary = self.summaries.get(e.fn.ast)
+        for i, a in enumerate(e.args):
             ac = self._cell_for(a)
-            if ac is not None:
+            if ac is None:
+                continue
+            if summary is None or summary.retains(i):
                 self.cells.mark_shared_out(ac)
 
     # -- constraint-generating hooks ---------------------------------------
@@ -802,6 +830,7 @@ class Alias:
         func: FuncDef,
         def_use: DefineUseAnalysis | None = None,
         type_info: TypeAnalysis | None = None,
+        summaries: 'dict[FuncDef, EscapeSummary] | None' = None,
     ) -> AliasAnalysis:
         """Compute what may refer to each list in *func*.
 
@@ -810,6 +839,9 @@ class Alias:
             def_use: reuse an existing def-use analysis.
             type_info: reuse an existing type analysis (needed to tell which
                 expressions carry lists).
+            summaries: escape summaries for the callees, so an argument a callee
+                does not retain is not treated as shared.  A callee absent from
+                it is assumed to retain everything.
         """
         if not isinstance(func, FuncDef):
             raise TypeError(f"expected a 'FuncDef', got {func}")
@@ -817,4 +849,4 @@ class Alias:
             def_use = DefineUse.analyze(func)
         if type_info is None:
             type_info = TypeInfer.check(func, def_use=def_use)
-        return _Builder(func, def_use, type_info).run()
+        return _Builder(func, def_use, type_info, summaries or {}).run()

--- a/fpy2/analysis/escape.py
+++ b/fpy2/analysis/escape.py
@@ -6,49 +6,39 @@ keep it — so :mod:`fpy2.analysis.alias` marks any call argument *shared outwar
 That is what makes a compiled-to-compiled boundary keep its handles, and it is
 the whole cost of decomposing a program into several functions.
 
-A summary answers the question that assumption is standing in for: **after this
-call returns, can anything outside still reach the argument's list?**  A caller
-holding a summary that says no can stop marking the argument shared.
+A summary answers the question that assumption stands in for: **after this call
+returns, can anything outside still reach the argument's list?**  A caller whose
+summary says no can stop marking the argument shared.
 
 Retention is not mutation.  ``zs[0] = 99`` writes the caller's list *during* the
-call and keeps nothing afterwards, so it does not retain — which is the case most
-worth getting right, since a conservative reading of "the callee touches it"
-would give up exactly the kernels worth unboxing.
+call and keeps nothing afterwards, so it does not retain.  Reading "the callee
+touches it" as retention would give up exactly the kernels worth unboxing.
 
-A parameter is retained when its alias region:
+A parameter is retained when its alias region is returned, is reachable from
+another parameter (``yss[0] = xs``, so the caller can find it through something
+it already holds), or is marked *shared outward* — which covers a retaining
+callee, a foreign one, and any expression kind ``alias`` does not model.
 
-- is returned — the caller ends up with a second reference to it;
-- is reachable from another parameter, e.g. ``yss[0] = xs``, so the caller can
-  find it through something it already holds;
-- is handed to a callee that retains it, or to one this analysis cannot see.
+Reading routes off regions rather than syntax means aliasing inside the callee
+needs no rule of its own: ``ys = xs; return ys`` retains ``xs`` because both
+names are one region.
 
-Because the routes are read off alias regions rather than off syntax, aliasing
-inside the callee is handled for free: ``ys = xs; return ys`` retains ``xs``
-because both names are one region.
-
-Computed leaves-first over :attr:`CallGraphAnalysis.order`, so a callee's summary
-exists before its callers need it.  No fixpoint is needed and none would help:
-the parser rejects forward references, so recursion cannot be written and the
-order is always a DAG.  A missing summary — a foreign callee, or the cycle
-:mod:`.call_graph` guards against in a programmatically-built module — reads as
-*retains everything*, which is the only case a test can reach: a recursive FPy
-function cannot be written at all.
+Computed leaves-first, so a callee's summary exists before its callers need it.
+No fixpoint is needed and none would help — the parser rejects forward
+references, so recursion cannot be written and the order is always a DAG.  A
+missing summary reads as *retains everything*.
 """
 
 from dataclasses import dataclass
 
-from ..ast import Call, DefaultVisitor, Expr, FuncDef, NamedId
-from ..function import Function
+from ..ast import Argument, FuncDef, NamedId
 from .alias import Alias, AliasAnalysis, Region
 from .define_use import DefineUse, DefineUseAnalysis
 
 
 @dataclass(frozen=True)
 class EscapeSummary:
-    """Which of a function's parameters outlive a call to it, by index.
-
-    A parameter that carries no list is never retained; there is nothing to hold.
-    """
+    """Which of a function's parameters outlive a call to it, by index."""
 
     retained: frozenset[int]
 
@@ -70,20 +60,21 @@ class Escape:
 
         Args:
             func: the function to summarize.
-            summaries: summaries of its callees, keyed by ``FuncDef``.  A callee
-                absent from it is assumed to retain everything.
+            summaries: summaries of its callees.  One absent from it is assumed
+                to retain everything.
             def_use: reuse an existing def-use analysis.
-            alias: reuse an existing alias analysis.
+            alias: reuse an existing alias analysis.  It must have been built
+                with the same *summaries*, or every call argument reads as
+                shared and the result says nothing.
         """
         if not isinstance(func, FuncDef):
             raise TypeError(f"expected a 'FuncDef', got {func}")
         if def_use is None:
             def_use = DefineUse.analyze(func)
         if alias is None:
-            alias = Alias.analyze(func, def_use=def_use)
-
-        held = _RetainedRegions(alias, summaries or {})
-        held._visit_function(func, None)
+            alias = Alias.analyze(
+                func, def_use=def_use, summaries=summaries,
+            )
 
         retained: set[int] = set()
         for i, arg in enumerate(func.args):
@@ -92,52 +83,21 @@ class Escape:
             d = def_use.find_def_from_site(arg.name, arg)
             depth = 0
             while (region := alias.region_of(d, depth)) is not None:
-                if held.retains(region, arg):
+                if _retains(alias, region, arg):
                     retained.add(i)
                     break
                 depth += 1
         return EscapeSummary(frozenset(retained))
 
 
-class _RetainedRegions(DefaultVisitor):
-    """Collects the regions a call leaves reachable from outside."""
-
-    def __init__(
-        self,
-        alias: AliasAnalysis,
-        summaries: dict[FuncDef, EscapeSummary],
-    ):
-        self.alias = alias
-        self.summaries = summaries
-        self.by_call: set[Region] = set()
-
-    def retains(self, region: Region, arg) -> bool:
-        if region in self.by_call:
-            return True
-        sites = self.alias.sites_at(region)
-        if any(self.alias.is_returned(s) for s in sites):
-            return True
-        # reachable from a *different* parameter: the caller can find it through
-        # something it already holds
-        return any(
-            s.kind == 'param' and s.node is not arg for s in sites
-        )
-
-    def _visit_call(self, e: Call, ctx):
-        summary = None
-        if isinstance(e.fn, Function):
-            summary = self.summaries.get(e.fn.ast)
-        for i, a in enumerate(e.args):
-            if self.alias.region_of_expr(a) is None:
-                continue
-            if summary is None or summary.retains(i):
-                self._mark(a)
-        super()._visit_call(e, ctx)
-
-    def _mark(self, e: Expr) -> None:
-        """Retain *region* and everything inside it: handing out a nested list
-        hands out its rows."""
-        depth = 0
-        while (inner := self.alias.region_of_expr(e, depth)) is not None:
-            self.by_call.add(inner)
-            depth += 1
+def _retains(alias: AliasAnalysis, region: Region, arg: Argument) -> bool:
+    """Whether *region* outlives a call, given *arg* is the parameter asked
+    about."""
+    if alias.returned_at(region) or alias.escapes_at(region):
+        return True
+    # reachable from a *different* parameter: the caller can find it through
+    # something it already holds
+    return any(
+        s.kind == 'param' and s.node is not arg
+        for s in alias.sites_at(region)
+    )

--- a/fpy2/analysis/escape.py
+++ b/fpy2/analysis/escape.py
@@ -1,0 +1,143 @@
+"""
+Escape summaries: which of a function's list parameters outlive the call.
+
+A caller that hands a list to a callee has to assume the worst — the callee might
+keep it — so :mod:`fpy2.analysis.alias` marks any call argument *shared outward*.
+That is what makes a compiled-to-compiled boundary keep its handles, and it is
+the whole cost of decomposing a program into several functions.
+
+A summary answers the question that assumption is standing in for: **after this
+call returns, can anything outside still reach the argument's list?**  A caller
+holding a summary that says no can stop marking the argument shared.
+
+Retention is not mutation.  ``zs[0] = 99`` writes the caller's list *during* the
+call and keeps nothing afterwards, so it does not retain — which is the case most
+worth getting right, since a conservative reading of "the callee touches it"
+would give up exactly the kernels worth unboxing.
+
+A parameter is retained when its alias region:
+
+- is returned — the caller ends up with a second reference to it;
+- is reachable from another parameter, e.g. ``yss[0] = xs``, so the caller can
+  find it through something it already holds;
+- is handed to a callee that retains it, or to one this analysis cannot see.
+
+Because the routes are read off alias regions rather than off syntax, aliasing
+inside the callee is handled for free: ``ys = xs; return ys`` retains ``xs``
+because both names are one region.
+
+Computed leaves-first over :attr:`CallGraphAnalysis.order`, so a callee's summary
+exists before its callers need it.  No fixpoint is needed and none would help:
+the parser rejects forward references, so recursion cannot be written and the
+order is always a DAG.  A missing summary — a foreign callee, or the cycle
+:mod:`.call_graph` guards against in a programmatically-built module — reads as
+*retains everything*, which is the only case a test can reach: a recursive FPy
+function cannot be written at all.
+"""
+
+from dataclasses import dataclass
+
+from ..ast import Call, DefaultVisitor, Expr, FuncDef, NamedId
+from ..function import Function
+from .alias import Alias, AliasAnalysis, Region
+from .define_use import DefineUse, DefineUseAnalysis
+
+
+@dataclass(frozen=True)
+class EscapeSummary:
+    """Which of a function's parameters outlive a call to it, by index.
+
+    A parameter that carries no list is never retained; there is nothing to hold.
+    """
+
+    retained: frozenset[int]
+
+    def retains(self, index: int) -> bool:
+        return index in self.retained
+
+
+class Escape:
+    """Escape summaries for FPy programs."""
+
+    @staticmethod
+    def analyze(
+        func: FuncDef,
+        summaries: dict[FuncDef, EscapeSummary] | None = None,
+        def_use: DefineUseAnalysis | None = None,
+        alias: AliasAnalysis | None = None,
+    ) -> EscapeSummary:
+        """Which of *func*'s parameters outlive a call to it.
+
+        Args:
+            func: the function to summarize.
+            summaries: summaries of its callees, keyed by ``FuncDef``.  A callee
+                absent from it is assumed to retain everything.
+            def_use: reuse an existing def-use analysis.
+            alias: reuse an existing alias analysis.
+        """
+        if not isinstance(func, FuncDef):
+            raise TypeError(f"expected a 'FuncDef', got {func}")
+        if def_use is None:
+            def_use = DefineUse.analyze(func)
+        if alias is None:
+            alias = Alias.analyze(func, def_use=def_use)
+
+        held = _RetainedRegions(alias, summaries or {})
+        held._visit_function(func, None)
+
+        retained: set[int] = set()
+        for i, arg in enumerate(func.args):
+            if not isinstance(arg.name, NamedId):
+                continue
+            d = def_use.find_def_from_site(arg.name, arg)
+            depth = 0
+            while (region := alias.region_of(d, depth)) is not None:
+                if held.retains(region, arg):
+                    retained.add(i)
+                    break
+                depth += 1
+        return EscapeSummary(frozenset(retained))
+
+
+class _RetainedRegions(DefaultVisitor):
+    """Collects the regions a call leaves reachable from outside."""
+
+    def __init__(
+        self,
+        alias: AliasAnalysis,
+        summaries: dict[FuncDef, EscapeSummary],
+    ):
+        self.alias = alias
+        self.summaries = summaries
+        self.by_call: set[Region] = set()
+
+    def retains(self, region: Region, arg) -> bool:
+        if region in self.by_call:
+            return True
+        sites = self.alias.sites_at(region)
+        if any(self.alias.is_returned(s) for s in sites):
+            return True
+        # reachable from a *different* parameter: the caller can find it through
+        # something it already holds
+        return any(
+            s.kind == 'param' and s.node is not arg for s in sites
+        )
+
+    def _visit_call(self, e: Call, ctx):
+        summary = None
+        if isinstance(e.fn, Function):
+            summary = self.summaries.get(e.fn.ast)
+        for i, a in enumerate(e.args):
+            if self.alias.region_of_expr(a) is None:
+                continue
+            if summary is None or summary.retains(i):
+                self._mark(a)
+        super()._visit_call(e, ctx)
+
+    def _mark(self, e: Expr) -> None:
+        """Retain *region* and everything inside it: handing out a nested list
+        hands out its rows."""
+        depth = 0
+        while (inner := self.alias.region_of_expr(e, depth)) is not None:
+            self.by_call.add(inner)
+            depth += 1

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -16,11 +16,13 @@ from ...analysis import (
     ArraySizeInfer,
     ContextUse,
     DefineUse,
+    Escape,
     FormatInfer,
 )
 from ...analysis.alias import AliasAnalysis
 from ...analysis.context_use import ContextUseAnalysis
 from ...analysis.define_use import DefineUseAnalysis
+from ...analysis.escape import EscapeSummary
 from ...analysis.format_infer import FormatAnalysis
 from ...ast.fpyast import Call, FuncDef, NamedId
 from ...ast.visitor import DefaultVisitor
@@ -103,6 +105,25 @@ def _find_spec(specs: list[Function], func: Function) -> Function:
     raise CppCompileError(
         f'`{func.name}` has no specialization in this module'
     )
+
+
+def _param_storage(a: SpecAnalyses) -> list[tuple[CppType, bool]]:
+    """Each parameter's emitted type, and whether its elements are written.
+
+    Both cross a call edge: an argument must have the representation the callee
+    declared, and must be non-const if the callee writes it.
+    """
+    out: list[tuple[CppType, bool]] = []
+    for arg in a.ast.args:
+        if not isinstance(arg.name, NamedId):
+            raise CppCompileError(f'unnamed parameter in `{a.ast.name}`')
+        d = a.def_use.find_def_from_site(arg.name, arg)
+        ty = a.storage.storage_of(d)
+        written = a.unbox is not None and a.unbox.writes_through(
+            a.alias.region_of(d), ty,
+        )
+        out.append((ty, written))
+    return out
 
 
 def _callees(ast: FuncDef) -> list[Function]:
@@ -245,13 +266,45 @@ class CppCompiler(Backend):
           4. **Per-spec codegen**, leaves-first, one C++ definition per entry.
         """
         specs = self.specialize(module)
-        # A function compiled code calls cannot unbox its parameters; see
-        # `unbox.Unbox.decide`.
-        called = {id(c.ast) for f in specs for c in _callees(f.ast)}
+        params: dict[FuncDef, list[tuple[CppType, bool]]] = {}
         return '\n\n'.join(
-            self._compile_function(f, is_called=id(f.ast) in called)
-            for f in specs
+            self._emit(f, a, params)
+            for f, a in self._analyze_all(specs, params)
         )
+
+    def _analyze_all(
+        self,
+        specs: list[Function],
+        params: dict[FuncDef, list[tuple[CppType, bool]]],
+    ):
+        """Analyze every spec leaves-first, filling *params* as it goes.
+
+        One path, so :meth:`compile_module` and :meth:`signature` cannot reach
+        different conclusions about the same function — they did once, and it
+        was an ABI bug rather than a missed optimization.
+        """
+        called = {id(c.ast) for f in specs for c in _callees(f.ast)}
+        summaries = self._summaries(specs)
+        for f in specs:
+            a = self.analyze(
+                f, is_called=id(f.ast) in called, summaries=summaries,
+                callee_params=params,
+            )
+            yield f, a
+            params[f.ast] = _param_storage(a)
+
+    def _summaries(
+        self, specs: list[Function],
+    ) -> dict[FuncDef, EscapeSummary]:
+        """Escape summaries for every spec, leaves-first.
+
+        A caller needs its callees' summaries to know which arguments it can
+        stop treating as shared; :meth:`specialize` already orders them.
+        """
+        out: dict[FuncDef, EscapeSummary] = {}
+        for f in specs:
+            out[f.ast] = Escape.analyze(f.ast, out)
+        return out
 
     def specialize(self, module: Module) -> list[Function]:
         """Steps 1-3 of the pipeline: the fully-specialized functions, in
@@ -285,7 +338,12 @@ class CppCompiler(Backend):
         return list(specialized.call_graph().order)
 
     def analyze(
-        self, func: Function, *, is_called: bool = False,
+        self,
+        func: Function,
+        *,
+        is_called: bool = False,
+        summaries: dict[FuncDef, EscapeSummary] | None = None,
+        callee_params: dict[FuncDef, list[tuple[CppType, bool]]] | None = None,
     ) -> SpecAnalyses:
         """The per-spec analyses one fully-specialized function is emitted
         from."""
@@ -322,11 +380,14 @@ class CppCompiler(Backend):
                 f'internal error: {e!r}'
             ) from e
 
-        alias = Alias.analyze(ast, def_use=def_use)
+        alias = Alias.analyze(ast, def_use=def_use, summaries=summaries)
         unbox = None
         if self._unbox:
             unbox = Unbox.decide(
-                ast, storage, alias, def_use, is_called=is_called,
+                ast, storage, alias, def_use,
+                is_called=is_called,
+                summary=(summaries or {}).get(ast),
+                callee_params=callee_params,
             )
             # Rewrite each class's storage in place: the emitter reads a
             # declaration's representation straight off the type.
@@ -361,22 +422,17 @@ class CppCompiler(Backend):
             module = Module()
             module.add(func, ctx=ctx, arg_types=arg_types)
         specs = self.specialize(module)
-        called = {id(c.ast) for s in specs for c in _callees(s.ast)}
         entry = _find_spec(specs, func)
-        a = self.analyze(entry, is_called=id(entry.ast) in called)
-
-        params = []
-        for arg in a.ast.args:
-            if not isinstance(arg.name, NamedId):
-                raise CppCompileError(f'unnamed parameter in `{func.name}`')
-            d = a.def_use.find_def_from_site(arg.name, arg)
-            params.append(a.storage.storage_of(d))
+        emitted: dict[FuncDef, list[tuple[CppType, bool]]] = {}
+        a = next(
+            an for f, an in self._analyze_all(specs, emitted) if f is entry
+        )
 
         # same rule as `CppEmitter._infer_return_storage`
         ret = choose_storage(a.format_info.fn_fmt.ret_fmt)
         if a.unbox is not None:
             ret = a.unbox.annotate_return(ret)
-        return params, ret
+        return [ty for ty, _written in _param_storage(a)], ret
 
     def _compile_function(
         self, func: Function, *, is_called: bool = False,
@@ -385,7 +441,14 @@ class CppCompiler(Backend):
         :class:`Function`.  ``func.ast.name`` is the final emitted name
         (set by :class:`Specialize` — public entries keep their user-given
         name, private specs get a mangled one)."""
-        a = self.analyze(func, is_called=is_called)
+        return self._emit(func, self.analyze(func, is_called=is_called), {})
+
+    def _emit(
+        self,
+        func: Function,
+        a: SpecAnalyses,
+        callee_params: dict[FuncDef, list[tuple[CppType, bool]]],
+    ) -> str:
         ast = a.ast
 
         # Call.fn → emitted name.  ``Specialize`` rewired each Call.fn at
@@ -401,6 +464,7 @@ class CppCompiler(Backend):
             call_names=call_names,
             unsafe_cast_int=self._unsafe_cast_int,
             unbox=a.unbox,
+            callee_params=callee_params,
         )
         try:
             return emitter.emit()

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -66,6 +66,7 @@ class SpecAnalyses:
     format_info: FormatAnalysis
     storage: StorageAnalysis
     alias: AliasAnalysis
+    summary: EscapeSummary
     unbox: UnboxAnalysis | None
 
 
@@ -284,27 +285,15 @@ class CppCompiler(Backend):
         was an ABI bug rather than a missed optimization.
         """
         called = {id(c.ast) for f in specs for c in _callees(f.ast)}
-        summaries = self._summaries(specs)
+        summaries: dict[FuncDef, EscapeSummary] = {}
         for f in specs:
             a = self.analyze(
                 f, is_called=id(f.ast) in called, summaries=summaries,
                 callee_params=params,
             )
             yield f, a
+            summaries[f.ast] = a.summary
             params[f.ast] = _param_storage(a)
-
-    def _summaries(
-        self, specs: list[Function],
-    ) -> dict[FuncDef, EscapeSummary]:
-        """Escape summaries for every spec, leaves-first.
-
-        A caller needs its callees' summaries to know which arguments it can
-        stop treating as shared; :meth:`specialize` already orders them.
-        """
-        out: dict[FuncDef, EscapeSummary] = {}
-        for f in specs:
-            out[f.ast] = Escape.analyze(f.ast, out)
-        return out
 
     def specialize(self, module: Module) -> list[Function]:
         """Steps 1-3 of the pipeline: the fully-specialized functions, in
@@ -381,12 +370,19 @@ class CppCompiler(Backend):
             ) from e
 
         alias = Alias.analyze(ast, def_use=def_use, summaries=summaries)
+        # This function's own summary, from the alias analysis it already has.
+        # Its callers read it to decide whether they can stop treating an
+        # argument as shared; it reads its own to decide the same about its
+        # parameters, so both ends reach the same answer.
+        summary = Escape.analyze(
+            ast, summaries, def_use=def_use, alias=alias,
+        )
         unbox = None
         if self._unbox:
             unbox = Unbox.decide(
                 ast, storage, alias, def_use,
                 is_called=is_called,
-                summary=(summaries or {}).get(ast),
+                summary=summary,
                 callee_params=callee_params,
             )
             # Rewrite each class's storage in place: the emitter reads a
@@ -400,6 +396,7 @@ class CppCompiler(Backend):
             format_info=format_info,
             storage=storage,
             alias=alias,
+            summary=summary,
             unbox=unbox,
         )
 

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -119,6 +119,7 @@ from ...ast.fpyast import (
     Zip,
 )
 from ...ast.visitor import Visitor
+from ...function import Function
 from ...number import (
     REAL,
     RM,
@@ -257,6 +258,7 @@ class CppEmitter(Visitor):
         call_names: dict | None = None,
         unsafe_cast_int: bool = False,
         unbox: 'UnboxAnalysis | None' = None,
+        callee_params: dict | None = None,
     ):
         self.ast = ast
         self.storage = storage
@@ -265,6 +267,8 @@ class CppEmitter(Visitor):
         self.ctx_use = ctx_use
         # How each list is represented, or ``None`` to keep every handle.
         self.unbox = unbox
+        # Emitted parameter types of the callees, so a call site can adapt.
+        self._callee_params: dict = callee_params or {}
         # Optional C++ name to emit at the function-signature site
         # — used by the compiler to differentiate specializations of
         # the same callee at distinct rounding contexts (template-
@@ -506,27 +510,15 @@ class CppEmitter(Visitor):
     def _writes_through(self, d: Definition, storage: CppType) -> bool:
         """Whether a ``const`` reference to *d* would reject a write FPy allows.
 
-        ``const fpy::list<T>&`` does not: ``const`` qualifies the handle, and
-        ``xs[i] = e`` through one is exactly FPy's parameter semantics.  An
-        unboxed list has no such indirection, so ``const std::vector<T>&`` makes
-        its elements const too and the same store stops compiling.
+        Region-wide, and across calls: ``ys = xs; ys[0] = e`` writes through a
+        different storage class than the one declared, and a callee that writes
+        its parameter makes the caller's argument non-const too.
         """
         if self.unbox is None:
             return False
-        # Region-wide at each level, not class-wide: `ys = xs; ys[0] = e`
-        # writes through a *different* storage class than the one declared.
-        ty, depth = storage, 0
-        while isinstance(ty, CppList) and not ty.boxed:
-            region = self.unbox.alias.region_of(d, depth)
-            if region is None:
-                return True
-            if any(
-                isinstance(m, AssignDef) and isinstance(m.site, IndexedAssign)
-                for m in self.unbox.alias.defs_in(region)
-            ):
-                return True
-            ty, depth = ty.elt, depth + 1
-        return False
+        return self.unbox.writes_through(
+            self.unbox.alias.region_of(d), storage,
+        )
 
     def _foreach_decl(self, target_def, name: str) -> str:
         """Loop-variable declaration for a range-for over a container.
@@ -2229,9 +2221,43 @@ class CppEmitter(Visitor):
                 f'(call to `{e.func}`)',
                 at=e,
             )
-        args = ', '.join(self._visit_expr(a, ctx) for a in e.args)
+        params = None
+        if isinstance(e.fn, Function):
+            params = self._callee_params.get(e.fn.ast)
+        parts = []
+        for i, a in enumerate(e.args):
+            want = params[i][0] if params and i < len(params) else None
+            parts.append(self._adapt_arg(self._visit_expr(a, ctx), a, want))
         target = self._call_names.get(e, str(e.func))
-        return f'{target}({args})'
+        return f'{target}({", ".join(parts)})'
+
+    def _adapt_arg(self, emitted: str, e: Expr, want: CppType | None) -> str:
+        """*emitted* as the callee spelled its parameter.
+
+        A callee's signature is fixed by its own body, so a caller that keeps a
+        handle for a local reason the callee does not share must hand over the
+        pointee.  That names the same elements — no copy, and a write through it
+        still reaches the caller.
+
+        Only this direction arises: ``unbox`` gives an argument a handle whenever
+        the callee declared one, so a caller never holds a bare vector where a
+        handle is wanted.  Which is just as well — the reverse needs
+        ``fpy::borrow``, and that cannot take the ``const`` reference a read-only
+        parameter is.
+        """
+        if want is None or self.unbox is None:
+            return emitted
+        have = self._storage_for_expr(e)
+        if not (isinstance(have, CppList) and isinstance(want, CppList)):
+            return emitted
+        if have.boxed == want.boxed:
+            return emitted
+        if not have.boxed:
+            raise CppEmitError(
+                f'passing an unboxed list where `{want.format()}` is declared',
+                at=e,
+            )
+        return f'*{self._bind_operand(emitted)}'
 
     def _visit_tuple_expr(self, e: TupleExpr, ctx) -> str:
         # ``(a, b, c)`` → ``std::make_tuple(a, b, c)``.  Type deduction

--- a/fpy2/backend/cpp/unbox.py
+++ b/fpy2/backend/cpp/unbox.py
@@ -37,10 +37,12 @@ from dataclasses import dataclass, field
 from ...analysis import Definition
 from ...analysis.alias import AliasAnalysis, Region
 from ...analysis.define_use import DefineUseAnalysis
+from ...analysis.escape import EscapeSummary
 from ...analysis.reaching_defs import AssignDef
 from ...ast.fpyast import (
     Argument,
     Assign,
+    Call,
     Expr,
     ForStmt,
     FuncDef,
@@ -51,6 +53,7 @@ from ...ast.fpyast import (
     Var,
 )
 from ...ast.visitor import DefaultVisitor
+from ...function import Function
 from .storage_infer import (
     StorageAnalysis,
     binds_by_reference,
@@ -72,10 +75,33 @@ class UnboxAnalysis:
     boxed: dict[Region, bool] = field(default_factory=dict)
     storage: dict[Definition, CppType] = field(default_factory=dict)
     ret_regions: list[set[Region]] = field(default_factory=list)
+    written: set[Region] = field(default_factory=set)
     at_boundary: set[Region] = field(default_factory=set)
     boxed_because: dict[tuple[Definition, int], str] = field(
         default_factory=dict,
     )
+
+    def writes_through(self, region: Region | None, ty: CppType) -> bool:
+        """Whether a ``const`` reference to this would reject a write FPy allows.
+
+        ``const fpy::list<T>&`` does not — ``const`` qualifies the handle, and
+        ``xs[i] = e`` through one is FPy's parameter semantics.  An unboxed list
+        has no such indirection, so ``const std::vector<T>&`` makes its elements
+        const too.
+
+        Walks every *unboxed* level: ``const`` reaches through a value
+        container, so a write to a row needs the whole thing non-const.  A boxed
+        level stops it.
+        """
+        depth = 0
+        while isinstance(ty, CppList) and not ty.boxed:
+            if region is None:
+                return True
+            if region in self.written:
+                return True
+            region = self.alias.region_at(region)
+            ty, depth = ty.elt, depth + 1
+        return False
 
     def annotate(self, e: Expr, ty: CppType) -> CppType:
         """*ty* with each list level's representation as decided for *e*.
@@ -119,6 +145,8 @@ class Unbox:
         def_use: DefineUseAnalysis,
         *,
         is_called: bool = False,
+        summary: 'EscapeSummary | None' = None,
+        callee_params: 'dict[FuncDef, list[tuple[CppType, bool]]] | None' = None,
     ) -> UnboxAnalysis:
         """Which lists may drop the handle.
 
@@ -127,9 +155,13 @@ class Unbox:
             storage: the storage classes to decide.
             alias: what may refer to what.
             def_use: to tell a binding that copies from one that references.
-            is_called: whether compiled code calls this function.  If so its
-                parameters keep their handles, since a caller passing a list has
-                marked it shared outward and will hold a handle.
+            is_called: whether compiled code calls this function.
+            summary: this function's own escape summary.  A parameter it does
+                not retain can drop its handle even when it is called, because
+                the caller reads that same summary and stops treating the
+                argument as shared.  Absent means retains everything.
+            callee_params: emitted parameter types of the callees, so an
+                argument can be given the representation the callee declares.
         """
         out = UnboxAnalysis(alias)
 
@@ -163,11 +195,23 @@ class Unbox:
                 r = alias.region_of_site(site)
                 if r is not None:
                     out.at_boundary.add(r)
+        # An argument keeps its handle when the callee's parameter has one.
+        # Deciding this here rather than in `alias` keeps that analysis free of
+        # C++ representations: it answers whether the callee *retains* the list,
+        # which is what lets the callee unbox in the first place; this is the
+        # separate question of matching what it then declared.
+        out.at_boundary |= _boxed_by_callees(ast, alias, callee_params or {})
+        out.written = _written_regions(ast, alias, callee_params or {})
         if is_called:
+            # The return still does: a caller stores the result somewhere, and
+            # nothing yet tells it what representation to expect back.
             for regions in out.ret_regions:
                 out.at_boundary |= regions
+            # A parameter only keeps its handle if this function *retains* it.
+            # Its callers read the same summary, so both ends agree.
             for cls, per_depth in classes:
-                if _has_parameter(storage.class_members[cls]):
+                i = _parameter_index(ast, storage.class_members[cls])
+                if i is not None and (summary is None or summary.retains(i)):
                     out.at_boundary |= {r for r in per_depth if r is not None}
         for r in out.at_boundary:
             out.boxed[r] = True
@@ -248,16 +292,81 @@ def _read(
     return CppList(elt, boxed=True)
 
 
-def _has_parameter(members: list[Definition]) -> bool:
-    """Whether this storage class is a function parameter.
+def _parameter_index(ast: FuncDef, members: list[Definition]) -> int | None:
+    """Which parameter this storage class is, if any.
 
     Asks every member: which def represents a class is an artifact of union
     order, so the argument-sited one need not be it.
     """
-    return any(
-        isinstance(d, AssignDef) and isinstance(d.site, Argument)
-        for d in members
-    )
+    for d in members:
+        if isinstance(d, AssignDef) and isinstance(d.site, Argument):
+            for i, arg in enumerate(ast.args):
+                if arg is d.site:
+                    return i
+    return None
+
+
+def _written_regions(
+    ast: FuncDef,
+    alias: AliasAnalysis,
+    callee_params: 'dict[FuncDef, list[tuple[CppType, bool]]]',
+) -> set[Region]:
+    """Regions whose elements are stored into, here or in a callee.
+
+    The interprocedural half matters for the same reason the representation
+    does: a callee that writes its parameter needs a non-const reference, and
+    the caller's argument has to be one too.
+    """
+    out: set[Region] = set()
+    for d in alias.all_defs():
+        if isinstance(d, AssignDef) and isinstance(d.site, IndexedAssign):
+            r = alias.region_of(d)
+            if r is not None:
+                out.add(r)
+
+    class _Args(DefaultVisitor):
+        def _visit_call(self, e: Call, ctx):
+            params = None
+            if isinstance(e.fn, Function):
+                params = callee_params.get(e.fn.ast)
+            for i, a in enumerate(e.args):
+                if not params or i >= len(params) or not params[i][1]:
+                    continue
+                r = alias.region_of_expr(a)
+                if r is not None:
+                    out.add(r)
+            super()._visit_call(e, ctx)
+
+    _Args()._visit_function(ast, None)
+    return out
+
+
+def _boxed_by_callees(
+    ast: FuncDef,
+    alias: AliasAnalysis,
+    callee_params: 'dict[FuncDef, list[tuple[CppType, bool]]]',
+) -> set[Region]:
+    """Regions passed where the callee declared a handle."""
+    out: set[Region] = set()
+
+    class _Args(DefaultVisitor):
+        def _visit_call(self, e: Call, ctx):
+            params = None
+            if isinstance(e.fn, Function):
+                params = callee_params.get(e.fn.ast)
+            for i, a in enumerate(e.args):
+                want = params[i][0] if params and i < len(params) else None
+                unboxed_there = isinstance(want, CppList) and not want.boxed
+                if unboxed_there:
+                    continue
+                depth = 0
+                while (r := alias.region_of_expr(a, depth)) is not None:
+                    out.add(r)
+                    depth += 1
+            super()._visit_call(e, ctx)
+
+    _Args()._visit_function(ast, None)
+    return out
 
 
 def _return_regions(ast: FuncDef, alias: AliasAnalysis) -> list[set[Region]]:

--- a/tests/unit/analysis/test_escape.py
+++ b/tests/unit/analysis/test_escape.py
@@ -1,0 +1,163 @@
+"""Unit tests for :class:`fpy2.analysis.Escape`.
+
+The distinction the whole thing turns on is *retention is not mutation*: a callee
+that writes its argument keeps nothing afterwards, and a summary that confused
+the two would give up exactly the kernels worth unboxing.
+"""
+
+import fpy2 as fp
+
+from fpy2.analysis import Escape
+
+
+def _retained(f: fp.Function, callees=None) -> set[int]:
+    """Indices of *f*'s parameters that outlive a call to it."""
+    summaries = {g.ast: s for g, s in (callees or {}).items()}
+    return set(Escape.analyze(f.ast, summaries).retained)
+
+
+def _summary(f: fp.Function, callees=None):
+    summaries = {g.ast: s for g, s in (callees or {}).items()}
+    return Escape.analyze(f.ast, summaries)
+
+
+class TestLocal:
+    """Routes visible without looking at any callee."""
+
+    def test_read_only_parameter_is_not_retained(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                return xs[0]
+
+        assert _retained(f) == set()
+
+    def test_written_parameter_is_not_retained(self):
+        """The case most worth getting right: ``xs[0] = 99`` mutates the
+        caller's list *during* the call and keeps nothing after it."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                xs[0] = 99
+                return xs[0]
+
+        assert _retained(f) == set()
+
+    def test_returned_parameter_is_retained(self):
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return xs
+
+        assert _retained(f) == {0}
+
+    def test_retained_through_an_alias(self):
+        """Read off alias regions, not syntax, so this needs no extra rule."""
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                ys = xs
+                return ys
+
+        assert _retained(f) == {0}
+
+    def test_stored_into_another_parameter_is_retained(self):
+        """The caller can reach it afterwards through ``yss``."""
+        @fp.fpy
+        def f(yss: list[list[fp.Real]], xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                yss[0] = xs
+                return xs[0]
+
+        assert 1 in _retained(f)
+
+    def test_a_fresh_local_does_not_retain_the_parameter(self):
+        @fp.fpy
+        def f(xs: list[fp.Real], x: fp.Real) -> list[fp.Real]:
+            with fp.FP64:
+                ys = [x, x]
+                ys[0] = xs[0]
+                return ys
+
+        assert _retained(f) == set()
+
+    def test_a_scalar_parameter_is_never_retained(self):
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return x
+
+        assert _retained(f) == set()
+
+
+class TestThroughCalls:
+    """A callee's summary is what makes the caller's precise."""
+
+    @staticmethod
+    def _leaf_reads():
+        @fp.fpy
+        def g(zs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                return zs[0]
+        return g
+
+    @staticmethod
+    def _leaf_retains():
+        @fp.fpy
+        def g(zs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return zs
+        return g
+
+    def test_argument_to_a_non_retaining_callee(self):
+        g = self._leaf_reads()
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                return g(xs)
+
+        assert _retained(g) == set()
+        assert _retained(f, {g: _summary(g)}) == set()
+
+    def test_argument_to_a_retaining_callee(self):
+        g = self._leaf_retains()
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                ys = g(xs)
+                return ys[0]
+
+        assert _retained(g) == {0}
+        assert _retained(f, {g: _summary(g)}) == {0}
+
+    def test_a_callee_with_no_summary_retains_everything(self):
+        """A foreign function, an unresolved target, or one in a cycle: the
+        absence of a summary is the conservative answer."""
+        g = self._leaf_reads()
+
+        @fp.fpy
+        def f(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                return g(xs)
+
+        assert _retained(f, callees=None) == {0}
+
+    def test_only_the_retained_position_matters(self):
+        """A callee that retains its *second* argument says nothing about the
+        first."""
+        @fp.fpy
+        def g(a: list[fp.Real], b: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                n = a[0]
+                return b
+
+        @fp.fpy
+        def f(p: list[fp.Real], q: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                r = g(p, q)
+                return r[0]
+
+        assert _retained(g) == {1}
+        assert _retained(f, {g: _summary(g)}) == {1}

--- a/tests/unit/backend/cpp/test_module_boundary.py
+++ b/tests/unit/backend/cpp/test_module_boundary.py
@@ -198,9 +198,10 @@ def test_asking_for_a_function_that_is_not_in_the_module_is_an_error():
 
 
 def test_a_two_function_module_is_not_answered_by_emission_order():
-    """The minimal shape bug #3 had: with `specs[-1]` the answer depended on
-    which function happened to be emitted last."""
+    """With `specs[-1]` the answer depended on which function happened to be
+    emitted last.  What it *is* matters less than that it does not move."""
     cc = CppCompiler()
+    seen = set()
     for order in ([g_mutates, g_middle], [g_middle, g_mutates]):
         m = Module()
         for f in order:
@@ -208,6 +209,5 @@ def test_a_two_function_module_is_not_answered_by_emission_order():
         params, _ = cc.signature(
             g_mutates, ctx=fp.FP64, arg_types=[L], module=m,
         )
-        assert params[0].format() == 'fpy::list<double>', (
-            f'order {[f.name for f in order]} gave {params[0].format()}'
-        )
+        seen.add(params[0].format())
+    assert len(seen) == 1, f'answer depends on module order: {seen}' 

--- a/tests/unit/backend/cpp/test_unbox.py
+++ b/tests/unit/backend/cpp/test_unbox.py
@@ -5,6 +5,8 @@ becomes a miscompilation rather than a missed optimization.  See
 :mod:`fpy2.backend.cpp.unbox`.
 """
 
+import re
+
 import fpy2 as fp
 
 from fpy2.analysis import Alias
@@ -122,23 +124,27 @@ class TestUnboxed:
 class TestStaysBoxed:
     """The conservative direction, one reason at a time."""
 
-    def test_parameter_handed_to_a_call(self):
-        """Conservative: a callee may retain its argument, so the caller keeps
-        a handle — and the callee's parameter has to match it."""
+    def test_parameter_handed_to_a_retaining_call(self):
+        """A callee that *keeps* its argument shares it.
+
+        Writing does not: ``zs[0] = 99`` holds nothing once the call returns,
+        which is why the callee here returns the list instead.  See
+        :mod:`fpy2.analysis.escape`.
+        """
         @fp.fpy
-        def g(zs: list[fp.Real]) -> fp.Real:
+        def g(zs: list[fp.Real]) -> list[fp.Real]:
             with fp.FP64:
-                zs[0] = 99
-                return zs[0]
+                return zs
 
         @fp.fpy
         def f(xs: list[fp.Real]) -> fp.Real:
             with fp.FP64:
-                return g(xs)
+                ys = g(xs)
+                return ys[0]
 
         storage, reasons = _decide(f, [ListType(R)])
         assert _levels(storage['xs']) == [True]
-        assert reasons[('xs', 0)] == 'shared'
+        assert reasons[('xs', 0)] == 'reached across a boundary'
 
     def test_levels_are_decided_independently(self):
         """Returning a row hands out the row, not the outer list — so the outer
@@ -309,4 +315,99 @@ class TestInvisibleToTheHarness:
         params, _ = cc.signature(
             callee, ctx=fp.FP64, arg_types=[ListType(R)], module=m,
         )
-        assert f'const {params[0].format()}& zs' in cc.compile_module(m)
+        # const-ness is a separate question; what must agree is the type
+        assert f'{params[0].format()}& zs' in cc.compile_module(m)
+
+
+class TestAcrossACall:
+    """What a summary buys, and what it must not.
+
+    A compiled-to-compiled boundary used to keep its handles unconditionally.
+    With :mod:`fpy2.analysis.escape` it keeps them only where the callee really
+    holds on to the list.
+    """
+
+    def test_both_ends_unbox_when_the_callee_keeps_nothing(self):
+        @fp.fpy
+        def inner(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                acc = 0.0
+                for i in range(len(xs)):
+                    acc = acc + xs[i]
+                return acc
+
+        @fp.fpy
+        def outer(xss: list[list[fp.Real]]) -> fp.Real:
+            with fp.FP64:
+                acc = 0.0
+                for i in range(len(xss)):
+                    acc = acc + inner(xss[i])
+                return acc
+
+        m = Module()
+        m.add(outer, ctx=fp.FP64, arg_types=[ListType(ListType(R))])
+        out = CppCompiler().compile_module(m)
+        assert 'const std::vector<double>& xs' in out
+        assert 'const std::vector<std::vector<double>>& xss' in out
+        assert 'fpy::list' not in out
+
+    def test_a_retaining_callee_keeps_both_ends_boxed(self):
+        @fp.fpy
+        def keep(zs: list[fp.Real]) -> list[fp.Real]:
+            with fp.FP64:
+                return zs
+
+        @fp.fpy
+        def hand_over(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                ys = keep(xs)
+                return ys[0]
+
+        m = Module()
+        m.add(hand_over, ctx=fp.FP64, arg_types=[ListType(R)])
+        out = CppCompiler().compile_module(m)
+        assert 'std::vector<double>& xs' not in out
+        assert 'fpy::list<double>' in out
+
+    def test_a_writing_callee_makes_both_ends_non_const(self):
+        """Writing is not retaining, so both unbox — but ``const`` has to cross
+        the call edge or the argument will not bind."""
+        @fp.fpy
+        def bump(zs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                zs[0] = 99
+                return zs[0]
+
+        @fp.fpy
+        def call_it(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                return bump(xs)
+
+        m = Module()
+        m.add(call_it, ctx=fp.FP64, arg_types=[ListType(R)])
+        out = CppCompiler().compile_module(m)
+        assert 'std::vector<double>& zs' in out
+        assert 'std::vector<double>& xs' in out
+        assert 'const std::vector<double>&' not in out
+
+    def test_a_boxed_caller_hands_over_the_pointee(self):
+        """The callee's signature is fixed by its own body, so a caller that
+        keeps a handle for a local reason passes ``*handle`` — same elements,
+        no copy."""
+        @fp.fpy
+        def reads(zs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                return zs[0]
+
+        @fp.fpy
+        def shares(xs: list[fp.Real]) -> fp.Real:
+            with fp.FP64:
+                t = (xs, 1.0)          # a tuple keeps `xs` boxed
+                return reads(xs) + fp.fst(t)[0]
+
+        m = Module()
+        m.add(shares, ctx=fp.FP64, arg_types=[ListType(R)])
+        out = CppCompiler().compile_module(m)
+        assert 'const std::vector<double>& zs' in out
+        assert 'const fpy::list<double>& xs' in out
+        assert re.search(r'reads__\w+\(\*xs\)', out), out


### PR DESCRIPTION
This PR adds an escape analysis to compute which values are still reachable after a function returns. The C++ compiler uses escape analysis to support intraprocedural unboxing.