### PR TITLE
Port graphics, hamming, and daisy to FPy

### DIFF
--- a/bench/daisy.py
+++ b/bench/daisy.py
@@ -1,0 +1,149 @@
+import fpy2 as fp
+
+
+@fp.fpy(
+    meta={
+        "name": "carthesianToPolar, radius",
+        "pre": lambda x, y: fp.round(1) <= x <= fp.round(100)
+        and fp.round(1) <= y <= fp.round(100),
+        "spec": lambda x, y: fp.hypot(x, y),
+    }
+)
+def carthesianToPolar_radius(x: fp.Real, y: fp.Real) -> fp.Real:
+    return fp.sqrt(x * x + y * y)
+
+
+@fp.fpy(
+    meta={
+        "name": "carthesianToPolar, theta",
+        "pre": lambda x, y: fp.round(1) <= x <= fp.round(100)
+        and fp.round(1) <= y <= fp.round(100),
+        "spec": lambda x, y: fp.atan2(y, x) * (fp.round(180) / fp.const_pi()),
+    }
+)
+def carthesianToPolar_theta(x: fp.Real, y: fp.Real) -> fp.Real:
+    pi = fp.round(3.14159265359)
+    radiant = fp.atan(y / x)
+    return radiant * (fp.round(180.0) / pi)
+
+
+@fp.fpy(
+    meta={
+        "name": "polarToCarthesian, x",
+        "pre": lambda radius, theta: fp.round(1) <= radius <= fp.round(10)
+        and fp.round(0) <= theta <= fp.round(360),
+        "spec": lambda radius, theta: radius
+        * fp.cos(theta * (fp.round(180) / fp.const_pi())),
+    }
+)
+def polarToCarthesian_x(radius: fp.Real, theta: fp.Real) -> fp.Real:
+    pi = fp.round(3.14159265359)
+    radiant = theta * (pi / fp.round(180.0))
+    return radius * fp.cos(radiant)
+
+
+@fp.fpy(
+    meta={
+        "name": "polarToCarthesian, y",
+        "pre": lambda radius, theta: fp.round(1) <= radius <= fp.round(10)
+        and fp.round(0) <= theta <= fp.round(360),
+        "spec": lambda radius, theta: radius
+        * fp.sin(theta * (fp.round(180) / fp.const_pi())),
+    }
+)
+def polarToCarthesian_y(radius: fp.Real, theta: fp.Real) -> fp.Real:
+    pi = fp.round(3.14159265359)
+    radiant = theta * (pi / fp.round(180.0))
+    return radius * fp.sin(radiant)
+
+
+@fp.fpy(
+    meta={
+        "name": "instantaneousCurrent",
+        "pre": lambda t, resistance, frequency, inductance, maxVoltage: (
+            fp.round(0) <= t <= fp.round(300.0)
+            and fp.round(1) <= resistance <= fp.round(50)
+            and fp.round(1) <= frequency <= fp.round(100)
+            and fp.round(0.001) <= inductance <= fp.round(0.004)
+            and fp.round(1) <= maxVoltage <= fp.round(12)
+        ),
+    }
+)
+def instantaneousCurrent(
+    t: fp.Real,
+    resistance: fp.Real,
+    frequency: fp.Real,
+    inductance: fp.Real,
+    maxVoltage: fp.Real,
+) -> fp.Real:
+    pi = fp.round(3.14159265359)
+    impedance_re = resistance
+    impedance_im = fp.round(2) * pi * frequency * inductance
+    denom = impedance_re * impedance_re + impedance_im * impedance_im
+    current_re = (maxVoltage * impedance_re) / denom
+    current_im = -(maxVoltage * impedance_im) / denom
+    maxCurrent = fp.sqrt(current_re * current_re + current_im * current_im)
+    theta = fp.atan(current_im / current_re)
+    return maxCurrent * fp.cos(fp.round(2) * pi * frequency * t + theta)
+
+
+@fp.fpy(
+    meta={
+        "name": "matrixDeterminant",
+        "pre": lambda a, b, c, d, e, f, g, h, i: (
+            fp.round(-10) <= a <= fp.round(10)
+            and fp.round(-10) <= b <= fp.round(10)
+            and fp.round(-10) <= c <= fp.round(10)
+            and fp.round(-10) <= d <= fp.round(10)
+            and fp.round(-10) <= e <= fp.round(10)
+            and fp.round(-10) <= f <= fp.round(10)
+            and fp.round(-10) <= g <= fp.round(10)
+            and fp.round(-10) <= h <= fp.round(10)
+            and fp.round(-10) <= i <= fp.round(10)
+        ),
+    }
+)
+def matrixDeterminant(
+    a: fp.Real,
+    b: fp.Real,
+    c: fp.Real,
+    d: fp.Real,
+    e: fp.Real,
+    f: fp.Real,
+    g: fp.Real,
+    h: fp.Real,
+    i: fp.Real,
+) -> fp.Real:
+    return (a * e * i + b * f * g + c * d * h) - (c * e * g + b * d * i + a * f * h)
+
+
+@fp.fpy(
+    meta={
+        "name": "matrixDeterminant2",
+        "pre": lambda a, b, c, d, e, f, g, h, i: (
+            fp.round(-10) <= a <= fp.round(10)
+            and fp.round(-10) <= b <= fp.round(10)
+            and fp.round(-10) <= c <= fp.round(10)
+            and fp.round(-10) <= d <= fp.round(10)
+            and fp.round(-10) <= e <= fp.round(10)
+            and fp.round(-10) <= f <= fp.round(10)
+            and fp.round(-10) <= g <= fp.round(10)
+            and fp.round(-10) <= h <= fp.round(10)
+            and fp.round(-10) <= i <= fp.round(10)
+        ),
+    }
+)
+def matrixDeterminant2(
+    a: fp.Real,
+    b: fp.Real,
+    c: fp.Real,
+    d: fp.Real,
+    e: fp.Real,
+    f: fp.Real,
+    g: fp.Real,
+    h: fp.Real,
+    i: fp.Real,
+) -> fp.Real:
+    return (a * (e * i) + (g * (b * f) + c * (d * h))) - (
+        e * (c * g) + (i * (b * d) + a * (f * h))
+    )

--- a/bench/fptaylor_tests.py
+++ b/bench/fptaylor_tests.py
@@ -1,0 +1,181 @@
+import fpy2 as fp
+
+
+@fp.fpy(
+    meta={
+        "name": "intro-example",
+        "cite": ["solovyev-et-al-2015"],
+        "pre": lambda t: fp.round(0) <= t <= fp.round(999),
+    }
+)
+def intro_example(t: fp.Real) -> fp.Real:
+    return t / (t + fp.round(1))
+
+
+@fp.fpy(
+    ctx=fp.FP64,
+    meta={
+        "name": "sec4-example",
+        "cite": ["solovyev-et-al-2015"],
+        "pre": lambda x, y: fp.round(1.001) <= x <= fp.round(2)
+        and fp.round(1.001) <= y <= fp.round(2),
+    },
+)
+def sec4_example(x: fp.Real, y: fp.Real) -> fp.Real:
+    t = x * y
+    return (t - fp.round(1)) / (t * t - fp.round(1))
+
+
+@fp.fpy(
+    ctx=fp.FP32,
+    meta={
+        "name": "test01_sum3",
+        "pre": lambda x0, x1, x2: fp.round(1) < x0 < fp.round(2)
+        and fp.round(1) < x1 < fp.round(2)
+        and fp.round(1) < x2 < fp.round(2),
+    },
+)
+def test01_sum3(x0: fp.Real, x1: fp.Real, x2: fp.Real) -> fp.Real:
+    p0 = (x0 + x1) - x2
+    p1 = (x1 + x2) - x0
+    p2 = (x2 + x0) - x1
+    return (p0 + p1) + p2
+
+
+@fp.fpy(
+    ctx=fp.FP64,
+    meta={
+        "name": "test02_sum8",
+        "pre": lambda x0, x1, x2, x3, x4, x5, x6, x7: (
+            fp.round(1) < x0 < fp.round(2)
+            and fp.round(1) < x1 < fp.round(2)
+            and fp.round(1) < x2 < fp.round(2)
+            and fp.round(1) < x3 < fp.round(2)
+            and fp.round(1) < x4 < fp.round(2)
+            and fp.round(1) < x5 < fp.round(2)
+            and fp.round(1) < x6 < fp.round(2)
+            and fp.round(1) < x7 < fp.round(2)
+        ),
+    },
+)
+def test02_sum8(
+    x0: fp.Real,
+    x1: fp.Real,
+    x2: fp.Real,
+    x3: fp.Real,
+    x4: fp.Real,
+    x5: fp.Real,
+    x6: fp.Real,
+    x7: fp.Real,
+) -> fp.Real:
+    return x0 + x1 + x2 + x3 + x4 + x5 + x6 + x7
+
+
+@fp.fpy(
+    ctx=fp.FP64,
+    meta={
+        "name": "test03_nonlin2",
+        "pre": lambda x, y: fp.round(0) < x < fp.round(1)
+        and fp.round(-1) < y < fp.round(-0.1),
+    },
+)
+def test03_nonlin2(x: fp.Real, y: fp.Real) -> fp.Real:
+    return (x + y) / (x - y)
+
+
+@fp.fpy(
+    ctx=fp.FP64,
+    meta={
+        "name": "test04_dqmom9",
+        "pre": lambda m0, m1, m2, w0, w1, w2, a0, a1, a2: (
+            fp.round(-1) < m0 < fp.round(1)
+            and fp.round(-1) < m1 < fp.round(1)
+            and fp.round(-1) < m2 < fp.round(1)
+            and fp.round(0.00001) < w0 < fp.round(1)
+            and fp.round(0.00001) < w1 < fp.round(1)
+            and fp.round(0.00001) < w2 < fp.round(1)
+            and fp.round(0.00001) < a0 < fp.round(1)
+            and fp.round(0.00001) < a1 < fp.round(1)
+            and fp.round(0.00001) < a2 < fp.round(1)
+        ),
+    },
+)
+def test04_dqmom9(
+    m0: fp.Real,
+    m1: fp.Real,
+    m2: fp.Real,
+    w0: fp.Real,
+    w1: fp.Real,
+    w2: fp.Real,
+    a0: fp.Real,
+    a1: fp.Real,
+    a2: fp.Real,
+) -> fp.Real:
+    v2 = (w2 * (fp.round(0) - m2)) * (
+        fp.round(-3) * (fp.round(1) * (a2 / w2) * (a2 / w2))
+    )
+    v1 = (w1 * (fp.round(0) - m1)) * (
+        fp.round(-3) * (fp.round(1) * (a1 / w1) * (a1 / w1))
+    )
+    v0 = (w0 * (fp.round(0) - m0)) * (
+        fp.round(-3) * (fp.round(1) * (a0 / w0) * (a0 / w0))
+    )
+    return fp.round(0.0) + (
+        v0 * fp.round(1) + (v1 * fp.round(1) + (v2 * fp.round(1) + fp.round(0.0)))
+    )
+
+
+@fp.fpy(
+    ctx=fp.FP64,
+    meta={
+        "name": "test05_nonlin1, r4",
+        "pre": lambda x: fp.round(1.00001) < x < fp.round(2),
+    },
+)
+def test05_nonlin1_r4(x: fp.Real) -> fp.Real:
+    r1 = x - fp.round(1)
+    r2 = x * x
+    return r1 / (r2 - fp.round(1))
+
+
+@fp.fpy(
+    ctx=fp.FP64,
+    meta={
+        "name": "test05_nonlin1, test2",
+        "pre": lambda x: fp.round(1.00001) < x < fp.round(2),
+    },
+)
+def test05_nonlin1_test2(x: fp.Real) -> fp.Real:
+    return fp.round(1) / (x + fp.round(1))
+
+
+@fp.fpy(
+    ctx=fp.FP32,
+    meta={
+        "name": "test06_sums4, sum1",
+        "pre": lambda x0, x1, x2, x3: (
+            fp.round(-1e-5) < x0 < fp.round(1.00001)
+            and fp.round(0) < x1 < fp.round(1)
+            and fp.round(0) < x2 < fp.round(1)
+            and fp.round(0) < x3 < fp.round(1)
+        ),
+    },
+)
+def test06_sums4_sum1(x0: fp.Real, x1: fp.Real, x2: fp.Real, x3: fp.Real) -> fp.Real:
+    return x0 + x1 + x2 + x3
+
+
+@fp.fpy(
+    ctx=fp.FP32,
+    meta={
+        "name": "test06_sums4, sum2",
+        "pre": lambda x0, x1, x2, x3: (
+            fp.round(-1e-5) < x0 < fp.round(1.00001)
+            and fp.round(0) < x1 < fp.round(1)
+            and fp.round(0) < x2 < fp.round(1)
+            and fp.round(0) < x3 < fp.round(1)
+        ),
+    },
+)
+def test06_sums4_sum2(x0: fp.Real, x1: fp.Real, x2: fp.Real, x3: fp.Real) -> fp.Real:
+    return (x0 + x1) + (x2 + x3)

--- a/bench/graphics.py
+++ b/bench/graphics.py
@@ -13,9 +13,9 @@ def eigenvalue_calculation_TNG(
     c: fp.Real,
     d: fp.Real,
 ) -> fp.Real:
-    return fp.sqrt(
-        fp.pow(a + d, fp.round(2)) + fp.pow(b - c, fp.round(2))
-    ) - fp.sqrt(fp.pow(a - d, fp.round(2)) + fp.pow(b + c, fp.round(2)))
+    return fp.sqrt(fp.pow(a + d, fp.round(2)) + fp.pow(b - c, fp.round(2))) - fp.sqrt(
+        fp.pow(a - d, fp.round(2)) + fp.pow(b + c, fp.round(2))
+    )
 
 
 @fp.fpy(
@@ -33,9 +33,7 @@ def eigenvalue_calculation_TNG_stable(
 ) -> fp.Real:
     sos = ((a * a + b * b) + c * c) + d * d
     det = a * d - b * c
-    return fp.sqrt(sos + fp.round(2) * det) - fp.sqrt(
-        sos - fp.round(2) * det
-    )
+    return fp.sqrt(sos + fp.round(2) * det) - fp.sqrt(sos - fp.round(2) * det)
 
 
 @fp.fpy(

--- a/bench/graphics.py
+++ b/bench/graphics.py
@@ -1,0 +1,56 @@
+import fpy2 as fp
+
+
+@fp.fpy(
+    meta={
+        "name": "An eigenvalue calculation from TNG",
+        "fpbench_domain": "graphics",
+    }
+)
+def eigenvalue_calculation_TNG(
+    a: fp.Real,
+    b: fp.Real,
+    c: fp.Real,
+    d: fp.Real,
+) -> fp.Real:
+    return fp.sqrt(
+        fp.pow(a + d, fp.round(2)) + fp.pow(b - c, fp.round(2))
+    ) - fp.sqrt(fp.pow(a - d, fp.round(2)) + fp.pow(b + c, fp.round(2)))
+
+
+@fp.fpy(
+    meta={
+        "name": "An eigenvalue calculation from TNG",
+        "description": "This version is much more numerically stable.",
+        "fpbench_domain": "graphics",
+    }
+)
+def eigenvalue_calculation_TNG_stable(
+    a: fp.Real,
+    b: fp.Real,
+    c: fp.Real,
+    d: fp.Real,
+) -> fp.Real:
+    sos = ((a * a + b * b) + c * c) + d * d
+    det = a * d - b * c
+    return fp.sqrt(sos + fp.round(2) * det) - fp.sqrt(
+        sos - fp.round(2) * det
+    )
+
+
+@fp.fpy(
+    meta={
+        "name": "An eigenvalue calculation from TNG",
+        "description": "This version is best if sos >> det.",
+        "fpbench_domain": "graphics",
+    }
+)
+def eigenvalue_calculation_TNG_sos_dominates_det(
+    a: fp.Real,
+    b: fp.Real,
+    c: fp.Real,
+    d: fp.Real,
+) -> fp.Real:
+    sos = ((a * a + b * b) + c * c) + d * d
+    det = a * d - b * c
+    return fp.round(2) * det / fp.sqrt(sos)

--- a/bench/hamming_ch3.py
+++ b/bench/hamming_ch3.py
@@ -1,0 +1,333 @@
+import fpy2 as fp
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.1",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x >= fp.round(0),
+    }
+)
+def nmse_example_3_1(x: fp.Real) -> fp.Real:
+    return fp.sqrt(x + fp.round(1)) - fp.sqrt(x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.3",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+    }
+)
+def nmse_example_3_3(x: fp.Real, eps: fp.Real) -> fp.Real:
+    return fp.sin(x + eps) - fp.sin(x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.4",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x != fp.round(0),
+    }
+)
+def nmse_example_3_4(x: fp.Real) -> fp.Real:
+    return (fp.round(1) - fp.cos(x)) / fp.sin(x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.5",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+    }
+)
+def nmse_example_3_5(N: fp.Real) -> fp.Real:
+    return fp.atan(N + fp.round(1)) - fp.atan(N)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.6",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x >= fp.round(0),
+    }
+)
+def nmse_example_3_6(x: fp.Real) -> fp.Real:
+    return fp.round(1) / fp.sqrt(x) - fp.round(1) / fp.sqrt(x + fp.round(1))
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.3.1",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x != fp.round(0),
+    }
+)
+def nmse_problem_3_3_1(x: fp.Real) -> fp.Real:
+    return fp.round(1) / (x + fp.round(1)) - fp.round(1) / x
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.3.2",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+    }
+)
+def nmse_problem_3_3_2(x: fp.Real, eps: fp.Real) -> fp.Real:
+    return fp.tan(x + eps) - fp.tan(x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.3.3",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x != fp.round(0) and x != fp.round(1) and x != fp.round(-1),
+    }
+)
+def nmse_problem_3_3_3(x: fp.Real) -> fp.Real:
+    return fp.round(1) / (x + fp.round(1)) - fp.round(2) / x + fp.round(1) / (x - fp.round(1))
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.3.4",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x >= fp.round(0),
+    }
+)
+def nmse_problem_3_3_4(x: fp.Real) -> fp.Real:
+    return fp.pow(x + fp.round(1), fp.round(1) / fp.round(3)) - fp.pow(x, fp.round(1) / fp.round(3))
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.3.5",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+    }
+)
+def nmse_problem_3_3_5(x: fp.Real, eps: fp.Real) -> fp.Real:
+    return fp.cos(x + eps) - fp.cos(x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.3.6",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda N: N > fp.round(0),
+    }
+)
+def nmse_problem_3_3_6(N: fp.Real) -> fp.Real:
+    return fp.log(N + fp.round(1)) - fp.log(N)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.3.7",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+    }
+)
+def nmse_problem_3_3_7(x: fp.Real) -> fp.Real:
+    return (fp.exp(x) - fp.round(2)) + fp.exp(-x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE p42, positive",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda a, b, c: b * b >= fp.round(4) * (a * c) and a != fp.round(0),
+    }
+)
+def nmse_p42_positive(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
+    return (-b + fp.sqrt(b * b - fp.round(4) * (a * c))) / (fp.round(2) * a)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE p42, negative",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda a, b, c: b * b >= fp.round(4) * (a * c) and a != fp.round(0),
+    }
+)
+def nmse_p42_negative(a: fp.Real, b: fp.Real, c: fp.Real) -> fp.Real:
+    return (-b - fp.sqrt(b * b - fp.round(4) * (a * c))) / (fp.round(2) * a)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.2.1, positive",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda a, b2, c: b2 * b2 >= a * c and a != fp.round(0),
+    }
+)
+def nmse_problem_3_2_1_positive(a: fp.Real, b2: fp.Real, c: fp.Real) -> fp.Real:
+    return (-b2 + fp.sqrt(b2 * b2 - a * c)) / a
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.2.1, negative",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda a, b2, c: b2 * b2 >= a * c and a != fp.round(0),
+    }
+)
+def nmse_problem_3_2_1_negative(a: fp.Real, b2: fp.Real, c: fp.Real) -> fp.Real:
+    return (-b2 - fp.sqrt(b2 * b2 - a * c)) / a
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.7",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+    }
+)
+def nmse_example_3_7(x: fp.Real) -> fp.Real:
+    return fp.exp(x) - fp.round(1)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.8",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda N: N > fp.round(0),
+    }
+)
+def nmse_example_3_8(N: fp.Real) -> fp.Real:
+    return ((N + fp.round(1)) * fp.log(N + fp.round(1)) - N * fp.log(N)) - fp.round(1)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.9",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x != fp.round(0),
+    }
+)
+def nmse_example_3_9(x: fp.Real) -> fp.Real:
+    return fp.round(1) / x - fp.round(1) / fp.tan(x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE example 3.10",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "daisy_pre": lambda x: fp.round(-0.99) < x < fp.round(0.99),
+        "pre": lambda x: fp.round(-1) < x < fp.round(1),
+    }
+)
+def nmse_example_3_10(x: fp.Real) -> fp.Real:
+    return fp.log(fp.round(1) - x) / fp.log(fp.round(1) + x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.4.1",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x != fp.round(0),
+    }
+)
+def nmse_problem_3_4_1(x: fp.Real) -> fp.Real:
+    return (fp.round(1) - fp.cos(x)) / (x * x)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.4.2",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda a, b, eps: eps != fp.round(0),
+    }
+)
+def nmse_problem_3_4_2(a: fp.Real, b: fp.Real, eps: fp.Real) -> fp.Real:
+    return (eps * (fp.exp((a + b) * eps) - fp.round(1))) / (
+        (fp.exp(a * eps) - fp.round(1)) * (fp.exp(b * eps) - fp.round(1))
+    )
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.4.3",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda eps: fp.round(-1) < eps < fp.round(1),
+    }
+)
+def nmse_problem_3_4_3(eps: fp.Real) -> fp.Real:
+    return fp.log((fp.round(1) - eps) / (fp.round(1) + eps))
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.4.4",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x != fp.round(0),
+    }
+)
+def nmse_problem_3_4_4(x: fp.Real) -> fp.Real:
+    return fp.sqrt((fp.exp(fp.round(2) * x) - fp.round(1)) / (fp.exp(x) - fp.round(1)))
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.4.5",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x != fp.round(0),
+    }
+)
+def nmse_problem_3_4_5(x: fp.Real) -> fp.Real:
+    return (x - fp.sin(x)) / (x - fp.tan(x))
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE problem 3.4.6",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x, n: x >= fp.round(0),
+    }
+)
+def nmse_problem_3_4_6(x: fp.Real, n: fp.Real) -> fp.Real:
+    return fp.pow(x + fp.round(1), fp.round(1) / n) - fp.pow(x, fp.round(1) / n)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE section 3.5",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+    }
+)
+def nmse_section_3_5(a: fp.Real, x: fp.Real) -> fp.Real:
+    return fp.exp(a * x) - fp.round(1)
+
+
+@fp.fpy(
+    meta={
+        "name": "NMSE section 3.11",
+        "cite": ["hamming-1987", "herbie-2015"],
+        "fpbench_domain": "textbook",
+        "pre": lambda x: x != fp.round(0),
+    }
+)
+def nmse_section_3_11(x: fp.Real) -> fp.Real:
+    return fp.exp(x) / (fp.exp(x) - fp.round(1))

--- a/bench/hamming_ch3.py
+++ b/bench/hamming_ch3.py
@@ -65,7 +65,7 @@ def nmse_example_3_6(x: fp.Real) -> fp.Real:
         "cite": ["hamming-1987", "herbie-2015"],
         "fpbench_domain": "textbook",
         "pre": lambda x: x != fp.round(0),
-    }
+    },
 )
 def nmse_problem_3_3_1(x: fp.Real) -> fp.Real:
     return fp.round(1) / (x + fp.round(1)) - fp.round(1) / x
@@ -91,7 +91,11 @@ def nmse_problem_3_3_2(x: fp.Real, eps: fp.Real) -> fp.Real:
     }
 )
 def nmse_problem_3_3_3(x: fp.Real) -> fp.Real:
-    return fp.round(1) / (x + fp.round(1)) - fp.round(2) / x + fp.round(1) / (x - fp.round(1))
+    return (
+        fp.round(1) / (x + fp.round(1))
+        - fp.round(2) / x
+        + fp.round(1) / (x - fp.round(1))
+    )
 
 
 @fp.fpy(
@@ -103,7 +107,9 @@ def nmse_problem_3_3_3(x: fp.Real) -> fp.Real:
     }
 )
 def nmse_problem_3_3_4(x: fp.Real) -> fp.Real:
-    return fp.pow(x + fp.round(1), fp.round(1) / fp.round(3)) - fp.pow(x, fp.round(1) / fp.round(3))
+    return fp.pow(x + fp.round(1), fp.round(1) / fp.round(3)) - fp.pow(
+        x, fp.round(1) / fp.round(3)
+    )
 
 
 @fp.fpy(


### PR DESCRIPTION
Ports `graphics.fpcore`, `hamming-ch3.fpcore`, `daisy.fpcore`, and `fptaylor-tests.fpcore` from FPBench to FPy. I chose these because they are sort of the "minimal set of benchmarks" that cover a large amount of FPBench's varied use of FPCore syntax. I'll translate the rest of the FPBench benchmarks after this is reviewed. Most of it is rote translation, so I've listed all the key choices I made below to look out for.

I put the new FPy ports in `bench/`, perhaps theres a better place for them? As requested, here are some notes on the most important things I noticed while porting:
 * All literals need to be wrapped in `fp.round` because FPy is exact and FPCore rounds based on context
 * I split benchmarks with multiple alts (e.g. `An eigenvalue calculation from TNG`) into different functions with the same `name` field in the `fp.fpy` metadata
 * Uses of `:precision` are translated to `ctx=fp.IEEEContext(...)` (e.g. `ctx=fp.FP64` for `:precision binary64`)
 * Uses of `:spec` are translated to lambda functions that use FPy themselves; I assumed these should not be wrapped in `fp.fpy`?
 * Most of the metadata and naming is lifted straight from FPCore and Pythonified (e.g. `name`, `cite`, `fpbench_domain`)
 * Formatting looks a bit odd for some of the preconditions (I use Black to format), let me know if there's a chosen formatter for FPy