### PR TITLE
Fix C++ compiler

### DIFF
--- a/docs/todos/array-size-symbolic.md
+++ b/docs/todos/array-size-symbolic.md
@@ -1,359 +1,75 @@
-# Array-size analysis: symbolic sizes via union-find
+# Array-size analysis: symbolic sizes
 
-> **Status: implemented.**  The proposal below was the original design;
-> the as-built differs in a few deliberate ways, summarized here.  The
-> rest of the document is retained as design rationale.
->
-> ### As-built summary
->
-> - **Representation.** No bespoke `SymbolicSize` / `_SizeUF`.  Following
->   the type-inference precedent, a *size variable* is a `NamedId` minted
->   by a `Gensym`, and the analysis carries a shared
->   `Unionfind[NamedId | int]` (`fpy2.utils.Unionfind`).  So:
->   `ArraySize: TypeAlias = int | NamedId | None`.
-> - **Concrete int is the representative.** Pinning a class to a constant
->   is just `union(int, var)` with the `int` as leader — no separate
->   `pin`/`resolve` map.
-> - **Result is fully resolved; the union-find is not exposed.** Before
->   returning, every size is replaced by its representative (`_resolve`,
->   cf. type inference's `_resolve_type`): an `int` if the class is pinned,
->   else the canonical variable.  So `ArraySizeAnalysis` carries **no**
->   `size_uf`; a size is known iff it's an `int`, and the helpers
->   `concrete_size(size)` / `is_size_eq(b1, b2)` take no union-find.
-> - **Size-preserving propagation is mostly free.** `ys = xs`,
->   `[f(x) for x in xs]`, `enumerate(xs)`, `xs[:]`, and `IndexedAssign`
->   already thread `.size`, so the size variable rides along — no special
->   per-op symbol plumbing was needed.  Arguments / free vars mint one
->   fresh variable for their outer list dimension (`_arg_bound`).
-> - **Phase 3 (loop-phi merge) was NOT implemented — it is unsound.**
->   Optimistically merging the pre-loop and post-body size vars assumes
->   the body preserves length, which is false for size-changing bodies
->   (e.g. `ys = ys[1:]`).  Instead the loop fixpoint uses the ordinary
->   join: a size-preserving body re-propagates the *same* variable so the
->   join keeps it; a size-changing body yields a different size so the
->   join goes to `None`.  Sound, and no optimism required.
-> - **`zip` is strict, not min.** (Already corrected in the operation
->   rules below.)  Any concrete input pins the symbolic inputs to it and
->   the result is that int; all-symbolic inputs are merged and the result
->   keeps the representative.
-> - **Cross-function safety.** `_refine_sizes` (call-result size overlay)
->   adopts only *concrete* `int` callee sizes — a callee's size variables
->   belong to its own run and must not leak across the call.
-> - **Convergence (open question #3) resolved.** The visitor keeps a
->   monotone `_uf_changes` counter (bumped only on a real union); the loop
->   fixpoint requires both stored-bound stability *and* a stable counter,
->   so a `zip`-merge inside a loop body can't terminate the fixpoint one
->   iteration early.
-> - **Assertion-seeded equalities (done).** `assert len(xs) == len(ys)`
->   merges the two size variables and `assert len(xs) == N` pins one — but
->   only for *unconditional* asserts (not nested in an `if`/loop), so the
->   equality holds on every execution.
->
-> ### Remaining work
->
-> The analysis is implemented; what's left is **consumer integration** —
-> nothing yet reads the symbolic equalities (`format_infer` ignores
-> non-`int` sizes, a safe no-op):
->
-> - **Bounds-check elimination** — discharge `ys[i]` when `is_size_eq`
->   proves `len(ys) == len(xs)` and `i < len(xs)`.  The flagship payoff;
->   three equality sources now feed it (arguments, strict `zip`, asserts).
-> - **`format_infer` `Sum`** — fall back to a runtime-bounded loop when the
->   list size is a tracked variable rather than a static `int`.
+**Implemented.** `array_size` used to track sizes as a flat `int | None`, which is
+precise for compile-time constants and throws away everything about runtime sizes
+that are *statically constrained to be equal* — `ys = xs` makes `len(ys) ==
+len(xs)`, and the old lattice recorded `None`. It now tracks those equalities.
 
-## Context
+What remains is **consumer integration**: nothing reads them yet. This document
+is the as-built record plus that remaining work; the original design proposal has
+been dropped, since the implementation diverged from it in ways worth stating
+directly rather than reconstructing from a diff.
 
-The current `array_size` analysis tracks list sizes as a flat lattice
-`ArraySize: TypeAlias = int | None`.  This is precise for
-compile-time-known constants but throws away **all** information about
-runtime sizes that are statically constrained to be equal:
+## As built
 
-```python
-def f(xs: list[fp.Real]) -> list[fp.Real]:
-    ys = xs                       # len(ys) == len(xs), but we record None
-    return ys
+- **A size variable is a `NamedId`** minted by a `Gensym`, with a shared
+  `Unionfind[NamedId | int]` — following the type-inference precedent rather than
+  a bespoke `SymbolicSize` class. So `ArraySize: TypeAlias = int | NamedId | None`.
+- **A concrete `int` is the class representative.** Pinning is `union(int, var)`
+  with the `int` as leader; no separate pin/resolve map.
+- **The result is fully resolved and the union-find is not exposed.** `_resolve`
+  (cf. type inference's `_resolve_type`) replaces every size by its
+  representative before returning, so a size is known iff it is an `int`, and
+  `concrete_size` / `is_size_eq` take no union-find argument.
+- **Propagation is mostly free.** `ys = xs`, `[f(x) for x in xs]`,
+  `enumerate(xs)`, `xs[:]`, and `IndexedAssign` already thread `.size`, so the
+  variable rides along. Arguments and free variables mint one fresh variable for
+  their outer dimension (`_arg_bound`).
+- **`zip` is strict, not `min`.** Any concrete input pins the symbolic ones to it;
+  all-symbolic inputs merge and the result keeps the representative.
+- **Unconditional `assert` seeds equalities.** `assert len(xs) == len(ys)` merges
+  the two variables and `assert len(xs) == N` pins one — only when not nested in
+  an `if` or loop, so the equality holds on every execution.
+- **Calls adopt only concrete callee sizes.** `_refine_sizes` ignores a callee's
+  size *variables*: they belong to that run and must not leak across the call.
 
-def g(xs: list[fp.Real]) -> list[fp.Real]:
-    ys = [0.0 for _ in xs]        # len(ys) == len(xs)
-    for i, x in enumerate(xs):
-        ys[i] = x                 # in-bounds because lengths match
-    return ys
-```
+Two deliberate departures from the original plan:
 
-Several downstream consumers would benefit from knowing
-`len(ys) == len(xs)` symbolically:
+- **No optimistic loop-phi merge.** Merging the pre-loop and post-body size
+  variables assumes the body preserves length, which `ys = ys[1:]` violates. The
+  loop fixpoint uses the ordinary join instead: a size-preserving body
+  re-propagates the *same* variable so the join keeps it, and a size-changing body
+  yields a different size so the join goes to `None`. Sound with no optimism.
+- **Convergence needs the union-find in the check.** A merge does not change the
+  `NamedId` stored in `by_def`, so bound-stability alone can end the fixpoint one
+  iteration early — a `zip`-merge inside a loop body would be missed. The visitor
+  keeps a monotone `_uf_changes` counter and the fixpoint requires both stored
+  bounds *and* that counter to be stable.
 
-- `mpfx/format_infer.py:Sum` could fall back to a runtime-bounded loop
-  rather than refusing to expand when the size isn't a static `int`.
-- A future bounds-check elimination pass could discharge `ys[i]` given
-  `i < len(xs)` and `len(ys) == len(xs)`.
-- A future allocation analysis could match a `[…]`-comprehension's
-  allocation size to the iterable.
+## Remaining work: nothing consumes the equalities
 
-## Goals
+`format_infer` ignores non-`int` sizes, which is a safe no-op.
 
-1. Extend the lattice so equal-but-unknown sizes are tracked.
-2. Preserve the existing API for consumers that only care about
-   concrete `int` sizes.
-3. Don't regress fixpoint convergence (loops in the inferred function
-   must still terminate the analysis).
-4. Stay scoped — pick the operations whose symbolic propagation
-   actually buys precision; don't gold-plate.
+- **Bounds-check elimination** — the flagship payoff. Discharge `ys[i]` when
+  `is_size_eq` proves `len(ys) == len(xs)` and `i < len(xs)`. Three equality
+  sources already feed it (arguments, strict `zip`, asserts). This is also what
+  the C++ backend's bounds-check TODO would want, so the two are worth doing
+  together — see `backend-cpp.md`.
+- **`format_infer` `Sum`** — fall back to a runtime-bounded loop when the size is
+  a tracked variable rather than a static `int`.
 
-## Non-goals
+## Caveats for consumers
 
-- Reasoning about size *expressions* (e.g., `len(xs) + 1`).  Only
-  equivalence classes of "same size."
-- Cross-function symbolic propagation.  Each analysis run is
-  self-contained; symbols are fresh per-function.
-- Recognising user-written `assert len(xs) == len(ys)` constraints in
-  the first cut (it falls out for free if/when assertions are part of
-  the analysis input, but isn't required day-1).
-- Alias analysis.  The fresh-def model for `IndexedAssign` already
-  handles size propagation across mutations of the *same* name; aliased
-  variables remain a separate, pre-existing limitation.
-
-## Design
-
-### Lattice extension
-
-```python
-@dataclass(frozen=True)
-class SymbolicSize:
-    """Identifier for an equivalence class of unknown sizes."""
-    id: int
-
-ArraySize: TypeAlias = int | SymbolicSize | None
-```
-
-- `int n` — known concrete size (current behavior, unchanged).
-- `SymbolicSize(id)` — unknown size, but tracked by an id that's
-  shared with other sizes proven equal via the union-find.
-- `None` — top (no information; equivalent to "we gave up").
-
-### Union-find: `_SizeUF`
-
-```python
-class _SizeUF:
-    """Tracks equivalence classes of symbolic sizes within one analysis run."""
-
-    def fresh(self, key: object | None = None) -> SymbolicSize:
-        """Mint a new symbol.  When *key* is non-None, repeated calls
-        with the same key return the same symbol (used to anchor symbols
-        to AST node identity for fixpoint convergence)."""
-
-    def merge(self, a: SymbolicSize, b: SymbolicSize) -> None:
-        """Merge two classes.  Monotone — only collapses, never splits."""
-
-    def equiv(self, a: SymbolicSize, b: SymbolicSize) -> bool:
-        """True iff *a* and *b* are in the same equivalence class."""
-
-    def pin(self, s: SymbolicSize, n: int) -> None:
-        """Record that the class equals concrete *n*.  Future
-        :meth:`resolve` calls return *n*."""
-
-    def resolve(self, s: SymbolicSize) -> int | None:
-        """Return the class's pinned concrete size, or ``None``."""
-```
-
-The UF lives on the visitor and is exposed in `ArraySizeAnalysis`:
-
-```python
-@dataclass
-class ArraySizeAnalysis:
-    by_expr: dict[Expr, ArraySizeBound]
-    by_def: dict[Definition, ArraySizeBound]
-    ret_size: ArraySizeBound | None
-    def_use: DefineUseAnalysis
-    size_uf: _SizeUF              # NEW
-```
-
-Consumers can ask `info.size_uf.equiv(a, b)` to test equivalence.  A
-helper `is_size_eq(b1: ArraySizeBound, b2: ArraySizeBound, uf) -> bool`
-should wrap the common case of checking two `ListSize.size` fields.
-
-### Mint sites — where new symbols are created
-
-Symbols **must be keyed on AST node identity** so that revisiting a
-node during the loop fixpoint returns the *same* symbol.  Without this,
-every iteration mints a fresh symbol, the phi never stabilizes, and the
-analysis diverges.  Concrete keys per site:
-
-| Site                         | Key                | Notes                               |
-|------------------------------|--------------------|-------------------------------------|
-| `Argument: list[T]`          | the `Argument` node | One symbol per arg.                |
-| Free var `list[T]`           | `(FuncDef, name)`   |                                    |
-| `range(n)`                   | `Range1` node       | If `n` is static, use `int`.       |
-| `range(start, stop)`         | `Range2` node       | Same idea.                         |
-| `range(start, stop, step)`   | `Range3` node       | Same.                              |
-| `Empty(…dims)`               | `Empty` node        | One symbol per dimension.          |
-| `xs[a:b]`                    | `ListSlice` node    | If `a, b` static, pin to `b - a`.  |
-| `xs + ys` (concat)           | concat-expr node    | If both static, pin to sum.        |
-
-For operations that **preserve** length, propagate the existing symbol
-without minting:
-
-- `[expr for x in xs]` → same symbol as `xs.size`.
-- `enumerate(xs)`      → same symbol.
-- `zip(xs)` (1-arg)    → same symbol.
-- `zip(xs, ys, …)`     → all-equal: see "Operation rules" below.
-- `xs[i] = e`          → same symbol (length is unchanged by element
-  mutation; this is a free win from the existing fresh-def
-  IndexedAssign treatment).
-- `reverse(xs)`        → same symbol.
-- `ys = xs` (rebind)   → same symbol.
-
-### Operation rules
-
-Where the rule isn't "fresh symbol" or "propagate symbol," the visitor
-needs to compute relationships explicitly.  Highlights:
-
-- **`zip(xs1, …, xsN)`**: FPy's `zip` is *strict* — it raises unless
-  every input has the same length (it does **not** truncate to the
-  shortest like Python's default `zip`).  So the result length *equals*
-  the common input length.  If all inputs are *equal* (UF-equiv)
-  symbols, the result keeps that symbol.  If any input is concrete,
-  every other input must equal it on the non-raising path, so the
-  result size is exactly that int — and a symbolic input can be
-  `pin`/`merge`d to it.  Statically-conflicting concrete sizes mean the
-  call always raises (the result is unreachable): report `None`.
-- **List concatenation `xs + ys`**: result size = `len(xs) + len(ys)`.
-  Concrete + concrete → int.  Anything else → fresh symbol (we don't
-  track sums, see Non-goals).
-- **`Empty(d1, …, dN)`**: each dimension's symbol is keyed on the
-  corresponding `Expr` argument (or pinned to the int value if static).
-
-### Join rule extension
-
-```python
-def _join_size(uf: _SizeUF, a: ArraySize, b: ArraySize) -> ArraySize:
-    if a == b:                     # int == int, or same symbol
-        return a
-    match a, b:
-        case None, _ | _, None:
-            return None
-        case int(), int():         # different concrete values
-            return None
-        case SymbolicSize(), SymbolicSize() if uf.equiv(a, b):
-            return a
-        case SymbolicSize() as s, int(n) | int(n), SymbolicSize() as s:
-            return n if uf.resolve(s) == n else None
-        case _:
-            return None
-```
-
-### Phi handling in loops
-
-When a phi merges `lhs` (pre-loop) and `rhs` (post-body) symbols, and
-they're distinct, **the right action is `merge(lhs, rhs)`** — the loop
-body is repeatedly assigning to the same name, so by the loop-back
-edge those two symbols denote the same runtime size.  After the merge,
-they're UF-equivalent and the join collapses.
-
-**Convergence argument:** UF merges are monotone (classes only
-collapse).  The set of symbols a single function ever creates is
-bounded (one per AST mint site, plus one per loop's lhs/rhs phi pair).
-So the lattice has finite height per program, and the fixpoint
-terminates.
-
-### Public API impact
-
-- `ArraySize` becomes a wider union; consumers that wrote
-  `isinstance(b.size, int)` keep working (they'll now correctly classify
-  `SymbolicSize` as "not a known concrete size").
-- Consumers that wrote `b.size == n` keep working (different type ⇒
-  unequal).
-- Consumers that wrote `b.size is None` may want to broaden to "no
-  *concrete* size known" — depends on semantics.  Add a helper
-  `concrete_size(b: ArraySize) -> int | None`.
-- New helper `is_size_eq(b1: ArraySizeBound, b2: ArraySizeBound, uf) ->
-  bool` for the recursive structural-equality-of-sizes check.
-
-## Implementation plan
-
-### Phase 1 — UF + lattice extension, no symbolic propagation
-
-- Add `SymbolicSize`, `_SizeUF`.
-- Wire `size_uf` through `_ArraySizeInferInstance` and
-  `ArraySizeAnalysis`.
-- Mint a fresh symbol for each `Argument: list[T]` (replacing today's
-  `None`).  Keep all other mint sites at `None` for now.
-- Update `_join_size` to handle the new variant.
-- Verify nothing breaks: existing tests must still pass, just with
-  argument lists having a `SymbolicSize` instead of `None`.
-
-### Phase 2 — propagate through size-preserving operations
-
-- `Var` (rebind), `[expr for x in xs]`, `enumerate`, `IndexedAssign`'s
-  fresh def, `reverse`, slices that resolve to `b - a`.
-- Add tests confirming `ys = xs ⇒ size_uf.equiv(ys.size, xs.size)`.
-
-### Phase 3 — phi merging in loops
-
-- In `_iterate_to_fixpoint`'s phi-update step, when both edges are
-  `SymbolicSize` and unequal, call `uf.merge(lhs, rhs)` instead of
-  going to `None`.
-- Tests confirming a loop that re-binds `xs = xs[1:] + [0.0]`-style
-  preserves the symbol.
-
-### Phase 4 — opt-in concrete pinning
-
-- When a symbol gets joined with a concrete int, optionally `pin` the
-  class.  Skip on first pass — implement only if a consumer needs it.
-
-### Phase 5 — operation rules for size-changing ops
-
-- `zip(*xss)` with all-equal symbols.
-- Concatenation: pin to sum when all concrete.
-- Skip rules whose programs in the codebase don't actually exercise.
-
-### Phase 6 — consumer integration
-
-- Update `mpfx/format_infer.py:Sum` to consult `size_uf` and emit a
-  runtime-bounded loop when the size is symbolic.
-- (Future) bounds-check elimination consumer.
-
-## Risks / open questions
-
-1. **Symbol keying details**: `Empty(m, n)` mints two symbols, one per
-   dimension argument.  What if the *same* `Expr` is reused as
-   different dimensions of nested `Empty` calls?  Probably fine — each
-   `Empty` is its own AST node, so the key tuple includes the position.
-   Worth a focused test.
-
-2. **Cross-function symbol identity**: each `analyze` call gets a
-   fresh UF.  If a downstream pass invokes `analyze` on multiple
-   functions and tries to compare their symbols, equality fails.  This
-   is the right behavior (a function's args are unrelated to another
-   function's args), but consumers should be aware.  Document on
-   `_SizeUF`.
-
-3. **Mutability of UF inside fixpoint**: the loop fixpoint runs the
-   body multiple times; each pass might call `uf.merge`.  Convergence
-   needs the merge operation to be monotone (it is — it only
-   collapses).  But the *visible bound* of a phi doesn't change just
-   because merge happened — the UF has more equivalences but the
-   `SymbolicSize` value stored in `by_def` is still the same id.  So
-   the fixpoint's `prev != current` check might miss a UF change.
-   Need to either (a) include UF state in the convergence check, or (b)
-   prove that any UF change forces some `by_def` change downstream.
-   (b) seems likely but needs verification.
-
-4. **Type alias vs class**: `SymbolicSize` could be a `NewType(int)`
-   instead of a dataclass.  Dataclass is friendlier for `match`
-   patterns; `NewType` is leaner.  Pick during implementation.
-
-5. **`hash` and `==` semantics for `SymbolicSize`**: must be by `id`,
-   not by representative.  That way two `ArraySize` values are `==` iff
-   they're the same symbol, leaving UF consultation as the only way to
-   ask the deeper "are these equivalent?" question.  Avoids surprising
-   hash-equal behavior changing as classes merge.
+- **Size variables are per-`analyze` call.** Two runs mint unrelated variables, so
+  comparing symbols across functions fails. That is correct — one function's
+  arguments are unrelated to another's — but a consumer holding results from two
+  runs must not compare them.
+- **`Empty(m, n)` mints one variable per dimension**, keyed including position, so
+  reusing one `Expr` as two dimensions is fine. Worth a focused test if anything
+  starts depending on it.
 
 ## Out of scope
 
-- Reasoning about arbitrary integer expressions (`len(xs) + 1`,
-  `2 * len(xs)`, etc.).  Useful but a much bigger design (linear
-  arithmetic, Presburger, etc.).  This proposal stops at equivalence.
-- Whole-program / inter-procedural symbolic sizes.
-- User assertions (`assert len(xs) == len(ys)`) — natural extension
-  once assertions are part of the analysis pipeline.
+- Arbitrary integer expressions (`len(xs) + 1`, `2 * len(xs)`). A much larger
+  design — linear arithmetic, Presburger. This stops at equivalence.
+- Interprocedural symbolic sizes.

--- a/docs/todos/backend-cpp.md
+++ b/docs/todos/backend-cpp.md
@@ -52,7 +52,7 @@ offending expression.
 Two things complicate the per-expression story, both documented separately: a
 list also has a *representation* (handle or value — `unbox.py`), and where
 several expressions reach one place they must agree on one C++ type
-(`storage_infer.place_floors` and `emitter._emit_at`).
+(`emitter._emit_at`).
 
 ### SSA rebinds → fresh C++ variables
 
@@ -139,15 +139,13 @@ Module
   → ContextUse                 # resolves with-block contexts
   → ArraySizeInfer             # FormatInfer needs it for bounded iteration
   → FormatInfer                # rounding format per def/expr
-  → StorageInfer  ×2           # storage per SSA def; see place_floors
+  → StorageInfer               # storage per SSA def
   → Alias / Escape             # what may refer to what; what a callee retains
   → Unbox                      # handle or value, per alias region
   → emit C++
 ```
 
-`StorageInfer` runs twice: `place_floors` needs to know which names the emitter
-binds by reference, and that is a property of the storage analysis. `Specialize`
-means a callee's formats follow its call site — so a callee called with a wider
+`Specialize` means a callee's formats follow its call site — so a callee called with a wider
 list is automatically instantiated wider, which is the workaround
 `cpp-narrower-variable-at-a-join.md` relies on.
 

--- a/docs/todos/backend-cpp.md
+++ b/docs/todos/backend-cpp.md
@@ -1,9 +1,10 @@
 # C++ backend — design notes & open TODOs
 
-The cpp backend (`fpy2/backend/cpp/`) compiles FPy to C++ end-to-end
-across scalar arithmetic, control flow, lists, tuples, in-place
-mutation, the `<cmath>` family, and rounding-context boundaries.  Unit
-coverage lives at `tests/unit/backend/cpp/`.
+The cpp backend (`fpy2/backend/cpp/`) compiles FPy to C++ end-to-end across
+scalar arithmetic, control flow, lists, tuples, in-place mutation, the `<cmath>`
+family, and rounding-context boundaries. Unit coverage lives at
+`tests/unit/backend/cpp/`; the differential harness is
+`tests/infra/backend/cpp.py`.
 
 Module layout:
 
@@ -12,326 +13,212 @@ Module layout:
 - `ops.py` — per-op tables of supported C++ signatures.
 - `storage.py` — storage-type ladder, format-containment helpers.
 - `storage_infer.py` — per-SSA-def storage assignment via union-find.
-- `types.py` — `CppScalar` / `CppList` / `CppTuple` and source-string
-  formatting.
-- `utils.py` — header / helper preamble.
+- `unbox.py` — which lists may drop the `fpy::list` handle.
+- `types.py` — `CppScalar` / `CppList` / `CppTuple` and source formatting.
+- `target.py`, `utils.py` — target description, header / helper preamble.
 
-The remaining work is at the bottom under [Open TODOs](#open-todos).
-The sections in between are the design pieces that any of the open
-TODOs build on — read the design before making changes.
+Read the design before changing anything; [Open TODOs](#open-todos) is at the
+bottom. Three narrower questions have their own documents:
 
-## Strategy
-
-The backend was built up in **vertical slices**: each commit got a
-small subset of the language compiling end-to-end before broadening
-coverage.  The unit suite stays green at every commit.
+- `unboxing-gaps.md` — what stays boxed, and why.
+- `cpp-narrower-variable-at-a-join.md` — two element types meeting at one place.
+- `format-infer-aliasing.md` — an unsound bound the backend inherits.
 
 ## Design
 
 ### Storage vs. rounding
 
-The core insight is that **storage type and rounding format are
-separate**:
+The core insight is that **storage type and rounding format are separate**:
 
-- **Rounding format** (from `FormatInfer`): the smallest format that
-  bounds the value of an expression at runtime.  Per-expression.
-- **Storage format**: the C++ type used to *hold* the value in a
-  variable.  Per-definition.  Must contain the rounding format of
-  every expression assigned into that variable (across phi merges
-  and SSA rebinds).
+- **Rounding format** (`FormatInfer`): the smallest format that bounds an
+  expression's value at runtime. Per-expression.
+- **Storage format**: the C++ type that *holds* the value. Per-definition. Must
+  contain the rounding format of everything assigned into that variable.
 
-A storage choice is **valid** iff for every expression assigned into
-the variable, the rounding format is contained in (representable by)
-the storage format.  We pick the smallest valid storage type from a
-fixed ladder: `int{8,16,32,64}_t` / `uint*` / `float` / `double`.
-Unbounded integer formats (`MPFixedFormat` with `expmin >= 0`) fall
-back to `int64_t`; non-abstractable / `REAL_FORMAT` results are
-rejected with an error pointing at the offending expression.
+We pick the smallest valid storage from a fixed ladder: `int{8,16,32,64}_t` /
+`uint*` / `float` / `double`. Unbounded integer formats fall back to `int64_t`;
+non-abstractable / `REAL_FORMAT` results are rejected with an error naming the
+offending expression.
+
+Two things complicate the per-expression story, both documented separately: a
+list also has a *representation* (handle or value — `unbox.py`), and where
+several expressions reach one place they must agree on one C++ type
+(`storage_infer.place_floors` and `emitter._emit_at`).
 
 ### SSA rebinds → fresh C++ variables
 
-The cpp emitter is free to give every SSA def its own C++ variable.
-The *one* constraint is that defs joined by either of two coalescing
-edges must share storage:
+The emitter is free to give every SSA def its own C++ variable. The one
+constraint is that defs joined by a coalescing edge share storage:
 
-- **Phi edges** — a phi merge means both incoming defs write to the
-  same C++ variable.
-- **In-place mutation edges** — `xs[i] = e` is in-place per the FPy
-  interpreter (`interpret/byte.py:_visit_indexed_assign`), so the
-  SSA-fresh def at the `IndexedAssign` site is unioned with its
-  `prev`.  Same C++ name, no widening, no rename.
+- **Phi edges** — a phi merge means both incoming defs write one variable.
+- **In-place mutation edges** — `xs[i] = e` mutates in place per the interpreter
+  (`interpret/byte.py:_visit_indexed_assign`), so the SSA-fresh def at the
+  `IndexedAssign` is unioned with its `prev`. Same name, no rename.
 
-`storage_infer.py` computes the partition with `Unionfind[Definition]`.
-Function-argument and free-variable defs anchor a class to the bare
-source name; other classes for the same source name pick up `_1`,
-`_2`, … suffixes.
+`storage_infer.py` computes the partition with `Unionfind[Definition]`. Argument
+and free-variable defs anchor a class to the bare source name; other classes for
+the same name take `_1`, `_2`, … suffixes.
 
 Per-class declaration shape:
 
-- **Single-writer (`declare_at_assign`)** — the lowest-index writer
-  is its declaration site; the emitter folds the type into the
-  assign (`double t = (a + b);`, `for (int64_t i = 0; …)`,
-  `double y = x;` followed by reassignments inside an `if1` body or
-  loop).
-- **Multi-writer hoisted (`hoists_before`)** — only required when a
-  class has writers in disjoint branches of an `if/else` and the
-  variable did not exist before the `if` (the merge phi has
-  `is_intro=True`).  In that case the emitter hoists `T name{};`
-  *just before* the responsible `IfStmt` (anchoring to the outermost
-  responsible if when nested).
+- **`declare_at_assign`** — the lowest-index writer is the declaration site, so
+  the type folds into the assign (`double t = (a + b);`).
+- **`hoists_before`** — a class with writers in disjoint `if`/`else` branches
+  where the variable did not exist before the `if` (the merge phi is
+  `is_intro=True`). No single writer dominates, so the emitter hoists
+  `T name{};` just before the responsible `IfStmt`.
 
 ### Operation type matching
 
-C++ doesn't have ad-hoc polymorphism for primitive numeric ops:
-each operator is only defined on a fixed set of operand-type
-combinations.  `ops.py` enumerates the supported signatures per
-FPy op type.  Each `UnaryCppOp` / `BinaryCppOp` / `TernaryCppOp` is
-parameterized by:
+C++ has no ad-hoc polymorphism for primitive numeric ops, so `ops.py` enumerates
+supported signatures per FPy op, parameterized by *argument C++ types* and
+*output context*. At an op site the emitter matches the active rounding context
+(`ContextUseAnalysis`) against the signature's `out_ctx`, and each operand's
+storage against `in_ty`. On a miss it falls back to the all-active-context
+signature and casts every operand in.
 
-- *argument C++ types* (`CppScalar`) — the concrete scalar types
-  the generated C++ feeds the operator.  ``int8_t + int8_t`` is
-  one signature, ``float + float`` is another.
-- *output context* (a full `Context` — format + rounding mode).
-  Its C++ type comes from `choose_storage(out_ctx.format())`; the
-  rounding-mode half is enforced separately by the `fesetround`
-  boundary at `with` blocks.
+**Every** conversion is an explicit `static_cast` — no reliance on implicit
+promotion, even for lossless widenings. Two paths:
 
-At an op site the emitter consults:
-
-- The **active rounding context** at the expression
-  (`ContextUseAnalysis.find_scope_from_use(e).ctx`) — must equal
-  the signature's `out_ctx`.
-- Each operand's **C++ storage type** (from `StorageAnalysis`) —
-  must equal the signature's `in_ty`.
-
-Direct-match preferred; on miss the emitter falls back to the
-all-active-context signature and casts every operand into the active
-context's storage type.  **Every** type conversion goes through an
-explicit `static_cast` — no reliance on C++ implicit promotion, even
-for "lossless" widenings.
-
-The cast helper splits into two paths:
-
-- `_maybe_cast` — used for *implicit* casts (op-dispatch fallback,
-  comparison cast-to-supremum).  Rejects the compilation when the
-  conversion is lossy (`not scalar_fits_in(arg_ty, target_ty)`).
-  The error tells the user to wrap the operand in `fp.round(...)`
-  or pick a context that holds the value.
-- `_explicit_cast` — used for *user-explicit* casts (`Round` /
-  `RoundExact` lowerings, `xs[static_cast<size_t>(i)]` subscripts).
-  Emits the `static_cast` unconditionally; the user has already
-  said they accept the conversion.
-
-So a lossy implicit cast like FP64 → FP32 (or int64 → FP64) fails
-to compile until the program wraps the wider operand in
-`fp.round(...)` — making the rounding step part of the source.
-
-The default table covers `Add`/`Sub`/`Mul`/`Div`, `Neg`, `Abs`, all
-of `<cmath>` (transcendental + algebraic + FP rounding helpers),
-`Pow`/`Hypot`/`Atan2`/etc., and `Fma` — across FP32 / FP64 with each
-of the four `fesetround`-supported rounding modes (RNE / RTZ / RTP /
-RTN), plus the integer ladder (`SINT8…64`, `UINT8…64`, `INTEGER`)
-where applicable.
+- `_maybe_cast` — *implicit* casts (op-dispatch fallback, comparison
+  cast-to-supremum). **Rejects** a lossy conversion, telling the user to wrap the
+  operand in `fp.round(...)`. So FP64 → FP32 fails to compile until the rounding
+  is written in the source.
+- `_explicit_cast` — *user-explicit* casts (`Round`, subscript `size_t`). Emitted
+  unconditionally; the user already accepted the conversion.
 
 ### Context boundaries
 
-The active rounding context at every `FuncDef` / `ContextStmt` site
-comes from `ContextUseAnalysis`.
+The active context at every `FuncDef` / `ContextStmt` comes from
+`ContextUseAnalysis`.
 
-**Validation is gated on use.**  A scope is only validated when
-some primitive op (`NullaryOp` / `UnaryOp` / `BinaryOp` /
-`TernaryOp` / `Call`) actually dispatches under it — i.e., when
-`ctx_use.uses[scope]` is non-empty.  Scopes with no uses (e.g.,
-a function-level scope where every op lives inside a nested `with`,
-or a `with` block that holds an exotic context but only does
-context-free work like list indexing) are skipped entirely: no
-validation, no `fesetround`.  This means programs without a
-rounding-context use don't need a supported function-level context,
-and `with UnsupportedCtx:` blocks compile freely as long as nothing
-inside them dispatches under that scope.
+**Validation is gated on use.** A scope is validated only when some primitive op
+actually dispatches under it. Scopes with no uses are skipped entirely — no
+validation, no `fesetround` — so a program with no rounding-context use needs no
+supported function-level context, and `with UnsupportedCtx:` compiles as long as
+nothing inside dispatches under it.
 
-When a scope *is* used, validation runs:
+When a scope is used:
 
-- The context must be a concrete :class:`Context` — symbolic
-  context variables (`ContextUse` falls back to a fresh `NamedId`
-  when partial-eval can't pin one) are rejected at the
+- The context must be concrete; a symbolic context variable is rejected at its
   introduction site.
-- **Float contexts** must use a rounding mode supported by
-  `fesetround` (RNE / RTZ / RTP / RTN).  `_visit_function` /
-  `_visit_context` save / set / restore `fenv` only when the active
-  mode actually *changes*.  The active mode is tracked on
-  `_current_rm: RM | None`:
-  - At function entry it's seeded from the function-level scope:
-    a concrete FP context's RM (the FPy contract says the caller
-    delivers it), or `None` for a symbolic / integer / unsupported
-    outer scope.
-  - `None` means "unknown" — any nested concrete-FP `with` block
-    must emit `fesetround` unconditionally to recover certainty,
-    matching the user's "safest option" rule.
-  - When `_current_rm` is concrete and matches the target, the
-    `with` block is a no-op at the C++ level (no fenv noise for
-    plain `with FP64:` under an FP64 function).
-- **Integer contexts** must use RTZ — that matches C++'s integer
-  truncation, and other modes would require per-operation
-  emulation.  No runtime support emitted.
+- **Float contexts** need an `fesetround`-supported mode (RNE / RTZ / RTP / RTN).
+  `_current_rm` tracks the mode the live `fenv` is guaranteed to hold, seeded at
+  entry from the function-level scope (`None` = unknown, so a nested concrete
+  `with` must emit `fesetround` unconditionally). A matching mode makes the
+  `with` a C++-level no-op.
+- **Integer contexts** must use RTZ — that is what C++ integer truncation does.
 
-`Round`, `RoundExact`, `Cast`:
+`Round` / `Cast`:
 
-- `Round(arg)` lowers to `static_cast<target>(arg)` — the cast's
-  rounding mode comes from the surrounding `fesetround` boundary,
-  not the cast itself.
-- `RoundExact(arg)` adds a runtime assertion that the cast was
-  lossless: cast → bind to a temp →
-  `assert(arg == tmp || (std::isnan(arg) && std::isnan(tmp)))`
-  for FP operands (NaN-aware) or `assert(arg == tmp)` for purely
-  integer pairs.
-- `Cast(arg)` is the identity — analysis-only annotation, no
-  generated code.  Same-type `Round` / `RoundExact` short-circuit
-  to the identity.
+- `Round(arg)` lowers to `static_cast<target>(arg)`, whose rounding mode comes
+  from the surrounding `fesetround` boundary. A **literal** argument is folded at
+  compile time instead (`_fold_rounded_literal`) — C++ has no exact-real literal,
+  so this is the only way an inexact constant is representable at all, and it
+  also gets the mode the program asked for rather than whatever `fesetround`
+  last left behind.
+- `Cast(arg)` — the node `fp.cast` and `fp.round_exact` both parse to — is the
+  same cast plus a runtime assertion that it was lossless, NaN-aware for FP
+  operands. Same-type short-circuits to the identity.
 
 ### Pipeline
 
 ```
-FuncDef
-  → Monomorphize.apply_by_arg(arg_types)   # ground type vars
-  → DefineUse.analyze
-  → ContextUse.analyze                     # resolves with-block ctxs
-  → ArraySizeInfer.analyze
-  → FormatInfer.analyze                     # rounding format per def/expr
-  → StorageInfer.infer                      # storage class per SSA def
+Module
+  → Specialize                 # one FuncDef per (callee, ctx, arg formats)
+  → DefineUse
+  → ContextUse                 # resolves with-block contexts
+  → ArraySizeInfer             # FormatInfer needs it for bounded iteration
+  → FormatInfer                # rounding format per def/expr
+  → StorageInfer  ×2           # storage per SSA def; see place_floors
+  → Alias / Escape             # what may refer to what; what a callee retains
+  → Unbox                      # handle or value, per alias region
   → emit C++
 ```
 
-`ArraySizeInfer` is needed because `FormatInfer` consults it for
-bounded-iteration mode (loops with statically-known length).
-`ContextUse` builds a `site → ContextScope` lookup that the emitter
-also consults for `with` boundaries and per-op active contexts.
+`StorageInfer` runs twice: `place_floors` needs to know which names the emitter
+binds by reference, and that is a property of the storage analysis. `Specialize`
+means a callee's formats follow its call site — so a callee called with a wider
+list is automatically instantiated wider, which is the workaround
+`cpp-narrower-variable-at-a-join.md` relies on.
 
 ### Translation-unit preamble
 
-`CppCompiler.compile` returns a function definition only so
-single-function tests can use exact-string equality.  Callers that
-want a complete translation unit pull `headers()`, `helpers()`, or
-`prelude()` (the two combined) explicitly.  Header coverage tracks
-exactly what the emitted code uses (`<cassert>` for assertions,
-`<cfenv>` for `fesetround`, `<cmath>` for transcendentals,
-`<cstdint>` for fixed-width ints, `<numeric>` for `accumulate`,
-`<vector>` and `<tuple>`).
-
-Helpers is currently empty — cpp doesn't yet need custom runtime
-support — but the slot exists for future additions
-(see [TODOs](#open-todos)).
+`CppCompiler.compile` returns a function definition only, so single-function
+tests can use exact-string equality. Callers wanting a full translation unit
+pull `headers()`, `helpers()`, or `prelude()`. `helpers()` carries the runtime:
+`fpy::list<T>` (a `shared_ptr<vector<T>>`), `fpy::make_list`, and the nary
+`fpy::min` / `fpy::max`. Headers track exactly what the emitted code uses.
 
 ## Open TODOs
 
-These items are queued for a future pass.  The design above defines
-the constraints they need to fit; pick whichever is most relevant
-to your changes.
-
 ### Bounds-checked list operations
 
-`_visit_list_ref`, `_visit_list_slice`, and `_visit_indexed_assign`
-currently emit raw `xs[i]` / iterator arithmetic with no out-of-
-range check.  The FPy interpreter is strict (raises on out-of-range
-indices); cpp should match.  Likely shape: a small bounds-checked
-subscript helper added to `CPP_HELPERS`, called from each subscript
-site.  See the TODO comments at `emitter.py:_visit_list_ref` and
-`_visit_list_slice` for current behavior.
+`_visit_list_ref`, `_visit_list_slice`, and `_visit_indexed_assign` emit raw
+`xs[i]` with no range check — `xs[10]` on a shorter list is undefined behaviour,
+while the interpreter raises. Likely shape: a checked subscript helper in
+`CPP_HELPERS`, called from each subscript site.
 
 ### RAII fenv guard
 
-When a function-level `fesetround` is active and the body executes
-`return X;`, the trailing `fesetround(prev)` is dead code — the
-caller's rounding mode is leaked.  Best fix is an RAII guard
-emitted as part of the helper preamble:
+A `return` inside an active `fesetround` scope leaves the restore unreachable, so
+the caller's rounding mode leaks:
+
+```cpp
+double leak(double x) {
+    const auto _tmp1 = std::fegetround();
+    std::fesetround(FE_TOWARDZERO);
+    return (x + static_cast<double>(1));
+    std::fesetround(_tmp1);          // dead
+}
+```
+
+Fix with a guard in the helper preamble whose destructor runs on every exit path:
 
 ```cpp
 struct __cpp_FenvGuard {
     int prev;
-    explicit __cpp_FenvGuard(int new_rm) : prev(std::fegetround()) {
-        std::fesetround(new_rm);
-    }
+    explicit __cpp_FenvGuard(int rm) : prev(std::fegetround()) { std::fesetround(rm); }
     ~__cpp_FenvGuard() { std::fesetround(prev); }
 };
 ```
 
-`_visit_function` and `_visit_context` would then declare a guard at
-the start of the affected scope; the destructor runs on every exit
-path (including `return`).  Drop the manual save / set / restore
-emission once the guard lands.
+`_visit_function` / `_visit_context` declare a guard instead of the manual
+save / set / restore.
 
-### Classification ops + nary `Min` / `Max`
+### Narrowing inside `std::accumulate`, so `Sum` can fuse
 
-`IsFinite` / `IsInf` / `IsNan` / `IsNormal` / `Signbit` return
-`bool` — they don't fit the existing `(in_fmt, out_ctx)` shape (the
-output isn't a numeric context).  Either add a `bool`-output slot to
-the op-table classes, or special-case these in `_visit_unaryop`
-alongside `Len` / `Sum` / `Enumerate`.
+`ReduceFusion` fuses `any` / `all` over a comprehension into one loop, skipping
+the intermediate vector. `Sum` / `AMin` / `AMax` pay the same allocation cost but
+are not fused, because the fused shape needs an implicit narrowing inside
+`std::accumulate` that `_maybe_cast` rejects at an ordinary assignment. Today
+`sum([x * x for x in xs])` still materializes:
 
-`Min` / `Max` are nary in FPy.  These reduce naturally to pairwise
-`std::fmin` / `std::fmax` in `_visit_naryop`.
+```cpp
+std::vector<double> _tmp1 = std::vector<double>(0);
+for (double x : xs) { _tmp1.push_back((x * x)); }
+return std::accumulate(_tmp1.begin(), _tmp1.end(), static_cast<double>(0));
+```
 
-### Round-trip tests against `cc -std=c++17`
-
-Mirror `tests/infra/backend/cpp.py`: compile each test program with
-the cpp backend, run it through `cc -std=c++17`, link, and exec —
-asserting the runtime result matches the FPy interpreter's.  Catches
-header-omission bugs and silent dispatch errors that pure-string
-unit tests miss.
+The emitter side is the blocker; see `fpy2/transform/reduce_fusion.py`'s module
+docstring for the transform side.
 
 ### `fpy2/backend/cpp/README.md`
 
-A short README in the package directory pointing at this file and
-listing the public surface (`CppCompiler.compile` / `headers` /
-`helpers` / `prelude`, exception types).
+A short package README pointing at this file and listing the public surface
+(`CppCompiler.compile` / `headers` / `helpers` / `prelude`, exception types).
 
-### Whole-call-graph optimization pass
+## Out of scope
 
-`CppCompiler(optimize=True)` currently applies `ZipElim` (and any
-future optimizing transforms wired into `_run_pipeline`) only to
-the top-level `FuncDef` of each `compile` / `add` call.  Callees
-reached transitively via `FormatInfer`'s `by_call` walk still see
-their original AST — so e.g. a `for ... in zip(...)` inside a
-library helper continues to lower to a `std::vector<std::tuple<...>>`
-even when the top-level was optimized.
+- Linking an external multi-precision library.
+- Emitting exact arithmetic where format inference reports `REAL_FORMAT`; those
+  programs are rejected with an error naming the symbolic expression.
+- `with FP64 as ctx:` — binding the active context to a name.
 
-Proposed shape:
+## Done since this document was written
 
-1. Before `_run_pipeline` runs, construct a call graph rooted at the
-   top-level `Function`.  Walk every `Call` in the body, look up its
-   target via the existing `Function` linkage, and recurse — keyed
-   by `FuncDef` identity so each callee is visited once.  The
-   existing `_discover_specializations` does part of this walk
-   *after* `FormatInfer`; we want the structural walk *before*.
-2. Apply the optimizing transforms (`ZipElim`, …) to each FuncDef
-   in the graph, producing a `FuncDef → FuncDef` rewrite map.
-3. Thread the rewrite map through the pipeline so `FormatInfer`
-   (and downstream consumers that look up callee ASTs) see the
-   rewritten version.  The cleanest plumbing point is probably the
-   `fn.ast` access in `_FormatInferInstance._visit_call`
-   ([format_infer/analysis.py:1060](fpy2/analysis/format_infer/analysis.py))
-   — substitute via the map before handing to the sub-analysis.
-4. The `PreAnalysisCache` is keyed by `FuncDef`; the rewritten
-   FuncDefs become its new keys.  As long as the rewrite is
-   deterministic (same input → same output identity), the cache
-   semantics carry over.
-
-Open questions:
-
-- Whether the rewrite should be eager (apply once up-front, mutate
-  the map) or lazy (rewrite-on-demand during the walk).  Eager is
-  simpler; lazy avoids work for unreachable callees but those are
-  rare in practice.
-- Whether to expose the rewrite map externally for debugging /
-  caching across multiple `compile` calls within the same
-  `CppTranslationUnit` build.
-
-## Out of scope (for the first pass)
-
-- Linking against an external multi-precision library (mpfr, etc.).
-- Generating exact arithmetic where the format-inference fallback
-  reports `REAL_FORMAT` — those programs are rejected with a clear
-  error pointing at the symbolic expression.  (Future work: emit a
-  multi-precision fallback rather than rejecting.)
-- Binding the active rounding context to a name in `with`
-  (`with FP64 as ctx:` …) — the emitter currently rejects.
+Kept as a record so they are not re-proposed: classification ops
+(`isfinite`/`isinf`/`isnan`/`isnormal`/`signbit`) and nary `Min`/`Max`; the
+execute-and-bit-compare harness (`tests/infra/backend/cpp.py --mode run`, plus a
+generated format matrix); and whole-call-graph optimization — `Specialize` runs
+before the pipeline, so `ZipElim` and friends reach callees, not just the entry.

--- a/docs/todos/backend-cpp.md
+++ b/docs/todos/backend-cpp.md
@@ -18,11 +18,20 @@ Module layout:
 - `target.py`, `utils.py` — target description, header / helper preamble.
 
 Read the design before changing anything; [Open TODOs](#open-todos) is at the
-bottom. Three narrower questions have their own documents:
+bottom. Narrower questions have their own documents:
 
 - `unboxing-gaps.md` — what stays boxed, and why.
 - `cpp-narrower-variable-at-a-join.md` — two element types meeting at one place.
 - `format-infer-aliasing.md` — an unsound bound the backend inherits.
+- **`reals-in-integer-storage.md`** — the largest open correctness problem: a
+  real narrowed into an integer holds neither `-0.0` nor NaN.
+- `cpp-literal-tokens-and-sum.md` — three smaller disagreements between the
+  emitted C++ and the interpreter.
+
+The correctness criterion those last three are measured against: *if the
+compiler succeeds, the emitted C++ must compile and must behave as the FPy
+interpreter does.* A refusal is always acceptable — the compiler may be limited —
+so a shape it cannot handle should raise, never miscompile.
 
 ## Design
 

--- a/docs/todos/cpp-literal-tokens-and-sum.md
+++ b/docs/todos/cpp-literal-tokens-and-sum.md
@@ -1,0 +1,83 @@
+# Three more places the emitted C++ disagrees with FPy
+
+Found by an adversarial audit against the criterion *"if the compiler succeeds,
+the C++ compiles and behaves the same."* All three predate the join/widening
+work and are independent of it. None is fixed.
+
+## 1. A literal's predicted storage is not the type of the token written
+
+The emitter picks a literal's storage from its *value* — `1.5` fits binary32, so
+the prediction is `F32` — and `_maybe_cast` then inserts nothing because the
+prediction already matches the target. But the **token** emitted is `1.5`, a C++
+`double`. Where the callee is generic, the argument's real type wins:
+
+```python
+with fp.FP32:
+    return fp.fmax(y, 1.5)          # y: FP32
+```
+```cpp
+float f(float y) { return fpy::max(y, 1.5); }
+// error: no matching function for call to 'max(float&, double)'
+//   note: deduced conflicting types for parameter 'T' ('float' and 'double')
+```
+
+*Does not compile.* Triggered by any literal whose own narrowest storage is
+already `F32` — `1.5`, `0.5`, `0.25` — in an FP32 context. FP64 contexts are safe
+because the cast *is* inserted. This was 20 of 31 failures in one 3,200-program
+sweep.
+
+The silent twin picks a wide **overload** instead of failing to deduce:
+
+```python
+with fp.FP32:
+    return fp.fma(y, z, 0.25)
+```
+emits `std::fma(y, z, 0.25)`, which resolves to the `double` overload — so the
+product is rounded to binary64 and *then* to binary32, where FPy rounds the exact
+result once. With `y = 24929·2^60` and `z = 673`, chosen so `y·z` is exactly a
+binary32 midpoint: interpreter `0x1.000002p+84`, compiled `0x1p+84`.
+
+Most other `<cmath>` ops are unaffected in practice — for them the double
+rounding is provably harmless since 53 ≥ 2·24+2. `fma` is the exception because
+its exact product can exceed 53 bits.
+
+Fix: spell the literal at the target type (an `f` suffix, or a cast) rather than
+trusting the predicted storage. One change fixes both.
+
+## 2. An integral literal too large for a C++ integer literal is printed verbatim
+
+`_emit_numeric_literal` prints any value with `denominator == 1` as decimal
+digits, with no range check and no floating spelling. Storage selection catches
+this at scalar level (it refuses), but a **list element or slot** never asks:
+
+```python
+zs = [1e300, y]
+```
+```cpp
+std::vector<double> zs = std::vector<double>{1000000000000000052504...0160, y};
+```
+
+301 digits. GCC accepts it with only *"integer constant is too large for its
+type"* and the value becomes 0. Interpreter `1e300`, compiled `0`. Same for
+`xs[0] = 1e300`.
+
+Fix: print a floating literal (`repr(float(v))`) when the value is outside the
+integer range, or refuse.
+
+## 3. `sum(xs)` does not match the interpreter's reduction
+
+The emitter lowers it to `std::accumulate(begin, end, static_cast<T>(0))` — *n*
+additions from a typed zero. `interpret/byte.py`'s `_eval_sum` starts from
+`xs[0]` **unrounded** and does *n−1*. Two consequences:
+
+- `sum([-0.0])` — interpreter `-0.0`, compiled `+0.0`, because `0.0 + (-0.0)` is
+  `+0.0`.
+- Under a narrower accumulator the seed rounds the element away: `sum(xs)` under
+  FP32 with `xs = [5e-324]` gives the interpreter `4.94e-324` (the element,
+  untouched) and the compiled code `0`.
+
+Note the compiler *refuses* an explicit `f32 + f64` addition, but `sum` performs
+exactly that addition without the check.
+
+Fix: seed from the first element and reduce over the rest, or refuse when the
+element format differs from the accumulator's.

--- a/docs/todos/cpp-narrower-variable-at-a-join.md
+++ b/docs/todos/cpp-narrower-variable-at-a-join.md
@@ -6,25 +6,11 @@ bounds each expression by *its own* values, which is the question it answers and
 answers correctly: `[3.0]` really is bounded by `{3}`, even where it has to be a
 `std::vector<double>` because the other `return` is one.
 
-Reconciling the two is a **storage** question, so it lives in the backend, in two
-halves:
-
-- **`storage_infer.place_floors`** raises a *definition* to the join of the places
-  its value reaches. Nothing then needs converting. Lists only — a scalar
-  converts free at the point of use, so widening its declaration would change a
-  signature to no purpose.
-- **`emitter._emit_at`** builds a *constructor* at the place's type, and converts
-  anything else (`_convert_storage`). Flat lists take `std::vector`'s
-  iterator-range constructor, nested ones are rebuilt with a loop, tuples field
-  by field.
-
-The two must agree about which expressions contribute to a place; `_push` and
-`_emit_at` are deliberately the same shape.
-
-`place_floors` iterates, because the constraint runs both ways: a place raises a
-variable, and a raised variable raises the container built from it — once `base`
-is a `vector<double>`, `scratch = [base]` has to be a `vector<vector<double>>`.
-Bounds only rise and the ladder is finite, so it settles.
+Reconciling the two is a **storage** question, so it lives in the backend, in
+`emitter._emit_at`: it builds a *constructor* at the place's type, and converts
+anything else (`_convert_storage`). Flat lists take `std::vector`'s
+iterator-range constructor, nested ones are rebuilt with a loop, tuples field by
+field.
 
 > Do not push any of this into `format_infer`. An earlier version did, by
 > overwriting each contributor's `by_expr` entry with the join. It is sound but
@@ -34,37 +20,30 @@ Bounds only rise and the ladder is finite, so it settles.
 > — paid for a decision only the C++ backend cares about. Same principle as
 > "keep `alias` free of C++" in `unboxing-gaps.md`.
 
-Raising a *parameter* changes the ABI, and `signature()` reports the raised type.
-That was already the policy for a store — `_list_set_widen` widens a def on
-`xs[0] = y` — so the join arm now gives the same answer as the store arm rather
-than refusing where it widens.
+## What cannot be converted
 
-## What cannot be raised
+A **shared** list cannot be rebuilt. Converting allocates, a new allocation is a
+different object, and sharing exists precisely so FPy's aliasing survives — so
+rebuilding a shared list would hand its other references a list they no longer
+name. `_convert_storage` refuses, and `_refuse_unsharing` writes the message.
+(Unboxed → boxed is fine and is done: a value has no aliases to lose, so
+`std::make_shared` is free.)
 
-A handle cannot be rebuilt. Converting allocates, a new allocation is a different
-object, and a handle exists precisely so FPy's aliasing survives — so rebuilding
-one would hand the caller a list its other references no longer name.
-`_convert_storage` refuses. (Unboxed → boxed is fine and is done: a value has no
-aliases to lose, so `std::make_shared` is free.)
+So a narrower list reaching a wider place compiles when it is a fresh value and
+is refused when something else names it. Refusing is the point — the alternative
+is silently unsharing, which is a wrong answer rather than a compile error.
+`test_a_shared_narrower_list_is_refused` pins seven shapes: a local held by a
+list or a tuple, a mixed-precision local, a parameter, and the three
+reference-bound forms (`ys = xs`, `row = xss[i]`, a loop target).
 
-Two kinds of value have no storage of their own to raise, so they still reach
-that refusal.
+The reference-bound ones are why this has to be a refusal and not a diagnostic
+left to C++. The emitter spells them `const auto&`, so *nothing in the emitted
+text states the element type* — `const auto& ys = xs;` then `return ys;` would
+emit an `fpy::list<float>` where an `fpy::list<double>` is declared, and only the
+C++ compiler would object.
 
-**A name bound as a reference.** `ys = xs`, `row = xss[i]`, a loop target — the
-emitter spells these `const auto&`, naming storage that already exists.
-`_PlaceFloors._pinned` skips them, via the same `binds_by_reference` predicate the
-emitter and `unbox` use, so the three stay in agreement.
-
-> This was a bug first: raising them made `storage_of` report a type the
-> reference did not have, and because the binding is spelled `auto` nothing
-> caught it — `const auto& ys = xs;` then `return ys;` emitted an
-> `fpy::list<float>` as an `fpy::list<double>` and only the C++ compiler
-> objected. Pinned in `test_a_reference_bound_name_is_not_raised`.
-
-A *parameter* is also bound by reference, but its type is spelled from
-`storage_of` in the signature, so raising it does what it says.
-
-**A callee's result**, whose representation is fixed by the callee's own body:
+A **callee's result** is the same refusal from the other side: its representation
+is fixed by the callee's own body, so nothing at the call site can move it.
 
 ```python
 def g(zs: list[fp.Real]) -> list[fp.Real]:      # at FP32
@@ -73,8 +52,7 @@ def g(zs: list[fp.Real]) -> list[fp.Real]:      # at FP32
 
 def f(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
     with fp.FP64:
-        ws = g(xs)
-        return ws if c > 0 else [y]              # refused
+        return g(xs) if c > 0 else [y]           # refused
 ```
 
 ```
@@ -90,32 +68,46 @@ automatically, since a callee's formats already follow its call site. Pinned in
 `test_widening_the_call_site_is_a_real_workaround`, so the advice cannot quietly
 become false.
 
-**Closing it properly is harder than it looks, and not worth it yet.** The
-tempting description — "propagate the floor across the call edge" — is wrong.
-A callee's return format is a *function* of its parameter formats, so a caller
-cannot ask for a wider return directly; it has to find parameter formats that
-*produce* one. That is inverting the callee's body, not propagating a bound, and
-for many callees no answer exists: one returning `[1.5]` cannot be widened by any
-argument, so the refusal survives anyway. A fixpoint over the call graph would be
-the easy half.
-
-`unboxing-gaps.md` records the related decision not to specialize on
-boxed/unboxed, and the same argument applies here: nothing has measured a cost.
-
-The reference-bound cases are harder to close and less worth it: a reference is
-what makes `for a, b in zip(...)` over nested lists unbox at all, so raising one
-would mean giving it storage — a copy — which is the thing the refusal exists to
-avoid.
-
 Zero corpus programs reach any of this.
 
 ## Also considered
 
-**Stop value-narrowing list elements.** `[0.0, 1.0]` becoming `uint8_t` was the
+**Raise the definition instead of converting at the place** (`place_floors`,
+landed in `f05ea99` and removed again; the `cpp-old` branch is the last state
+that had it). A pass raises each *definition* to the
+join of the places its value reaches, so a narrower local is declared wide and
+nothing needs converting. It iterates, because the constraint runs both ways: a
+place raises a variable, and a raised variable raises the container built from it.
+
+Measured cost of removing it: the corpus failure set is unchanged (identical 174
+names), and the generated format matrix goes from 29 accepted instantiations to
+27 — the two lost are `_gen_return_param_or_literal[32_64]` and
+`_gen_ternary_param[32_64]`, both "return an FP32 list parameter or an FP64
+literal list", i.e. the raise-a-parameter case. So it compiles the "local held in
+a container" and "narrower parameter" shapes and nothing else — a pure
+capability, fixing no defect. Against that:
+
+- It has to skip exactly the values with no storage of their own to raise
+  (reference-bound names, callee results), and getting that set wrong is a
+  *silent* miscompile for the `const auto&` reason above. It got it wrong four
+  times, each in the same way: asking a definition a question whose answer
+  belongs to its whole storage class.
+- Raising a *parameter* changes the ABI. Fine for an entry point, wrong for a
+  function compiled code calls, which needs one signature on both sides. Both
+  shapes it buys for a parameter depend on getting that distinction right.
+
+Closing the callee-result case *properly* is harder than "propagate the floor
+across the call edge": a callee's return format is a *function* of its parameter
+formats, so a caller cannot ask for a wider return, only for parameter formats
+that *produce* one. That is inverting the callee's body, and for many callees no
+answer exists — one returning `[1.5]` cannot be widened by any argument. A
+fixpoint over the call graph would be the easy half.
+
+**Stop value-narrowing list elements.** `[0.0, 1.0]` becoming `uint8_t` is the
 most common accidental trigger. Measured: 21 of 112 corpus list element types are
 value-narrowed, all in `test_list*` / `test_range*` / `test_list_comp*`, none in
-the kernels. Raising definitions made it moot for correctness, so this is now
-purely a question of whether the narrowing earns its keep.
+the kernels. This is the cheapest way to shrink the refusal set, and it is a
+question about whether the narrowing earns its keep at all.
 
 **A language answer.** A returned list's element format is arguably part of what
 the function *is*; a signature claiming `-> list[fp.Real]` at FP64 while returning

--- a/docs/todos/cpp-narrower-variable-at-a-join.md
+++ b/docs/todos/cpp-narrower-variable-at-a-join.md
@@ -1,0 +1,123 @@
+# One place, two element types
+
+Where several values reach one place — a `return`, a ternary arm, a list's
+elements, a tuple's field — that place admits one C++ type. `format_infer`
+bounds each expression by *its own* values, which is the question it answers and
+answers correctly: `[3.0]` really is bounded by `{3}`, even where it has to be a
+`std::vector<double>` because the other `return` is one.
+
+Reconciling the two is a **storage** question, so it lives in the backend, in two
+halves:
+
+- **`storage_infer.place_floors`** raises a *definition* to the join of the places
+  its value reaches. Nothing then needs converting. Lists only — a scalar
+  converts free at the point of use, so widening its declaration would change a
+  signature to no purpose.
+- **`emitter._emit_at`** builds a *constructor* at the place's type, and converts
+  anything else (`_convert_storage`). Flat lists take `std::vector`'s
+  iterator-range constructor, nested ones are rebuilt with a loop, tuples field
+  by field.
+
+The two must agree about which expressions contribute to a place; `_push` and
+`_emit_at` are deliberately the same shape.
+
+`place_floors` iterates, because the constraint runs both ways: a place raises a
+variable, and a raised variable raises the container built from it — once `base`
+is a `vector<double>`, `scratch = [base]` has to be a `vector<vector<double>>`.
+Bounds only rise and the ladder is finite, so it settles.
+
+> Do not push any of this into `format_infer`. An earlier version did, by
+> overwriting each contributor's `by_expr` entry with the join. It is sound but
+> strictly less precise, and it makes a backend-independent analysis answer a C++
+> question: `[1.5, 2.5]` and `[3.0]` both came out bounded by `{3/2, 5/2, 3}`, so
+> every consumer — `round_elim`, `const_fold`, error analysis, the FPCore backend
+> — paid for a decision only the C++ backend cares about. Same principle as
+> "keep `alias` free of C++" in `unboxing-gaps.md`.
+
+Raising a *parameter* changes the ABI, and `signature()` reports the raised type.
+That was already the policy for a store — `_list_set_widen` widens a def on
+`xs[0] = y` — so the join arm now gives the same answer as the store arm rather
+than refusing where it widens.
+
+## What cannot be raised
+
+A handle cannot be rebuilt. Converting allocates, a new allocation is a different
+object, and a handle exists precisely so FPy's aliasing survives — so rebuilding
+one would hand the caller a list its other references no longer name.
+`_convert_storage` refuses. (Unboxed → boxed is fine and is done: a value has no
+aliases to lose, so `std::make_shared` is free.)
+
+Two kinds of value have no storage of their own to raise, so they still reach
+that refusal.
+
+**A name bound as a reference.** `ys = xs`, `row = xss[i]`, a loop target — the
+emitter spells these `const auto&`, naming storage that already exists.
+`_PlaceFloors._pinned` skips them, via the same `binds_by_reference` predicate the
+emitter and `unbox` use, so the three stay in agreement.
+
+> This was a bug first: raising them made `storage_of` report a type the
+> reference did not have, and because the binding is spelled `auto` nothing
+> caught it — `const auto& ys = xs;` then `return ys;` emitted an
+> `fpy::list<float>` as an `fpy::list<double>` and only the C++ compiler
+> objected. Pinned in `test_a_reference_bound_name_is_not_raised`.
+
+A *parameter* is also bound by reference, but its type is spelled from
+`storage_of` in the signature, so raising it does what it says.
+
+**A callee's result**, whose representation is fixed by the callee's own body:
+
+```python
+def g(zs: list[fp.Real]) -> list[fp.Real]:      # at FP32
+    with fp.FP32:
+        return zs                                # returns its argument: shared
+
+def f(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    with fp.FP64:
+        ws = g(xs)
+        return ws if c > 0 else [y]              # refused
+```
+
+```
+unsupported: the list `g` returns holds `float` elements where `double` is
+needed.  Changing a list's element type needs a new buffer, and this one is
+shared — so the copy would not be the list its other references name.  Either
+have `g` return the wider format, or do not mix formats at this point.
+```
+
+**There is a workaround, and it is the one the message names.** Widening at the
+call site is enough — `g` is then specialized at the wider argument format
+automatically, since a callee's formats already follow its call site. Pinned in
+`test_widening_the_call_site_is_a_real_workaround`, so the advice cannot quietly
+become false.
+
+**Closing it properly is harder than it looks, and not worth it yet.** The
+tempting description — "propagate the floor across the call edge" — is wrong.
+A callee's return format is a *function* of its parameter formats, so a caller
+cannot ask for a wider return directly; it has to find parameter formats that
+*produce* one. That is inverting the callee's body, not propagating a bound, and
+for many callees no answer exists: one returning `[1.5]` cannot be widened by any
+argument, so the refusal survives anyway. A fixpoint over the call graph would be
+the easy half.
+
+`unboxing-gaps.md` records the related decision not to specialize on
+boxed/unboxed, and the same argument applies here: nothing has measured a cost.
+
+The reference-bound cases are harder to close and less worth it: a reference is
+what makes `for a, b in zip(...)` over nested lists unbox at all, so raising one
+would mean giving it storage — a copy — which is the thing the refusal exists to
+avoid.
+
+Zero corpus programs reach any of this.
+
+## Also considered
+
+**Stop value-narrowing list elements.** `[0.0, 1.0]` becoming `uint8_t` was the
+most common accidental trigger. Measured: 21 of 112 corpus list element types are
+value-narrowed, all in `test_list*` / `test_range*` / `test_list_comp*`, none in
+the kernels. Raising definitions made it moot for correctness, so this is now
+purely a question of whether the narrowing earns its keep.
+
+**A language answer.** A returned list's element format is arguably part of what
+the function *is*; a signature claiming `-> list[fp.Real]` at FP64 while returning
+an FP32 parameter could be rejected by `TypeInfer` rather than by storage
+selection. A language decision, not a codegen one.

--- a/docs/todos/format-infer-aliasing.md
+++ b/docs/todos/format-infer-aliasing.md
@@ -1,8 +1,8 @@
 # `format_infer` ignores list aliasing
 
-**Unsound, and not a codegen bug.** The analysis reports a bound the program can
-exceed; the C++ backend implements that faithfully and gives a different answer
-than the interpreter.
+The analysis reports a bound the program can exceed. It no longer produces a
+wrong answer — the backend refuses these programs — but the imprecision is real
+and the refusal is a rough edge, not a fix.
 
 ```python
 def alias_then_mutate(xs: list[fp.Real], y: fp.Real) -> fp.Real:  # xs FP32, y FP64
@@ -12,58 +12,57 @@ def alias_then_mutate(xs: list[fp.Real], y: fp.Real) -> fp.Real:  # xs FP32, y F
         return xs[0]
 ```
 
-| | |
-|---|---|
-| interpreter | `0x1.999999999999ap-4` — the FP64 `0.1` |
-| compiled | `0x1.99999ap-4` — the FP32 one |
-| `fn_fmt.ret_fmt` | `IEEEFormat(es=8, nbits=32)` |
-
 `ys` and `xs` are one list, so after `ys[0] = y` it holds an FP64 value and
-`xs[0]` is FP64. `_list_set_widen` widens the def `ys[0] = y` produces, but
+`xs[0]` is FP64. `_list_set_widen` widens the def that `ys[0] = y` produces, but
 `xs`'s def keeps FP32 — `format_infer` has no aliasing model, so nothing connects
-them. `ret_fmt` then claims binary32 can hold the result, and it cannot.
+them, and `fn_fmt.ret_fmt` claims binary32 can hold the result.
 
 Every consumer inherits this, not just the C++ backend: any pass that trusts a
 bound to decide a rounding is eliminable, a constant foldable, or an error bound
 computable is being told something false about an aliased list.
 
-## Why the backend cannot fix it
+## Why the backend refuses instead of miscompiling
 
-Tried, and backed out. Propagating the widening to the aliased parameter in
-`storage_infer.place_floors` does correct the *storage* — `std::vector<double>&
-xs`, so the store no longer truncates — but the return type comes from
-`ret_fmt`, so the value truncates on the way out instead. The patch changed the
-ABI without fixing the answer, which is the wrong trade. The fix has to be where
-the bound is computed.
+The store is where it becomes observable, and the C++ slot is narrower than the
+value:
 
-## Options
+```
+unsupported: storing a `double` into a slot of `float` would narrow it, and the
+list would then not hold the value FPy says it does.  Round the value to the
+list's format, or build the list at the wider one.
+```
 
-**Union aliased defs in `format_infer`.** Treat `ys = xs` as making the two share
-one bound. Simple and sound, and it costs precision for every consumer even where
-nothing is ever stored — a read-only alias would drag both defs to the join.
+C++ *would* accept that store and narrow silently, which is the one shape where
+a format disagreement is a wrong answer rather than a compile error — so
+`_visit_indexed_assign` checks `scalar_fits_in` and refuses. The container's
+element type cannot simply be widened from there: another name may already alias
+it, and that is exactly the fact `format_infer` does not track.
+
+## Fixing it properly
+
+Three options, in increasing cost:
+
+**Widen only on a store.** When an `IndexedAssign` widens a def, also widen
+anything that may alias its base. Keeps read-only aliases precise and targets
+exactly the unsound case. Needs the next option's fact.
 
 **Use the alias analysis.** `fpy2.analysis.alias` already answers "may these name
-one list", which is exactly the missing fact. It would keep the precision, at the
-cost of a dependency from `format_infer` onto another analysis — worth checking
-for a cycle, since `alias` consumes type info.
+one list", which is the missing input. Costs a dependency from `format_infer`
+onto another analysis — check for a cycle, since `alias` consumes type info.
 
-**Widen only on a store.** Narrower than unioning: when an `IndexedAssign` widens
-a def, also widen anything that may alias its base. Keeps read-only aliases
-precise and targets exactly the unsound case.
+**Union aliased defs.** Treat `ys = xs` as making the two share one bound.
+Simple and sound, and it costs precision for every consumer even where nothing is
+ever stored.
 
-The third looks best, and it needs the second's fact to know what "may alias"
-means. Note the parallel with `docs/todos/cpp-narrower-variable-at-a-join.md`: a
-store already widens a def there too (`_list_set_widen`), and this is the same
-widening failing to cross an alias edge rather than a call edge.
+The first, using the second's fact, looks right. Note the parallel with
+`cpp-narrower-variable-at-a-join.md`: a store already widens a def there too, and
+this is the same widening failing to cross an *alias* edge rather than a call
+edge.
 
 ## Where it is pinned
 
-`tests/infra/backend/cpp.py::_generated_xfail`, the one instantiation of
-`_gen_alias_then_mutate` that has a narrower list than the value stored into it.
-Strict — if it starts agreeing with the interpreter, the harness fails and asks
-for the entry to be removed. The shape's other three format combinations run
-normally.
-
-The bug predates the branch's C++ work (reproduces at `50fd6aa`). It survived
-because no corpus program has a list at a format other than FP64, so nothing
-executed the shape until the generated matrix did.
+`tests/infra/backend/cpp.py::_gen_alias_then_mutate`, which is now *refused*
+rather than compared — it appears in the harness's "not compared" list. The bug
+predates the branch's C++ work (reproduces at `50fd6aa`); it survived because no
+corpus program has a list at a format other than FP64, so nothing executed the
+shape until the generated matrix did.

--- a/docs/todos/format-infer-aliasing.md
+++ b/docs/todos/format-infer-aliasing.md
@@ -58,10 +58,11 @@ widening failing to cross an alias edge rather than a call edge.
 
 ## Where it is pinned
 
-`tests/infra/backend/cpp.py::_generated_xfail`, two instantiations of
-`_gen_alias_then_mutate`. Strict — if either starts agreeing with the
-interpreter, the harness fails and asks for the entry to be removed. The other 6
-combinations of the same shape run normally.
+`tests/infra/backend/cpp.py::_generated_xfail`, the one instantiation of
+`_gen_alias_then_mutate` that has a narrower list than the value stored into it.
+Strict — if it starts agreeing with the interpreter, the harness fails and asks
+for the entry to be removed. The shape's other three format combinations run
+normally.
 
 The bug predates the branch's C++ work (reproduces at `50fd6aa`). It survived
 because no corpus program has a list at a format other than FP64, so nothing

--- a/docs/todos/format-infer-aliasing.md
+++ b/docs/todos/format-infer-aliasing.md
@@ -1,0 +1,68 @@
+# `format_infer` ignores list aliasing
+
+**Unsound, and not a codegen bug.** The analysis reports a bound the program can
+exceed; the C++ backend implements that faithfully and gives a different answer
+than the interpreter.
+
+```python
+def alias_then_mutate(xs: list[fp.Real], y: fp.Real) -> fp.Real:  # xs FP32, y FP64
+    with fp.FP64:
+        ys = xs
+        ys[0] = y
+        return xs[0]
+```
+
+| | |
+|---|---|
+| interpreter | `0x1.999999999999ap-4` — the FP64 `0.1` |
+| compiled | `0x1.99999ap-4` — the FP32 one |
+| `fn_fmt.ret_fmt` | `IEEEFormat(es=8, nbits=32)` |
+
+`ys` and `xs` are one list, so after `ys[0] = y` it holds an FP64 value and
+`xs[0]` is FP64. `_list_set_widen` widens the def `ys[0] = y` produces, but
+`xs`'s def keeps FP32 — `format_infer` has no aliasing model, so nothing connects
+them. `ret_fmt` then claims binary32 can hold the result, and it cannot.
+
+Every consumer inherits this, not just the C++ backend: any pass that trusts a
+bound to decide a rounding is eliminable, a constant foldable, or an error bound
+computable is being told something false about an aliased list.
+
+## Why the backend cannot fix it
+
+Tried, and backed out. Propagating the widening to the aliased parameter in
+`storage_infer.place_floors` does correct the *storage* — `std::vector<double>&
+xs`, so the store no longer truncates — but the return type comes from
+`ret_fmt`, so the value truncates on the way out instead. The patch changed the
+ABI without fixing the answer, which is the wrong trade. The fix has to be where
+the bound is computed.
+
+## Options
+
+**Union aliased defs in `format_infer`.** Treat `ys = xs` as making the two share
+one bound. Simple and sound, and it costs precision for every consumer even where
+nothing is ever stored — a read-only alias would drag both defs to the join.
+
+**Use the alias analysis.** `fpy2.analysis.alias` already answers "may these name
+one list", which is exactly the missing fact. It would keep the precision, at the
+cost of a dependency from `format_infer` onto another analysis — worth checking
+for a cycle, since `alias` consumes type info.
+
+**Widen only on a store.** Narrower than unioning: when an `IndexedAssign` widens
+a def, also widen anything that may alias its base. Keeps read-only aliases
+precise and targets exactly the unsound case.
+
+The third looks best, and it needs the second's fact to know what "may alias"
+means. Note the parallel with `docs/todos/cpp-narrower-variable-at-a-join.md`: a
+store already widens a def there too (`_list_set_widen`), and this is the same
+widening failing to cross an alias edge rather than a call edge.
+
+## Where it is pinned
+
+`tests/infra/backend/cpp.py::_generated_xfail`, two instantiations of
+`_gen_alias_then_mutate`. Strict — if either starts agreeing with the
+interpreter, the harness fails and asks for the entry to be removed. The other 6
+combinations of the same shape run normally.
+
+The bug predates the branch's C++ work (reproduces at `50fd6aa`). It survived
+because no corpus program has a list at a format other than FP64, so nothing
+executed the shape until the generated matrix did.

--- a/docs/todos/reals-in-integer-storage.md
+++ b/docs/todos/reals-in-integer-storage.md
@@ -1,0 +1,74 @@
+# A real stored in an integer
+
+The C++ backend narrows a `RealType` value to an integer type when its bound is a
+set of small integers — `acc = 0.0` becomes `uint8_t`, and a list of integral
+constants becomes `std::vector<uint8_t>`. That is unsound, and it is the root
+cause of several wrong answers.
+
+An integer holds neither a **signed zero** nor a **NaN**, and both are reachable:
+
+```python
+def f(y: fp.Real) -> fp.Real:
+    return 0.0 * y                  # uint8_t
+```
+```cpp
+uint8_t f(double y) {
+    uint8_t _t = 0;
+    uint8_t _t1 = static_cast<uint8_t>((static_cast<double>(_t) * y));
+    return _t1;
+}
+```
+
+| `y` | interpreter | compiled |
+|---|---|---|
+| `inf` | `nan` | `0` |
+| `nan` | `nan` | `0` |
+| `-0.0` | `-0.0` | `+0.0` |
+
+`static_cast<uint8_t>` of a NaN is undefined behaviour, so the `0` is not even a
+reliable wrong answer.
+
+Two things conspire. `exact_binop` reports `SetFormat({0})` for `0 * x` — knowingly
+unsound, see the comment there; it is kept because the alternative is a degenerate
+abstract format. And the storage ladder then picks the narrowest type containing
+`{0}`, which is `uint8_t`.
+
+## The fix has to be uniform
+
+> **A `RealType` value is stored in a float. Never in an integer.**
+
+Half-measures do not work, and this was measured rather than guessed. Refusing an
+integer storage only for a zero-containing set costs 9 corpus functions;
+restricting it to *exactly* `{0}` costs 7. In both cases the failures are
+*disagreements* rather than missing features — some zeros became `float` while
+others stayed `uint8_t`, and then they met:
+
+```
+test_ife2:      cannot implicitly cast `float` to `uint8_t`: conversion is lossy
+test_list_set1: storing a `float` into a slot of `uint8_t` would narrow it
+```
+
+Applied to every real, nothing disagrees: there are no integer-stored reals left
+to meet. It also makes the inexact `{0}` bound harmless, because a float holds
+whatever the multiply actually produced.
+
+## What it costs
+
+The narrowing is a size optimization, and dropping it is visible: 21 of the
+corpus's 112 list element types are value-narrowed reals (all in `test_list*`,
+`test_range*`, `test_list_comp*`), plus scalars like `uint8_t acc` inside FP64
+functions. So expect test churn proportional to that, and larger emitted objects
+in those cases — against emitted code that finally says `double` where FPy says
+real.
+
+*Integer*-typed FPy values keep integer storage; this is only about reals.
+`range(...)` needs an integer list and must stay one — that is what the first
+measured attempt broke.
+
+## Already fixed, separately
+
+A **negative-zero literal** no longer reports `SetFormat({0})`; it reports the
+narrowest float format (`format_infer._literal_bound`), so `return -0.0` keeps its
+sign and `[-0.0, -0.0]` compiles. That was free — no corpus change — because it
+only touches the one literal whose exact value a `Fraction` cannot represent.
+Pinned by `test_emit_scalar.py::TestNegativeZero`.

--- a/docs/todos/unboxing-gaps.md
+++ b/docs/todos/unboxing-gaps.md
@@ -1,0 +1,67 @@
+# Unboxing: what is still boxed, and why
+
+The C++ backend represents a list as a plain `std::vector<T>` wherever
+`fpy2.analysis.alias` proves nothing can observe the difference, and keeps the
+`fpy::list<T>` handle otherwise. **All 166 of the corpus's signature list levels
+come out unboxed**, so the two shapes below are ones the corpus does not contain
+— which is exactly why they need writing down.
+
+`tests/unit/backend/cpp/test_unbox_profile.py` pins both the count and the corpus
+size: an empty "still boxed" result only means something while the corpus is as
+large as when it was measured.
+
+## Still boxed
+
+**A list a local name and a container both hold.** *Open.* `xs = [n, n]; return
+(xs, 1.0)` keeps its handle — the name and the tuple's field are two places, even
+though the name is dead after the return. Written inline as `return ([n, n], 1.0)`
+it unboxes. The same conservatism applies to a list inside a list, so this is not
+about tuples.
+
+Closing it needs liveness, not just a sharing verdict, *and* the emitter must
+learn to **move** into the container: `std::make_tuple(xs, 1)` copies a value
+where it merely bumps a refcount for a handle. The two have to land together or
+the change makes things slower.
+
+**A projection whose slot is replaced.** *Deliberate, not a gap.* `row = xss[i]`
+binds a reference, which is what lets `for a, b in zip(...)` over nested lists
+unbox at all. But a C++ reference follows the *slot* while FPy keeps referring to
+the list that was in it, so any `xss[i] = <list>` anywhere in the function rules
+the reference out and the row keeps its handle. Function-wide by choice: nothing
+else in the analysis is flow-sensitive, and making this the one exception would
+set a bad precedent.
+
+## Two things not to rediscover
+
+**Keep an analysis free of C++.** `alias` answers whether a callee *retains* a
+list — a fact about the program. Whether an argument must therefore carry a
+handle is a separate question and belongs in `unbox`. Collapsing them looks
+simpler and produces `fpy::borrow` calls that cannot bind to a `const`
+reference.
+
+The same principle was violated later, in `format_infer`, and cost real
+precision before being reverted — see the boxed warning in
+`cpp-narrower-variable-at-a-join.md`. Both times the pull was the same: the
+backend needs one answer, so it is tempting to make the analysis give that
+answer instead of reconciling in the backend.
+
+**A representation decision is one change, not two.** Caller and callee must
+agree or the call does not compile, so the analysis and the codegen for a
+boundary land together. Same for `const`: a callee that writes its parameter
+forces the caller's argument non-const.
+
+## Not planned
+
+Interprocedural precision beyond retention — a caller-driven representation
+choice, with the callee specialized per argument representation. It needs one
+body per representation vector, and nothing has measured a gain that justifies
+that. If it is ever wanted, the representation must join the specialization key
+rather than be patched on afterwards, since storage is decided per spec.
+
+## Done
+
+Interprocedural unboxing: `fpy2.analysis.escape` gives each function a
+per-parameter summary of what it retains, so a call no longer forces handles.
+Measured at the time: a decomposed kernel at a native boundary went to 2.1–2.4x
+faster than the fully boxed build, matching what the monolithic version of the
+same kernel gets — decomposing a program costs nothing at the boundary any more.

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -132,7 +132,7 @@ from typing import Any, TypeAlias
 from ...ast.fpyast import *
 from ...ast.visitor import Visitor
 from ...function import Function
-from ...number import INTEGER, REAL, Context, Float, RealFloat
+from ...number import FP32, INTEGER, REAL, Context, Float, RealFloat
 from ...number.format import REAL_FORMAT, Format
 from ...types import (
     BoolType,
@@ -526,6 +526,16 @@ def exact_binop(
     lhs_zero = _is_zero_set(lhs)
     rhs_zero = _is_zero_set(rhs)
     if op is operator.mul and (lhs_zero or rhs_zero):
+        # UNSOUND, and knowingly so: in IEEE-754 `0 * x` is NaN when *x* is an
+        # infinity or a NaN, and `-0.0` when *x* is negative.  Kept because a
+        # recomputed abstract product is degenerate and drives a later add/sub's
+        # `prec` to 0 (`test_exact_binop_mul_by_zero_set_stays_set`).
+        #
+        # A consumer must not read `{0}` as "an integer can hold this".  The C++
+        # backend currently does, so `0.0 * inf` compiles to
+        # `static_cast<uint8_t>(NaN)` and returns 0 -- see
+        # `docs/todos/reals-in-integer-storage.md` for why the fix has to be
+        # uniform rather than a guard here.
         return _ZERO_SET
     if op is operator.add:
         if lhs_zero:
@@ -653,6 +663,29 @@ def _join_bounds(
             raise RuntimeError(
                 f'unreachable: cannot join incompatible formats {s1!r}, {s2!r}'
             )
+
+
+def _literal_bound(e) -> FormatBound:
+    """A numeric literal's bound: the singleton set of its exact value.
+
+    Except a **negative zero**.  ``SetFormat`` holds :class:`Fraction`s, and a
+    ``Fraction`` has no signed zero — so ``SetFormat({0})`` would assert that
+    ``-0.0`` and ``+0.0`` are the same value.  They are not: ``-0.0`` is a
+    distinct real that compares equal to ``+0.0`` but is distinguishable by
+    ``copysign``, and by division, where ``x / -0.0`` and ``x / +0.0`` have
+    opposite signs.
+
+    So the set cannot state this literal's value, and a bound that cannot state
+    a value must not pretend to.  Report the narrowest *format* that does
+    contain it instead — less precise, but true.
+
+    ``as_real`` returns a :class:`Float` for exactly this case and a
+    :class:`Fraction` otherwise, so it is the discriminator.
+    """
+    v = e.as_real()
+    if isinstance(v, Float):
+        return FP32.format()
+    return SetFormat.from_value(e.as_rational())
 
 
 def _list_set_widen(
@@ -1151,10 +1184,10 @@ class _FormatInferInstance(Visitor):
 
     # Numeric literals: exact real values bounded by the singleton set {v}
     def _visit_decnum(self, e: Decnum, ctx: None) -> FormatBound:
-        return SetFormat.from_value(e.as_rational())
+        return _literal_bound(e)
 
     def _visit_hexnum(self, e: Hexnum, ctx: None) -> FormatBound:
-        return SetFormat.from_value(e.as_rational())
+        return _literal_bound(e)
 
     def _visit_integer(self, e: Integer, ctx: None) -> FormatBound:
         return SetFormat.from_value(e.as_rational())

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -668,7 +668,7 @@ def _join_bounds(
 def _literal_bound(e) -> FormatBound:
     """A numeric literal's bound: the singleton set of its exact value.
 
-    Except a **negative zero**.  ``SetFormat`` holds :class:`Fraction`s, and a
+    Except a **signed zero**.  ``SetFormat`` holds :class:`Fraction`s, and a
     ``Fraction`` has no signed zero — so ``SetFormat({0})`` would assert that
     ``-0.0`` and ``+0.0`` are the same value.  They are not: ``-0.0`` is a
     distinct real that compares equal to ``+0.0`` but is distinguishable by
@@ -676,15 +676,27 @@ def _literal_bound(e) -> FormatBound:
     opposite signs.
 
     So the set cannot state this literal's value, and a bound that cannot state
-    a value must not pretend to.  Report the narrowest *format* that does
-    contain it instead — less precise, but true.
+    a value must not pretend to.  Report a *format* that does contain it
+    instead — less precise, but true.  Every binary floating-point format has a
+    signed zero, so ``FP32`` is a true bound for one; it is picked as a small
+    widely-supported format, and nothing here depends on which.
 
-    ``as_real`` returns a :class:`Float` for exactly this case and a
-    :class:`Fraction` otherwise, so it is the discriminator.
+    The discriminator is the literal's **value**, not the type ``as_real``
+    happens to return.  ``as_real`` returns a :class:`Float` only for a signed
+    zero today, but that invariant lives in :mod:`fpy2.ast.fpyast` and this
+    function cannot enforce it: a ``Float`` holding, say, ``1e-400`` is not in
+    ``FP32``, and answering ``FP32`` for it would be a false bound no consumer
+    could detect.  A non-zero ``Float`` *is* an exact rational, so it takes the
+    ``SetFormat`` path; anything else — an infinity or a NaN, which no literal
+    parses to — has no rational value at all, so the honest answer is the
+    scalar top.
     """
     v = e.as_real()
     if isinstance(v, Float):
-        return FP32.format()
+        if v.is_zero():
+            return FP32.format()
+        if v.isinf or v.isnan:
+            return REAL_FORMAT
     return SetFormat.from_value(e.as_rational())
 
 

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -42,7 +42,7 @@ from ...types import Type
 from ..backend import Backend, CompileError
 from .emitter import CppEmitError, CppEmitter
 from .storage import StorageSelectionError, choose_storage
-from .storage_infer import StorageAnalysis, StorageInfer, place_floors
+from .storage_infer import StorageAnalysis, StorageInfer
 from .types import CppType
 from .unbox import CalleeAbi, ParamAbi, Unbox, UnboxAnalysis
 from .utils import CPP_HEADERS, CPP_HELPERS
@@ -361,23 +361,7 @@ class CppCompiler(Backend):
 
         try:
             du = format_info.type_info.def_use
-            # Twice: the floors need to know which names the emitter binds by
-            # reference, and that is a property of the storage analysis.  A
-            # reference-bound name has no storage of its own to raise.
-            base = StorageInfer.infer(du, format_info.by_def)
-            storage = StorageInfer.infer(
-                du,
-                format_info.by_def,
-                place_floors(
-                    ast,
-                    du,
-                    format_info.by_def,
-                    format_info.by_expr,
-                    format_info.fn_fmt.ret_fmt,
-                    base,
-                    is_called,
-                ),
-            )
+            storage = StorageInfer.infer(du, format_info.by_def)
         except StorageSelectionError as e:
             raise CppCompileError(
                 f'storage selection failed for `{func.name}`: {e}'

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -42,7 +42,7 @@ from ...types import Type
 from ..backend import Backend, CompileError
 from .emitter import CppEmitError, CppEmitter
 from .storage import StorageSelectionError, choose_storage
-from .storage_infer import StorageAnalysis, StorageInfer
+from .storage_infer import StorageAnalysis, StorageInfer, place_floors
 from .types import CppType
 from .unbox import CalleeAbi, ParamAbi, Unbox, UnboxAnalysis
 from .utils import CPP_HEADERS, CPP_HELPERS
@@ -360,8 +360,22 @@ class CppCompiler(Backend):
         )
 
         try:
+            du = format_info.type_info.def_use
+            # Twice: the floors need to know which names the emitter binds by
+            # reference, and that is a property of the storage analysis.  A
+            # reference-bound name has no storage of its own to raise.
+            base = StorageInfer.infer(du, format_info.by_def)
             storage = StorageInfer.infer(
-                format_info.type_info.def_use, format_info.by_def,
+                du,
+                format_info.by_def,
+                place_floors(
+                    ast,
+                    du,
+                    format_info.by_def,
+                    format_info.by_expr,
+                    format_info.fn_fmt.ret_fmt,
+                    base,
+                ),
             )
         except StorageSelectionError as e:
             raise CppCompileError(

--- a/fpy2/backend/cpp/compiler.py
+++ b/fpy2/backend/cpp/compiler.py
@@ -375,6 +375,7 @@ class CppCompiler(Backend):
                     format_info.by_expr,
                     format_info.fn_fmt.ret_fmt,
                     base,
+                    is_called,
                 ),
             )
         except StorageSelectionError as e:

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -954,11 +954,11 @@ class CppEmitter(Visitor):
     ) -> str:
         """*code*, of storage *src*, as storage *want*.
 
-        Format inference gives one place one bound, and ``_push_format`` puts
+        Format inference gives one place one bound, and :meth:`_emit_at` builds
         every *constructor* that reaches a place at that bound.  A variable
-        cannot be re-decided that way -- its storage was fixed by its own
-        definition -- so a narrower one flowing into a wider place arrives here
-        and is converted.
+        cannot be built that way -- its storage was fixed by its own definition
+        -- so a narrower one flowing into a wider place arrives here and is
+        converted.
 
         A scalar is cast: ``std::make_tuple`` below deduces its type from the
         argument, so leaving the conversion implicit rebuilds the tuple at the
@@ -1133,9 +1133,9 @@ class CppEmitter(Visitor):
 
         A variable reads as its **declaration**, which is not always what its
         own format bound would choose: ``storage_infer`` aggregates a whole
-        storage class and raises it to the places the class reaches (see
-        ``storage_infer.place_floors``).  Asking ``by_expr`` here would compare
-        against a type the emitted name does not have.
+        storage class, so every member reads as the type the class settled on.
+        Asking ``by_expr`` here would compare against a type the emitted name
+        does not have.
         """
         if isinstance(e, Var):
             d = self.def_use.find_def_from_use(e)

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -81,6 +81,7 @@ from ...ast.fpyast import (
     FuncDef,
     Hexnum,
     If1Stmt,
+    IfExpr,
     IfStmt,
     IndexedAssign,
     Integer,
@@ -302,6 +303,9 @@ class CppEmitter(Visitor):
         self._unsafe_cast_int = unsafe_cast_int
         self.writer = _IndentedWriter()
         self._tmp_counter = 0
+        # The storage this function returns, set once the signature is
+        # emitted; see :meth:`_visit_return`.
+        self._return_storage: CppType | None = None
         self.op_table: ScalarOpTable = make_op_table()
         # Build a site → scope lookup over the analysis's scope list.
         self._scope_by_site: dict[ContextScopeSite, ContextScope] = {
@@ -645,6 +649,8 @@ class CppEmitter(Visitor):
         # ``with`` block).
         ret_ty = self._infer_return_storage(func)
         ret_str = ret_ty.format() if ret_ty is not None else 'void'
+        # Read back by each `return` to convert a narrower value into it.
+        self._return_storage = ret_ty
 
         # Emit arg list.  Each argument's class is anchored to the bare
         # source name in ``StorageInfer``, so it's safe to use ``arg.name``
@@ -799,60 +805,168 @@ class CppEmitter(Visitor):
                     at=stmt,
                 )
 
+    def _emit_at(self, e: Expr, want: CppType | None, ctx) -> str:
+        """Emit *e* as a value of storage *want*.
+
+        One place admits one C++ type, but ``format_infer`` bounds each
+        expression by *its own* values — correctly: that is the question it
+        answers.  ``[3.0]`` really is bounded by ``{3}``, even where it has to
+        be a ``std::vector<double>`` because the other ``return`` is one.
+        Reconciling the two is a storage question, so it lives here.
+
+        An expression that *constructs* its value is simply built at *want*.
+        Anything else already has storage of its own and is converted
+        (:meth:`_convert_storage`), which is where a shared list gets refused.
+        """
+        if want is None:
+            return self._visit_expr(e, ctx)
+        if isinstance(want, CppScalar):
+            # A scalar has no identity, so there is nothing to build at a
+            # storage: C++ converts it at the point of use.
+            return self._visit_expr(e, ctx)
+        match e:
+            case ListExpr() if isinstance(want, CppList):
+                parts = [self._emit_braced(elt, want.elt, ctx) for elt in e.elts]
+                return self._list_new_init(want, parts)
+            case TupleExpr() if (
+                isinstance(want, CppTuple) and len(want.elts) == len(e.elts)
+            ):
+                parts = [
+                    self._emit_at(elt, w, ctx)
+                    for elt, w in zip(e.elts, want.elts)
+                ]
+                return f'std::make_tuple({", ".join(parts)})'
+            case ListComp() if isinstance(want, CppList):
+                return self._emit_list_comp_at(e, want, ctx)
+            case IfExpr():
+                cond = self._visit_expr(e.cond, ctx)
+                ift = self._emit_at(e.ift, want, ctx)
+                iff = self._emit_at(e.iff, want, ctx)
+                return f'({cond} ? {ift} : {iff})'
+        emitted = self._visit_expr(e, ctx)
+        src = self._storage_or_none(e)
+        if src is None:
+            return emitted
+        return self._convert_storage(emitted, src, want, at=e)
+
+    def _emit_braced(self, e: Expr, want: CppType, ctx) -> str:
+        """:meth:`_emit_at`, for an element of a braced initializer.
+
+        A braced init forbids a narrowing conversion, so a scalar element's
+        cast has to be spelled even though the same conversion would be
+        implicit anywhere else.
+        """
+        code = self._emit_at(e, want, ctx)
+        if isinstance(want, CppScalar):
+            src = self._storage_or_none(e)
+            if isinstance(src, CppScalar) and src != want:
+                return self._explicit_cast(code, want)
+        return code
+
     def _emit_assign_rhs(
         self, expr: Expr, target_ty: CppType, ctx,
     ) -> str:
-        """Emit an assignment's RHS, coercing a list-literal wrapper to
-        the target's storage when they disagree.
+        """Emit an assignment's RHS at the target's storage.
 
-        Why this matters: ``_storage_for_expr`` picks the list's wrapper
-        from format inference (the tight per-expression join), but
-        :class:`StorageInfer` may have widened the variable's storage
-        beyond that — e.g. when a subsequent ``x[i] = y`` (IndexedAssign)
-        joins the def with a wider value.  Emitting
-        ``vector<wide> x = vector<narrow>{...}`` is a hard C++ type
-        error, and per-element narrowing inside the literal also
-        triggers ``-Wnarrowing`` when the element expressions were
-        emitted at the wider type (e.g. ``Round`` lowers to a
-        ``static_cast`` into the active context's scalar).  Using the
-        target's storage for the wrapper keeps the literal consistent
-        with the variable's declared type.
+        ``_storage_for_expr`` bounds the RHS by its own values, but
+        :class:`StorageInfer` may have widened the variable beyond that — a
+        later ``x[i] = y`` joins the def with a wider value.  Emitting
+        ``vector<wide> x = vector<narrow>{...}`` is a hard type error, and
+        narrowing per element trips ``-Wnarrowing`` when the elements were
+        emitted at the wider type (``Round`` lowers to a ``static_cast``).
         """
-        if isinstance(expr, ListExpr) and isinstance(target_ty, CppList):
-            return self._emit_list_expr_at(expr, target_ty, ctx)
-        return self._visit_expr(expr, ctx)
+        return self._emit_at(expr, target_ty, ctx)
 
-    def _emit_list_expr_at(
-        self, e: ListExpr, wrapper_ty: CppList, ctx,
+    def _convert_storage(
+        self, code: str, src: CppType, want: CppType, *, at: Expr,
     ) -> str:
-        """Emit ``[a, b, c]`` as ``wrapper_ty{a, b, c}``, casting each
-        element to ``wrapper_ty.elt`` when the per-element emitted
-        storage disagrees.  Mirrors :meth:`_visit_list_expr` but with
-        an externally-supplied wrapper type."""
-        elt_target = wrapper_ty.elt
-        parts: list[str] = []
-        for elt in e.elts:
-            elt_str = self._visit_expr(elt, ctx)
-            if isinstance(elt_target, CppScalar):
-                # Cast when the element's per-expression storage
-                # differs from the wrapper's element type.  Defensive
-                # ``try`` mirrors ``_storage_for_expr``'s exception
-                # contract — non-storable formats (e.g., symbolic
-                # REAL_FORMAT) just skip the cast.
-                try:
-                    elt_storage = self._storage_for_expr(elt)
-                except CppEmitError:
-                    elt_storage = None
-                if (
-                    isinstance(elt_storage, CppScalar)
-                    and elt_storage != elt_target
-                ):
-                    elt_str = self._explicit_cast(elt_str, elt_target)
-            parts.append(elt_str)
-        return self._list_new_init(wrapper_ty, parts)
+        """*code*, of storage *src*, as storage *want*.
+
+        Format inference gives one place one bound, and ``_push_format`` puts
+        every *constructor* that reaches a place at that bound.  A variable
+        cannot be re-decided that way -- its storage was fixed by its own
+        definition -- so a narrower one flowing into a wider place arrives here
+        and is converted.
+
+        Scalars convert implicitly, and so does a ``std::tuple`` whose fields
+        do.  ``std::vector`` does not, so a list is rebuilt element-wise.
+        """
+        if src == want:
+            return code
+        if isinstance(src, CppTuple) and isinstance(want, CppTuple):
+            if len(src.elts) != len(want.elts):
+                return code
+            base = self._bind_operand(code)
+            fields = [
+                self._convert_storage(f'std::get<{i}>({base})', s, w, at=at)
+                for i, (s, w) in enumerate(zip(src.elts, want.elts))
+            ]
+            return f'std::make_tuple({", ".join(fields)})'
+        if not (isinstance(src, CppList) and isinstance(want, CppList)):
+            return code
+        if src.boxed:
+            # A rebuilt list is a different object, and a handle exists exactly
+            # so that FPy's aliasing survives.  Unsharing it here would be
+            # silent, so refuse instead.
+            raise CppEmitError(
+                f'unsupported: `{src.format()}` cannot become `{want.format()}` '
+                f'— rebuilding a shared list would copy it out of its aliases',
+                at=at,
+            )
+        unboxed = CppList(want.elt, boxed=False)
+        if src.elt != want.elt:
+            code = self._rebuild_list(code, src, unboxed, at=at)
+        if not want.boxed:
+            return code
+        # A value has no aliases to lose, so giving it a handle is free.
+        return f'std::make_shared<{unboxed.format()}>({code})'
+
+    def _rebuild_list(
+        self, code: str, src: CppList, want: CppList, *, at: Expr,
+    ) -> str:
+        """A new list of *want*, element-wise from *code*.
+
+        Unboxed: :meth:`_convert_storage` adds the handle afterwards if one is
+        wanted, so that the boxed case has exactly one place that allocates.
+        """
+        assert not want.boxed, 'the caller boxes; see _convert_storage'
+        base = self._bind_operand(code)
+        if not isinstance(src.elt, CppList):
+            # Flat: the range constructor converts each element on the way in.
+            return self._list_new_range(
+                want, self._list_begin(src, base), self._list_end(src, base),
+            )
+        out, i = self._fresh_temp(), self._fresh_temp()
+        n = self._list_len(src, base)
+        self.writer.add_line(f'{want.format()} {out};')
+        self.writer.add_line(f'{self._member(want, out)}reserve({n});')
+        self.writer.add_line(f'for (size_t {i} = 0; {i} < {n}; ++{i}) {{')
+        self.writer.indent()
+        elt = self._convert_storage(
+            self._list_at_raw(src, base, i), src.elt, want.elt, at=at,
+        )
+        self.writer.add_line(f'{self._list_push(want, out, elt)};')
+        self.writer.dedent()
+        self.writer.add_line('}')
+        return out
+
+    def _storage_or_none(self, e: Expr) -> CppType | None:
+        """:meth:`_storage_for_expr`, or ``None`` where it has no answer.
+
+        A format with no storage on the ladder — a symbolic ``REAL_FORMAT``, say
+        — is not a disagreement to repair.  Callers that only want to *adjust* a
+        representation skip it rather than failing the compile.
+        """
+        try:
+            return self._storage_for_expr(e)
+        except CppEmitError:
+            return None
 
     def _visit_return(self, stmt: ReturnStmt, ctx):
-        rhs = self._visit_expr(stmt.expr, ctx)
+        # A function has one return type, so every `return` produces it: built
+        # at that storage where the value is constructed here, converted where
+        # it comes from somewhere with storage of its own.
+        rhs = self._emit_at(stmt.expr, self._return_storage, ctx)
         self.writer.add_line(f'return {rhs};')
 
     def _resolve_scope_ctx(self, scope: ContextScope) -> Context | None:
@@ -1086,17 +1200,15 @@ class CppEmitter(Visitor):
         """
         Emit a numeric literal as a C++ expression.
 
-        An FPy literal is an exact rational, rounded where it is *used* and
-        under the context in force there.  C++ has no such thing: every literal
-        it can spell is a value of some format.  So a value binary64 holds
-        exactly prints as itself, and one it cannot is refused.
+        An FPy literal is an exact rational, rounded where it is *used*.  C++
+        has no such thing — every literal it can spell is a value of some
+        format — so one binary64 holds exactly prints as itself and one it
+        cannot is refused.  The alternative, ``num / denom``, is an *operation*
+        where FPy has a constant: it rounds under whatever mode happens to be
+        set, and ``-O2`` folds it to nearest regardless.
 
-        The alternative — ``num / denom`` — is an *operation* where FPy has a
-        constant.  It rounds under whatever mode happens to be set rather than
-        the one the program asked for, and ``-O2`` folds it to nearest
-        regardless, so it is not even that.  ``fp.round`` is how a program says
-        which format the constant is in; :meth:`_fold_rounded_literal` folds it
-        here rather than emitting a cast of something unspellable.
+        ``fp.round`` is how a program says which format a constant is in; see
+        :meth:`_fold_rounded_literal`.
         """
         if v.denominator == 1:
             return str(v.numerator)
@@ -2180,10 +2292,11 @@ class CppEmitter(Visitor):
     def _scalar_cast_types(self, e):
         """Source/target scalar storage for a round-like node ``e``.
 
-        The argument's storage is only used to short-circuit
-        same-type casts.  Non-dyadic numeric literals
-        (e.g., ``fp.round(3.14159265359)``) have a SetFormat with
-        no representable storage — that's fine, we always cast."""
+        The argument's storage is only used to short-circuit same-type casts.
+        A non-dyadic literal has a ``SetFormat`` with no representable storage
+        — fine, we always cast.  ``Round`` folds those before getting here
+        (:meth:`_fold_rounded_literal`); ``Cast`` does not, and refuses them at
+        emission instead, which is right for a cast that asserts exactness."""
         try:
             arg_ty = self._scalar_storage_for_expr(e.arg)
         except CppEmitError:
@@ -2224,12 +2337,10 @@ class CppEmitter(Visitor):
     def _fold_rounded_literal(self, e) -> str | None:
         """``Round(<literal>)`` as a C++ literal, or ``None`` to emit a cast.
 
-        This is the only way an inexact constant reaches C++ at all: the
-        argument has no representation of its own (see
-        :meth:`_emit_numeric_literal`), and rounding it here is what the
-        program asked for.  Doing it at compile time also gets the mode the
-        program asked for rather than whatever ``fesetround`` left behind, and
-        is immune to ``-O2`` folding the division to nearest.
+        The only way an inexact constant reaches C++ at all, since the argument
+        has no representation of its own (:meth:`_emit_numeric_literal`).
+        Rounding at compile time also uses the mode the program asked for
+        rather than whatever ``fesetround`` last left behind.
         """
         if not isinstance(e.arg, Decnum | Hexnum | Rational | Digits | Integer):
             return None
@@ -2359,17 +2470,22 @@ class CppEmitter(Visitor):
     def _visit_tuple_expr(self, e: TupleExpr, ctx) -> str:
         # ``(a, b, c)`` → ``std::make_tuple(a, b, c)``.  Type deduction
         # from the argument types matches what the format-inference
-        # pipeline assigns to the tuple slot — no explicit type prefix.
-        elts = ', '.join(self._visit_expr(elt, ctx) for elt in e.elts)
-        return f'std::make_tuple({elts})'
+        # pipeline assigns to the tuple slot — no explicit type prefix,
+        # but a field whose own storage is narrower has to be converted
+        # or deduction produces a tuple type nothing accepts.
+        return self._emit_at(e, self._storage_for_expr(e), ctx)
 
     def _visit_list_expr(self, e: ListExpr, ctx) -> str:
         # ``[a, b, c]`` → ``fpy::make_list<T>({a, b, c})`` where ``T`` comes
-        # from format inference on the list expression.
-        parts = [self._visit_expr(elt, ctx) for elt in e.elts]
-        return self._list_new_init(self._storage_for_expr(e), parts)
+        # from format inference on the list expression.  One vector, one
+        # element type, so each element is emitted at ``T`` rather than at
+        # whatever it is on its own.
+        return self._emit_at(e, self._storage_for_expr(e), ctx)
 
     def _visit_list_comp(self, e: ListComp, ctx) -> str:
+        return self._emit_list_comp_at(e, self._storage_for_expr(e), ctx)
+
+    def _emit_list_comp_at(self, e: ListComp, result_ty: CppType, ctx) -> str:
         # ``[elt for x1 in iter1 [for x2 in iter2 ...]]``
         #
         # Emitted as a temporary ``fpy::list<T> tmp;`` followed by
@@ -2378,7 +2494,10 @@ class CppEmitter(Visitor):
         # value.  The temp shape mirrors the cpp/ backend; future
         # polish may inline directly into an ``Assign`` target to skip
         # the temp + copy.
-        result_ty = self._storage_for_expr(e)
+        #
+        # *result_ty* is supplied because a comprehension builds its vector
+        # element by element, so it is a contributor to whatever place it
+        # reaches — see :meth:`_emit_at`.
         tmp = self._fresh_temp()
         self.writer.add_line(
                     f'{result_ty.format()} {tmp} = '
@@ -2388,7 +2507,8 @@ class CppEmitter(Visitor):
         for target, iterable in zip(e.targets, e.iterables):
             self._open_comp_loop(target, iterable, e, ctx)
 
-        elt = self._visit_expr(e.elt, ctx)
+        elt_want = result_ty.elt if isinstance(result_ty, CppList) else None
+        elt = self._emit_at(e.elt, elt_want, ctx)
         self.writer.add_line(f'{self._list_push(result_ty, tmp, elt)};')
 
         for _ in e.targets:
@@ -2559,25 +2679,18 @@ class CppEmitter(Visitor):
         # unified storage (chosen by format inference + storage
         # selection over the merged formats).  Non-scalar branches
         # must already match — there's no widening for lists/tuples.
+        out_ty = self._storage_for_expr(e)
+        if not isinstance(out_ty, CppScalar):
+            # A list or tuple arm is built at the ternary's storage, or
+            # converted into it — see :meth:`_emit_at`.
+            return self._emit_at(e, out_ty, ctx)
         cond = self._visit_expr(e.cond, ctx)
         ift = self._visit_expr(e.ift, ctx)
         iff = self._visit_expr(e.iff, ctx)
-        out_ty = self._storage_for_expr(e)
-        if isinstance(out_ty, CppScalar):
-            ift_ty = self._scalar_storage_for_expr(e.ift)
-            iff_ty = self._scalar_storage_for_expr(e.iff)
-            ift = self._maybe_cast(ift, ift_ty, out_ty, at=e)
-            iff = self._maybe_cast(iff, iff_ty, out_ty, at=e)
-        else:
-            ift_ty_ = self._storage_for_expr(e.ift)
-            iff_ty_ = self._storage_for_expr(e.iff)
-            if ift_ty_ != out_ty or iff_ty_ != out_ty:
-                raise CppEmitError(
-                    f'IfExpr branches have incompatible non-scalar '
-                    f'storages: ift=`{ift_ty_!r}`, iff=`{iff_ty_!r}`, '
-                    f'expected `{out_ty!r}`',
-                    at=e,
-                )
+        ift_ty = self._scalar_storage_for_expr(e.ift)
+        iff_ty = self._scalar_storage_for_expr(e.iff)
+        ift = self._maybe_cast(ift, ift_ty, out_ty, at=e)
+        iff = self._maybe_cast(iff, iff_ty, out_ty, at=e)
         return f'({cond} ? {ift} : {iff})'
 
     def _visit_indexed_assign(self, stmt: IndexedAssign, ctx):

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -1059,50 +1059,57 @@ class CppEmitter(Visitor):
         return self._name_for_var_use(e)
 
     def _visit_decnum(self, e: Decnum, ctx) -> str:
-        return self._emit_real_literal(e.as_real())
+        return self._emit_real_literal(e.as_real(), at=e)
 
     def _visit_hexnum(self, e: Hexnum, ctx) -> str:
-        return self._emit_real_literal(e.as_real())
+        return self._emit_real_literal(e.as_real(), at=e)
 
     def _visit_integer(self, e: Integer, ctx) -> str:
         # Integer literals print directly.
         return str(e.val)
 
     def _visit_rational(self, e: Rational, ctx) -> str:
-        return self._emit_numeric_literal(e.as_rational())
+        return self._emit_numeric_literal(e.as_rational(), at=e)
 
     def _visit_digits(self, e: Digits, ctx) -> str:
-        return self._emit_numeric_literal(e.as_rational())
+        return self._emit_numeric_literal(e.as_rational(), at=e)
 
-    def _emit_real_literal(self, v: 'Fraction | Float') -> str:
+    def _emit_real_literal(self, v: 'Fraction | Float', *, at: Expr) -> str:
         """Emit an exact-real literal, preserving the sign of a negative zero
         (which has no `Fraction` form; see `RationalVal.as_real`)."""
         if isinstance(v, Float):
             # negative zero is the only non-`Fraction` real `as_real` produces
             return '-0.0'
-        return self._emit_numeric_literal(v)
+        return self._emit_numeric_literal(v, at=at)
 
-    def _emit_numeric_literal(self, v: Fraction) -> str:
+    def _emit_numeric_literal(self, v: Fraction, *, at: Expr) -> str:
         """
         Emit a numeric literal as a C++ expression.
 
         An FPy literal is an exact rational, rounded where it is *used* and
-        under the context in force there.  A value binary64 holds exactly needs
-        no rounding and prints as itself.
+        under the context in force there.  C++ has no such thing: every literal
+        it can spell is a value of some format.  So a value binary64 holds
+        exactly prints as itself, and one it cannot is refused.
 
-        One it cannot hold still becomes ``num / denom``, which is wrong in a
-        way worth knowing: that is an *operation* where FPy has a constant, so
-        it rounds under whatever mode happens to be set, and ``-O2`` folds it at
-        compile time to nearest regardless.  Rejecting such a literal outright
-        would be more honest, but three corpus functions rely on it today —
-        see ``docs/todos/cpp-literals-and-returns.md``.
+        The alternative — ``num / denom`` — is an *operation* where FPy has a
+        constant.  It rounds under whatever mode happens to be set rather than
+        the one the program asked for, and ``-O2`` folds it to nearest
+        regardless, so it is not even that.  ``fp.round`` is how a program says
+        which format the constant is in; :meth:`_fold_rounded_literal` folds it
+        here rather than emitting a cast of something unspellable.
         """
         if v.denominator == 1:
             return str(v.numerator)
         exact = _as_exact_double(v)
         if exact is not None:
             return repr(exact)
-        return f'((double){v.numerator} / (double){v.denominator})'
+        raise CppEmitError(
+            f'unsupported literal: `{v.numerator}/{v.denominator}` is not '
+            f'exactly representable as a double, and C++ has no exact-real '
+            f'literal to round at the point of use.  Wrap it in `fp.round` to '
+            f'say which format the constant is in.',
+            at=at,
+        )
 
     def _scalar_storage_for_expr(self, e: Expr) -> CppScalar:
         """Like :meth:`_storage_for_expr` but asserts the result is a
@@ -2214,6 +2221,38 @@ class CppEmitter(Visitor):
         self.writer.add_line(f'assert({check});')
         return tmp
 
+    def _fold_rounded_literal(self, e) -> str | None:
+        """``Round(<literal>)`` as a C++ literal, or ``None`` to emit a cast.
+
+        This is the only way an inexact constant reaches C++ at all: the
+        argument has no representation of its own (see
+        :meth:`_emit_numeric_literal`), and rounding it here is what the
+        program asked for.  Doing it at compile time also gets the mode the
+        program asked for rather than whatever ``fesetround`` left behind, and
+        is immune to ``-O2`` folding the division to nearest.
+        """
+        if not isinstance(e.arg, Decnum | Hexnum | Rational | Digits | Integer):
+            return None
+        active = self._active_ctx_for(e)
+        if not isinstance(active, EFloatContext):
+            return None
+        rounded = active.round(e.arg.as_rational())
+        if rounded.isinf or rounded.isnan:
+            # An overflowing literal is a value the target format does have,
+            # but ``HUGE_VAL``/``NAN`` are a separate spelling; leave it.
+            return None
+        v = rounded.as_rational()
+        if _as_exact_double(v) is None:
+            return None
+        lit = self._emit_numeric_literal(v, at=e)
+        # The literal prints as a ``double``.  A narrower target still needs
+        # its cast, but not a rounding one: the value is already in that
+        # format, so no mode can change it.
+        target_ty = self._scalar_for_ctx(active, at=e)
+        if target_ty == CppScalar.F64:
+            return lit
+        return self._explicit_cast(lit, target_ty)
+
     def _visit_round(self, e, ctx) -> str:
         # ``Round(arg)`` rounds ``arg`` to the active rounding
         # context — emitted as a plain ``static_cast`` (the cast's
@@ -2221,7 +2260,10 @@ class CppEmitter(Visitor):
         # Phase 5b at the surrounding ``with`` boundary).  The user
         # explicitly asked to round into the active context, so the
         # cast is emitted even when lossy.  Same-type short-circuits
-        # to a no-op.
+        # to a no-op.  A literal argument is rounded here instead.
+        folded = self._fold_rounded_literal(e)
+        if folded is not None:
+            return folded
         arg = self._visit_expr(e.arg, ctx)
         arg_ty, target_ty = self._scalar_cast_types(e)
         if arg_ty == target_ty:

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -66,6 +66,7 @@ from ...ast.fpyast import (
     Ast,
     BinaryOp,
     BoolVal,
+    Call,
     Cast,
     Compare,
     ContextStmt,
@@ -908,11 +909,7 @@ class CppEmitter(Visitor):
             # A rebuilt list is a different object, and a handle exists exactly
             # so that FPy's aliasing survives.  Unsharing it here would be
             # silent, so refuse instead.
-            raise CppEmitError(
-                f'unsupported: `{src.format()}` cannot become `{want.format()}` '
-                f'— rebuilding a shared list would copy it out of its aliases',
-                at=at,
-            )
+            raise self._refuse_unsharing(src, want, at)
         unboxed = CppList(want.elt, boxed=False)
         if src.elt != want.elt:
             code = self._rebuild_list(code, src, unboxed, at=at)
@@ -920,6 +917,48 @@ class CppEmitter(Visitor):
             return code
         # A value has no aliases to lose, so giving it a handle is free.
         return f'std::make_shared<{unboxed.format()}>({code})'
+
+    def _refuse_unsharing(
+        self, src: CppList, want: CppList, at: Expr,
+    ) -> CppEmitError:
+        """The one representation change with no sound lowering.
+
+        Points at the *definition* as well as the use: this is where the
+        conflict surfaces, but the declaration is where it can be fixed — give
+        the list the wider format and nothing needs converting.
+        """
+        what, where, fix = 'this list', '', 'define it at the wider format'
+        if isinstance(at, Var):
+            what = f'`{at.name}`'
+            fix = f'define {what} at the wider format'
+            site = self.def_use.find_def_from_use(at).site
+            loc = getattr(site, 'loc', None)
+            if loc is not None:
+                # Line only: the file is already in the location prefix, and
+                # ``Location.format`` opens a backtick it never closes.
+                where = f' (defined on line {loc.start_line})'
+        elif isinstance(at, Call):
+            # The remaining reachable case: a callee's return representation is
+            # fixed by its own body, so nothing on this side can raise it.
+            callee = getattr(at.func, 'name', at.func)
+            what = f'the list `{callee}` returns'
+            fix = f'have `{callee}` return the wider format'
+        if src.elt == want.elt:
+            detail = (
+                f'is `{src.format()}` where `{want.format()}` is needed'
+            )
+        else:
+            detail = (
+                f'holds `{src.elt.format()}` elements where '
+                f'`{want.elt.format()}` is needed'
+            )
+        return CppEmitError(
+            f'unsupported: {what}{where} {detail}.  Changing a list\'s element '
+            f'type needs a new buffer, and this one is shared — so the copy '
+            f'would not be the list its other references name.  Either {fix}, '
+            f'or do not mix formats at this point.',
+            at=at,
+        )
 
     def _rebuild_list(
         self, code: str, src: CppList, want: CppList, *, at: Expr,
@@ -951,12 +990,22 @@ class CppEmitter(Visitor):
         return out
 
     def _storage_or_none(self, e: Expr) -> CppType | None:
-        """:meth:`_storage_for_expr`, or ``None`` where it has no answer.
+        """The storage *e* actually emits as, or ``None`` where unknown.
 
         A format with no storage on the ladder — a symbolic ``REAL_FORMAT``, say
         — is not a disagreement to repair.  Callers that only want to *adjust* a
         representation skip it rather than failing the compile.
+
+        A variable reads as its **declaration**, which is not always what its
+        own format bound would choose: ``storage_infer`` aggregates a whole
+        storage class and raises it to the places the class reaches (see
+        ``storage_infer.place_floors``).  Asking ``by_expr`` here would compare
+        against a type the emitted name does not have.
         """
+        if isinstance(e, Var):
+            d = self.def_use.find_def_from_use(e)
+            ty = self.storage.storage_of(d)
+            return ty if self.unbox is None else self.unbox.annotate(e, ty)
         try:
             return self._storage_for_expr(e)
         except CppEmitError:

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -580,6 +580,21 @@ class CppEmitter(Visitor):
         """
         return self._binds_reference(target_def)
 
+    def _emitted_storage_of(self, d) -> CppType:
+        """The type *d*'s C++ name actually has.
+
+        ``storage_of`` is the type the analysis *chose*; when the emitter binds
+        the name as ``const auto&`` the type is the one C++ *deduced* from the
+        initializer, and the two can differ.  Every caller reasoning about the
+        emitted code wants this one.
+        """
+        src = self._reference_source(d)
+        if src is not None:
+            ty = self._storage_or_none(src)
+            if ty is not None:
+                return ty
+        return self.storage.storage_of(d)
+
     def _reference_source(self, d) -> 'Expr | None':
         """The initializer *d*'s C++ name deduces its type from, if any.
 
@@ -996,6 +1011,30 @@ class CppEmitter(Visitor):
             f'unsupported: this value is `{src.format()}` where '
             f'`{want.format()}` is needed, and C++ has no conversion between '
             f'them.  Keeping the two formats the same at this point avoids it.',
+            at=at,
+        )
+
+    def _require_no_narrowing(
+        self, src: CppType | None, want: CppType | None, at: Expr,
+    ) -> None:
+        """Refuse a store C++ would narrow silently.
+
+        The sibling of :meth:`_require_bridgeable`, for the one case where a
+        format disagreement is a *wrong answer* instead of a compile error: C++
+        accepts a narrowing store into a slot, and FPy says the list then holds
+        the wider value.  Widening the container instead is not available --
+        another name may already alias it, which ``format_infer`` does not track
+        (see ``docs/todos/format-infer-aliasing.md``).
+        """
+        if not (isinstance(src, CppScalar) and isinstance(want, CppScalar)):
+            return
+        if scalar_fits_in(src, want):
+            return
+        raise CppEmitError(
+            f'unsupported: storing a `{src.format()}` into a slot of '
+            f'`{want.format()}` would narrow it, and the list would then not '
+            f'hold the value FPy says it does.  Round the value to the list\'s '
+            f'format, or build the list at the wider one.',
             at=at,
         )
 
@@ -2881,7 +2920,7 @@ class CppEmitter(Visitor):
         target_name = self.storage.def_to_name[target_def]
         idxs = [self._visit_expr(idx, ctx) for idx in stmt.indices]
         chain = target_name
-        level = self.storage.storage_of(target_def)
+        level = self._emitted_storage_of(target_def)
         for idx in idxs:
             if not isinstance(level, CppList):
                 raise CppEmitError(
@@ -2893,9 +2932,9 @@ class CppEmitter(Visitor):
             level = level.elt
         # The slot's type comes from the container, so there is nowhere to put
         # a conversion: the value has to already fit.
-        self._require_bridgeable(
-            self._storage_or_none(stmt.expr), level, stmt.expr,
-        )
+        src = self._storage_or_none(stmt.expr)
+        self._require_bridgeable(src, level, stmt.expr)
+        self._require_no_narrowing(src, level, stmt.expr)
         rhs = self._emit_at(stmt.expr, level, ctx)
         self.writer.add_line(f'{chain} = {rhs};')
 

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -537,7 +537,10 @@ class CppEmitter(Visitor):
             self.unbox.alias.region_of(d), storage,
         )
 
-    def _foreach_decl(self, target_def, name: str) -> str:
+    def _foreach_decl(
+        self, target_def, name: str,
+        *, elt: CppType | None = None, at: Expr | None = None,
+    ) -> str:
         """Loop-variable declaration for a range-for over a container.
 
         Same rule as :meth:`_arg_decl`: an element that is never rebound binds
@@ -545,10 +548,16 @@ class CppEmitter(Visitor):
         iteration.  Writing ``row[i] = e`` through it still reaches the
         container.  ``target_def is None`` marks a discarded element — always
         read-only, and ``const auto&`` lets the type deduce.
+
+        *elt* is the container's element type when the caller knows it.  The
+        target reads that element, so the two have to agree — there is nowhere
+        in a range-for to put a conversion.
         """
         if target_def is None:
             return f'const auto& {name}'
         storage = self.storage.storage_of(target_def)
+        if elt is not None and at is not None:
+            self._require_bridgeable(elt, storage, at)
         if binds_by_reference(self.storage, self.def_use, target_def):
             # same rule as `_arg_decl`
             if self._writes_through(target_def, storage):
@@ -569,11 +578,37 @@ class CppEmitter(Visitor):
 
         Still worth it for a tuple, where a copy is O(size).
         """
+        return self._binds_reference(target_def)
+
+    def _reference_source(self, d) -> 'Expr | None':
+        """The initializer *d*'s C++ name deduces its type from, if any.
+
+        Asked of the whole storage class, not of *d*.  A use resolves to the
+        latest def, and ``xs[i] = e`` makes a fresh one that is unioned with its
+        ``prev`` — so a name declared as ``const auto& L3 = N2[1]`` and then
+        written through is *read* through an ``IndexedAssign``-sited def whose own
+        site says nothing about the binding.  One member of the class carries the
+        declaration, and that is the one whose initializer fixed the type.
+        """
+        cls = self.storage.def_class[d]
+        for m in self.storage.class_members[cls]:
+            if isinstance(m.site, Assign) and self._binds_reference(m):
+                return m.site.expr
+        return None
+
+    def _binds_reference(self, d) -> bool:
+        """Whether the emitter binds *d*'s name as a reference.
+
+        The single answer for the question, because two callers need the *same*
+        one: this decides what to emit, and :meth:`_storage_or_none` decides what
+        the emitted name's type therefore is.  Answering differently in the two
+        places means the guard compares against a type the code does not have.
+        """
         return binds_by_reference(
-            self.storage, self.def_use, target_def,
+            self.storage, self.def_use, d,
             allow_projection=(
                 self.unbox is not None
-                and self.unbox.may_reference_projection(target_def)
+                and self.unbox.may_reference_projection(d)
             ),
         )
 
@@ -597,6 +632,8 @@ class CppEmitter(Visitor):
         binding: TupleBinding,
         src: str,
         site,
+        src_ty: CppType | None = None,
+        at: Expr | None = None,
     ) -> None:
         """Emit destructuring assigns extracting each element of
         *binding* from the tuple-valued local *src*.  The SSA defs
@@ -610,13 +647,26 @@ class CppEmitter(Visitor):
                     continue
                 case NamedId():
                     access = f'std::get<{i}>({src})'
+                    # The name is declared at its own storage but initialized
+                    # from the tuple's field, and there is no room for a
+                    # conversion between the two.
+                    if isinstance(src_ty, CppTuple) and i < len(src_ty.elts) and at is not None:
+                        d = self.def_use.find_def_from_site(elt, site)
+                        self._require_bridgeable(
+                            src_ty.elts[i], self.storage.storage_of(d), at,
+                        )
                     self._emit_bind(elt, site, access)
                 case TupleBinding():
                     access = f'std::get<{i}>({src})'
                     sub_tmp = self._fresh_temp()
                     # read-only (destructured) -> reference, no copy
                     self.writer.add_line(f'auto&& {sub_tmp} = {access};')
-                    self._destructure(elt, sub_tmp, site)
+                    sub_ty = (
+                        src_ty.elts[i]
+                        if isinstance(src_ty, CppTuple) and i < len(src_ty.elts)
+                        else None
+                    )
+                    self._destructure(elt, sub_tmp, site, sub_ty, at)
                 case _:
                     raise CppEmitError(
                         f'unsupported tuple-binding element {elt!r}',
@@ -799,7 +849,10 @@ class CppEmitter(Visitor):
                 tmp = self._fresh_temp()
                 # read-only (destructured) -> reference, no copy
                 self.writer.add_line(f'auto&& {tmp} = {rhs};')
-                self._destructure(stmt.target, tmp, stmt)
+                self._destructure(
+                    stmt.target, tmp, stmt,
+                    self._storage_or_none(stmt.expr), stmt.expr,
+                )
             case _:
                 raise CppEmitError(
                     f'unsupported assignment target {stmt.target!r}',
@@ -827,13 +880,13 @@ class CppEmitter(Visitor):
             return self._visit_expr(e, ctx)
         match e:
             case ListExpr() if isinstance(want, CppList):
-                parts = [self._emit_braced(elt, want.elt, ctx) for elt in e.elts]
+                parts = [self._emit_deduced(elt, want.elt, ctx) for elt in e.elts]
                 return self._list_new_init(want, parts)
             case TupleExpr() if (
                 isinstance(want, CppTuple) and len(want.elts) == len(e.elts)
             ):
                 parts = [
-                    self._emit_at(elt, w, ctx)
+                    self._emit_deduced(elt, w, ctx)
                     for elt, w in zip(e.elts, want.elts)
                 ]
                 return f'std::make_tuple({", ".join(parts)})'
@@ -850,12 +903,15 @@ class CppEmitter(Visitor):
             return emitted
         return self._convert_storage(emitted, src, want, at=e)
 
-    def _emit_braced(self, e: Expr, want: CppType, ctx) -> str:
-        """:meth:`_emit_at`, for an element of a braced initializer.
+    def _emit_deduced(self, e: Expr, want: CppType, ctx) -> str:
+        """:meth:`_emit_at` where C++ takes the type *from the argument*.
 
-        A braced init forbids a narrowing conversion, so a scalar element's
-        cast has to be spelled even though the same conversion would be
-        implicit anywhere else.
+        A braced initializer and ``std::make_tuple`` both do: the first rejects
+        a narrowing conversion outright, and the second silently deduces a
+        different type — ``std::make_tuple(a, b)`` with a ``float`` ``a`` builds
+        a ``std::tuple<float, double>`` that the surrounding declaration then
+        will not accept.  Either way the scalar's cast has to be spelled, even
+        though the same conversion is implicit anywhere else.
         """
         code = self._emit_at(e, want, ctx)
         if isinstance(want, CppScalar):
@@ -889,14 +945,18 @@ class CppEmitter(Visitor):
         definition -- so a narrower one flowing into a wider place arrives here
         and is converted.
 
-        Scalars convert implicitly, and so does a ``std::tuple`` whose fields
-        do.  ``std::vector`` does not, so a list is rebuilt element-wise.
+        A scalar is cast: ``std::make_tuple`` below deduces its type from the
+        argument, so leaving the conversion implicit rebuilds the tuple at the
+        type it already had.  ``std::vector`` has no converting constructor
+        either, so a list is rebuilt element-wise.
         """
         if src == want:
             return code
+        if isinstance(src, CppScalar) and isinstance(want, CppScalar):
+            return self._explicit_cast(code, want)
         if isinstance(src, CppTuple) and isinstance(want, CppTuple):
             if len(src.elts) != len(want.elts):
-                return code
+                raise self._refuse_mismatch(src, want, at)
             base = self._bind_operand(code)
             fields = [
                 self._convert_storage(f'std::get<{i}>({base})', s, w, at=at)
@@ -904,7 +964,10 @@ class CppEmitter(Visitor):
             ]
             return f'std::make_tuple({", ".join(fields)})'
         if not (isinstance(src, CppList) and isinstance(want, CppList)):
-            return code
+            # Nothing bridges these, so handing the code back unchanged would
+            # emit a type error inside generated C++ -- the worst place for a
+            # user to meet one.  Refuse here instead.
+            raise self._refuse_mismatch(src, want, at)
         if src.boxed:
             # A rebuilt list is a different object, and a handle exists exactly
             # so that FPy's aliasing survives.  Unsharing it here would be
@@ -917,6 +980,39 @@ class CppEmitter(Visitor):
             return code
         # A value has no aliases to lose, so giving it a handle is free.
         return f'std::make_shared<{unboxed.format()}>({code})'
+
+    def _refuse_mismatch(
+        self, src: CppType, want: CppType, at: Expr,
+    ) -> CppEmitError:
+        """One place wants two types and nothing in C++ bridges them.
+
+        Reached where a *representation* decision could not be reconciled --
+        distinct ``std::vector`` instantiations are unrelated types, and so are a
+        vector and a handle.  A limitation in the compiler is acceptable;
+        emitting C++ that does not compile is not, so this refuses rather than
+        letting the mismatch reach the C++ compiler.
+        """
+        return CppEmitError(
+            f'unsupported: this value is `{src.format()}` where '
+            f'`{want.format()}` is needed, and C++ has no conversion between '
+            f'them.  Keeping the two formats the same at this point avoids it.',
+            at=at,
+        )
+
+    def _require_bridgeable(
+        self, src: CppType | None, want: CppType | None, at: Expr,
+    ) -> None:
+        """Refuse unless *src* can reach *want*, for a site that cannot convert.
+
+        A slot store, a loop target and a destructured field all take their type
+        from something else, so the emitter has nowhere to put a conversion --
+        the only options are agreement or a refusal.
+        """
+        if src is None or want is None or src == want:
+            return
+        if isinstance(src, CppScalar) and isinstance(want, CppScalar):
+            return                # C++ converts these
+        raise self._refuse_mismatch(src, want, at)
 
     def _refuse_unsharing(
         self, src: CppList, want: CppList, at: Expr,
@@ -1004,8 +1100,22 @@ class CppEmitter(Visitor):
         """
         if isinstance(e, Var):
             d = self.def_use.find_def_from_use(e)
+            # A name the emitter binds as `const auto&` has the type C++
+            # *deduced* from its initializer, not the one `storage_of` chose --
+            # so follow the alias.  Missing this is how `[L3, L3]` came to hold
+            # a `fpy::list<uint8_t>` in a `std::vector<fpy::list<float>>`.
+            src = self._reference_source(d)
+            if src is not None:
+                return self._storage_or_none(src)
             ty = self.storage.storage_of(d)
             return ty if self.unbox is None else self.unbox.annotate(e, ty)
+        if isinstance(e, ListRef):
+            # ``xss[i]`` reads a *declared* element, so peel the container's
+            # declaration rather than asking ``by_expr`` -- which answers from
+            # the format, and can name a type the container does not hold.
+            base = self._storage_or_none(e.value)
+            if isinstance(base, CppList):
+                return base.elt
         try:
             return self._storage_for_expr(e)
         except CppEmitError:
@@ -2401,10 +2511,16 @@ class CppEmitter(Visitor):
             # An overflowing literal is a value the target format does have,
             # but ``HUGE_VAL``/``NAN`` are a separate spelling; leave it.
             return None
-        v = rounded.as_rational()
-        if _as_exact_double(v) is None:
-            return None
-        lit = self._emit_numeric_literal(v, at=e)
+        if rounded.is_zero() and rounded.s:
+            # Underflow to *negative* zero.  It has to be spelled here: a
+            # `Fraction` has no signed zero, so going through `as_rational`
+            # below would emit `0` and turn `x / -0.0` from -inf into +inf.
+            lit = '-0.0'
+        else:
+            v = rounded.as_rational()
+            if _as_exact_double(v) is None:
+                return None
+            lit = self._emit_numeric_literal(v, at=e)
         # The literal prints as a ``double``.  A narrower target still needs
         # its cast, but not a rounding one: the value is already in that
         # format, so no mode can change it.
@@ -2504,9 +2620,14 @@ class CppEmitter(Visitor):
         """
         if want is None or self.unbox is None:
             return emitted
-        have = self._storage_for_expr(e)
+        have = self._storage_or_none(e)
         if not (isinstance(have, CppList) and isinstance(want, CppList)):
+            self._require_bridgeable(have, want, e)
             return emitted
+        if have.elt != want.elt:
+            # The callee declared a different element type; nothing at the call
+            # site can bridge two `std::vector` instantiations.
+            raise self._refuse_mismatch(have, want, e)
         if have.boxed == want.boxed:
             return emitted
         if not have.boxed:
@@ -2638,7 +2759,11 @@ class CppEmitter(Visitor):
                     f'{self._list_range(iter_ty, iter_str)}) {{'
                 )
                 self.writer.indent()
-                self._destructure(target, tmp, comp_site)
+                self._destructure(
+                    target, tmp, comp_site,
+                    iter_ty.elt if isinstance(iter_ty, CppList) else None,
+                    iterable,
+                )
                 return
             case _:
                 raise CppEmitError(
@@ -2671,7 +2796,11 @@ class CppEmitter(Visitor):
             case _:
                 iter_str = self._visit_expr(iterable, ctx)
                 iter_ty = self._storage_for_expr(iterable)
-                decl = self._foreach_decl(loop_def, target_name)
+                decl = self._foreach_decl(
+                    loop_def, target_name,
+                    elt=iter_ty.elt if isinstance(iter_ty, CppList) else None,
+                    at=iterable,
+                )
                 self.writer.add_line(
                     f'for ({decl} : {self._list_range(iter_ty, iter_str)}) {{'
                 )
@@ -2762,7 +2891,12 @@ class CppEmitter(Visitor):
                 )
             chain = self._list_at(level, chain, idx)
             level = level.elt
-        rhs = self._visit_expr(stmt.expr, ctx)
+        # The slot's type comes from the container, so there is nowhere to put
+        # a conversion: the value has to already fit.
+        self._require_bridgeable(
+            self._storage_or_none(stmt.expr), level, stmt.expr,
+        )
+        rhs = self._emit_at(stmt.expr, level, ctx)
         self.writer.add_line(f'{chain} = {rhs};')
 
     def _visit_if1(self, stmt: If1Stmt, ctx):
@@ -2940,8 +3074,13 @@ class CppEmitter(Visitor):
                 # read-only aggregates — no per-element copy).
                 iter_str = self._visit_expr(stmt.iterable, ctx)
                 iter_ty = self._storage_for_expr(stmt.iterable)
+                decl = self._foreach_decl(
+                    target_def, target,
+                    elt=iter_ty.elt if isinstance(iter_ty, CppList) else None,
+                    at=stmt.iterable,
+                )
                 header = (
-                    f'for ({self._foreach_decl(target_def, target)} : '
+                    f'for ({decl} : '
                     f'{self._list_range(iter_ty, iter_str)})'
                 )
         self.writer.add_line(f'{header} {{')
@@ -2970,7 +3109,11 @@ class CppEmitter(Visitor):
         )
         self.writer.indent()
         assert isinstance(stmt.target, TupleBinding)
-        self._destructure(stmt.target, tmp, stmt)
+        self._destructure(
+            stmt.target, tmp, stmt,
+            iter_ty.elt if isinstance(iter_ty, CppList) else None,
+            stmt.iterable,
+        )
         self._visit_block(stmt.body, ctx)
         self.writer.dedent()
         self.writer.add_line('}')

--- a/fpy2/backend/cpp/storage_infer.py
+++ b/fpy2/backend/cpp/storage_infer.py
@@ -57,6 +57,7 @@ from ...ast.fpyast import (
     ListRef,
     NamedId,
     Stmt,
+    TupleBinding,
     TupleExpr,
     Var,
 )
@@ -252,32 +253,60 @@ class _PlaceFloors(DefaultVisitor):
         by_expr: dict[Expr, FormatBound],
         ret_fmt: FormatBound,
         base: 'StorageAnalysis',
+        is_called: bool,
     ):
         self.def_use = def_use
         self.by_def = by_def
         self.by_expr = by_expr
         self.ret_fmt = ret_fmt
         self.base = base
+        self.is_called = is_called
         self.floors: dict[Definition, FormatBound] = {}
         self.assigns: list[Assign] = []
+        self.indexed: list[IndexedAssign] = []
+        self.loops: list[ForStmt] = []
         self.collected = False
         self.changed = False
 
     def _pinned(self, d: Definition) -> bool:
-        """Whether *d* has no storage of its own to raise.
+        """Whether *d*'s storage *class* has anything that cannot be raised.
 
-        The emitter binds some names as a ``const`` reference to storage that
-        already exists — ``ys = xs``, ``row = xss[i]``, a loop target.  Those are
-        spelled ``auto``, so raising one would make ``storage_of`` describe a
-        type the reference does not have and nothing would catch it until the
-        mismatch surfaced somewhere else.  ``allow_projection`` is on because
-        refusing to raise is the safe direction.
+        Asked about the class, not the definition: :meth:`StorageInfer.infer`
+        joins a floor into the whole class's bound, so a floor landing on one
+        member raises every member.  Checking only the def the floor arrived at
+        pins nothing — an ``xs[i] = e`` def shares its class with its ``prev``
+        by the in-place-mutation edge and is itself unpinnable, so it would
+        raise the very parameter or reference binding the check refused.
+        """
+        cls = self.base.def_class[d]
+        return any(
+            self._unraisable(m) for m in self.base.class_members[cls]
+        )
 
-        A *parameter* is also bound by reference but its type is spelled from
-        ``storage_of`` in the signature, so raising it does what it says — the
-        ABI changes, and ``signature()`` reports it.
+    def _unraisable(self, d: Definition) -> bool:
+        """Whether *d* alone has no storage of its own to raise.
+
+        The line is whether the emitter *spells* the type or lets C++ deduce it,
+        because raising only means anything when something reads ``storage_of``:
+
+        - **Spelled, so raisable.**  A parameter (``_arg_decl``), a loop target
+          and a comprehension target (``_foreach_decl``) all print
+          ``storage_of``, so raising one changes the declaration and the
+          reference follows.
+        - **Deduced, so not.**  ``ys = xs`` and ``row = xss[i]`` are emitted as
+          ``const auto&``, naming storage that already exists.  Raising one only
+          makes ``storage_of`` describe a type the reference does not have, and
+          the ``auto`` hides it until the mismatch surfaces somewhere else.
+
+        The one exception is a parameter of a function compiled code calls: its
+        caller's argument type is already fixed, so raising it underneath emits
+        a call that does not compile.  Same rule ``unbox`` states for
+        representations — a function compiled code calls keeps its signature on
+        both sides.  A native caller is not bound by that.
         """
         if isinstance(d.site, Argument):
+            return self.is_called
+        if isinstance(d.site, ForStmt | ListComp):
             return False
         return binds_by_reference(
             self.base, self.def_use, d, allow_projection=True,
@@ -346,7 +375,39 @@ class _PlaceFloors(DefaultVisitor):
         if not self.collected:
             self.assigns.append(stmt)
 
+    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx):
+        super()._visit_indexed_assign(stmt, ctx)
+        if not self.collected:
+            self.indexed.append(stmt)
+
+    def _visit_for(self, stmt: ForStmt, ctx):
+        super()._visit_for(stmt, ctx)
+        if not self.collected:
+            self.loops.append(stmt)
+
     # -- the other direction ------------------------------------------------
+
+    def _class_bound(self, d: Definition) -> FormatBound:
+        """The bound *d*'s C++ variable will actually have.
+
+        Over the whole storage class, because that is the unit
+        :meth:`StorageInfer.infer` joins: a floor on any member decides them
+        all.  Reading one def's own floor is how ``L6`` came out ``double`` while
+        the tuple it was destructured from stayed ``uint8_t`` -- the return
+        raised the ``L6[i] = e`` def, and the destructuring def next to it in the
+        same class had no floor of its own to find.
+        """
+        cls = self.base.def_class[d]
+        out: FormatBound = None
+        for m in self.base.class_members[cls]:
+            for b in (self.by_def.get(m), self.floors.get(m)):
+                if b is None:
+                    continue
+                try:
+                    out = b if out is None else _join_bounds(out, b)
+                except RuntimeError:
+                    return None       # incompatible kinds: not a widening question
+        return out
 
     def _effective(self, e: Expr) -> FormatBound:
         """*e*'s bound with the floors its leaves have picked up.
@@ -359,9 +420,7 @@ class _PlaceFloors(DefaultVisitor):
         """
         match e:
             case Var():
-                d = self.def_use.find_def_from_use(e)
-                own, floor = self.by_def.get(d), self.floors.get(d)
-                return own if floor is None else _join_bounds(own, floor)
+                return self._class_bound(self.def_use.find_def_from_use(e))
             case ListExpr() if e.elts:
                 elts = [self._effective(x) for x in e.elts]
                 return ListFormat(reduce(_join_bounds, elts))
@@ -376,17 +435,106 @@ class _PlaceFloors(DefaultVisitor):
         return self.by_expr.get(e)
 
     def _propagate_up(self) -> None:
-        """Floor each assignment target by what its RHS now builds."""
+        """Carry each floor to the other places that must agree with it."""
         for stmt in self.assigns:
-            if not isinstance(stmt.target, NamedId):
-                continue
-            d = self.def_use.find_def_from_site(stmt.target, stmt)
             try:
                 eff = self._effective(stmt.expr)
             except RuntimeError:
                 continue          # incompatible kinds: not a widening question
-            if isinstance(eff, ListFormat | TupleFormat):
-                self._raise(d, eff)
+            match stmt.target:
+                case NamedId():
+                    if isinstance(eff, ListFormat | TupleFormat):
+                        d = self.def_use.find_def_from_site(stmt.target, stmt)
+                        self._raise(d, eff)
+                case TupleBinding():
+                    self._bind_destructured(stmt, eff)
+        for ix in self.indexed:
+            self._raise_container(ix)
+        for loop in self.loops:
+            self._bind_loop_target(loop)
+
+    def _bind_loop_target(self, stmt: ForStmt) -> None:
+        """``for row in xss`` reads an element, so the two must agree.
+
+        The target's type is spelled from ``storage_of``, so raising the
+        container alone leaves ``for (const fpy::list<float>& row :
+        std::vector<fpy::list<double>>)``.  Both directions, as for a
+        destructuring: neither side can be left behind.
+        """
+        if not isinstance(stmt.target, NamedId):
+            return          # a destructuring target rides on the tuple instead
+        d = self.def_use.find_def_from_site(stmt.target, stmt)
+        try:
+            eff = self._effective(stmt.iterable)
+        except RuntimeError:
+            return
+        if isinstance(eff, ListFormat) and isinstance(
+            eff.elt, ListFormat | TupleFormat,
+        ):
+            self._raise(d, eff.elt)
+        if not isinstance(stmt.iterable, Var):
+            return
+        mine = self._class_bound(d)
+        if isinstance(mine, ListFormat | TupleFormat):
+            self._raise(
+                self.def_use.find_def_from_use(stmt.iterable), ListFormat(mine),
+            )
+
+    def _bind_destructured(self, stmt: Assign, eff: FormatBound) -> None:
+        """``a, b = t`` reads each name with ``std::get``, so its type is the
+        tuple's field type, not one it can choose.
+
+        A name here has no storage of its own to raise -- but it cannot be
+        pinned either, because the *tuple* may be raised and then the field it
+        reads has moved.  So the floor goes down from the tuple's fields to the
+        names, which is the direction the emitter cannot fix.
+        """
+        if not isinstance(eff, TupleFormat):
+            return
+        target = stmt.target
+        if not isinstance(target, TupleBinding):
+            return
+        if len(target.elts) != len(eff.elts):
+            return
+        for sub, field in zip(target.elts, eff.elts):
+            if isinstance(sub, NamedId) and isinstance(
+                field, ListFormat | TupleFormat,
+            ):
+                self._raise(self.def_use.find_def_from_site(sub, stmt), field)
+        # ...and back up.  A name raised from somewhere else -- returned wide,
+        # say -- has to drag the field it reads with it, or the two disagree the
+        # other way round.
+        if not isinstance(stmt.expr, Var):
+            return
+        fields: list[FormatBound] = []
+        for sub, field in zip(target.elts, eff.elts):
+            if not isinstance(sub, NamedId):
+                fields.append(field)
+                continue
+            d = self.def_use.find_def_from_site(sub, stmt)
+            mine = self._class_bound(d)
+            fields.append(field if mine is None else _join_bounds(field, mine))
+        self._raise(
+            self.def_use.find_def_from_use(stmt.expr), TupleFormat(tuple(fields)),
+        )
+
+    def _raise_container(self, stmt: IndexedAssign) -> None:
+        """``xss[i] = e`` puts *e* in a slot, so the container's element level
+        has to hold it.
+
+        The emitter stores straight into the slot and never converts there, so
+        a floor on *e* alone would leave the two disagreeing.  One ``ListFormat``
+        per index peeled.
+        """
+        try:
+            eff = self._effective(stmt.expr)
+        except RuntimeError:
+            return
+        if not isinstance(eff, ListFormat | TupleFormat):
+            return
+        for _ in stmt.indices:
+            eff = ListFormat(eff)
+        self._raise(self.def_use.find_def_from_site(stmt.var, stmt), eff)
 
 
 def place_floors(
@@ -396,6 +544,7 @@ def place_floors(
     by_expr: dict[Expr, FormatBound],
     ret_fmt: FormatBound,
     base: 'StorageAnalysis',
+    is_called: bool = False,
 ) -> dict[Definition, FormatBound]:
     """See :class:`_PlaceFloors`.
 
@@ -417,17 +566,18 @@ def place_floors(
     work left would return a *partial* answer, and an under-raised definition
     reappears later as a type disagreement the emitter has to refuse.
     """
-    v = _PlaceFloors(def_use, by_def, by_expr, ret_fmt, base)
+    v = _PlaceFloors(def_use, by_def, by_expr, ret_fmt, base, is_called)
     v._visit_function(ast, None)          # collects the assignments to revisit
     v.collected = True
-    for _ in range(len(v.assigns) + 2):
+    for _ in range(len(v.assigns) + len(v.indexed) + len(v.loops) + 2):
         v.changed = False
         v._visit_function(ast, None)      # places -> the defs reaching them
         v._propagate_up()                 # defs -> containers and aliases
         if not v.changed:
             break
     assert not v.changed, (
-        f'place_floors did not settle in {len(v.assigns) + 2} rounds over '
+        f'place_floors did not settle in '
+        f'{len(v.assigns) + len(v.indexed) + len(v.loops) + 2} rounds over '
         f'{len(v.assigns)} assignments: a floor is rising without bound, so '
         f'either a join is not monotone or a cycle is feeding itself'
     )

--- a/fpy2/backend/cpp/storage_infer.py
+++ b/fpy2/backend/cpp/storage_infer.py
@@ -260,6 +260,7 @@ class _PlaceFloors(DefaultVisitor):
         self.base = base
         self.floors: dict[Definition, FormatBound] = {}
         self.assigns: list[Assign] = []
+        self.collected = False
         self.changed = False
 
     def _pinned(self, d: Definition) -> bool:
@@ -339,7 +340,11 @@ class _PlaceFloors(DefaultVisitor):
 
     def _visit_assign(self, stmt: Assign, ctx):
         super()._visit_assign(stmt, ctx)
-        self.assigns.append(stmt)
+        # Once: the body is walked once per round, and re-appending would grow
+        # the list every time — harmless for the result, since raising a floor
+        # twice is idempotent, but it would make the iteration bound a lie.
+        if not self.collected:
+            self.assigns.append(stmt)
 
     # -- the other direction ------------------------------------------------
 
@@ -398,17 +403,34 @@ def place_floors(
     emitter binds by reference — those have no storage to raise.
 
     The two directions feed each other -- a place raises a variable, a raised
-    variable raises the container holding it -- so iterate.  Bounds only ever
-    rise and the ladder is finite, so this settles; the cap is a backstop.
+    variable raises the container holding it -- so iterate to a fixpoint.
+
+    It terminates in at most one round per assignment.  A place's own bound is
+    fixed (it comes from ``by_expr`` / ``ret_fmt``, which this does not touch),
+    so every floor originates in the first round and later rounds only carry it
+    along assignment edges -- and a chain of those is no longer than the number
+    of assignments.  One extra round detects that nothing moved.
+
+    Measured over the corpus: 175 functions settle in one round, 44 in two, and
+    the largest has 34 assignments.  So the bound is slack by a wide margin,
+    which is why it asserts rather than breaking: falling out of this loop with
+    work left would return a *partial* answer, and an under-raised definition
+    reappears later as a type disagreement the emitter has to refuse.
     """
     v = _PlaceFloors(def_use, by_def, by_expr, ret_fmt, base)
     v._visit_function(ast, None)          # collects the assignments to revisit
-    for _ in range(8):
+    v.collected = True
+    for _ in range(len(v.assigns) + 2):
         v.changed = False
         v._visit_function(ast, None)      # places -> the defs reaching them
         v._propagate_up()                 # defs -> containers and aliases
         if not v.changed:
             break
+    assert not v.changed, (
+        f'place_floors did not settle in {len(v.assigns) + 2} rounds over '
+        f'{len(v.assigns)} assignments: a floor is rising without bound, so '
+        f'either a join is not monotone or a cycle is feeding itself'
+    )
     return v.floors
 
 

--- a/fpy2/backend/cpp/storage_infer.py
+++ b/fpy2/backend/cpp/storage_infer.py
@@ -33,35 +33,23 @@ numeric suffixes (``x_1``, ``x_2``, …).
 
 from collections import defaultdict
 from dataclasses import dataclass
-from functools import reduce
 
 from ...analysis import Definition
 from ...analysis.define_use import DefineUseAnalysis
 from ...analysis.format_infer import FormatBound
-from ...analysis.format_infer.analysis import (
-    ListFormat,
-    TupleFormat,
-    _join_bounds,
-)
 from ...analysis.reaching_defs import AssignDef, PhiDef
 from ...ast.fpyast import (
     Argument,
     Assign,
     Expr,
     ForStmt,
-    FuncDef,
-    IfExpr,
     IndexedAssign,
     ListComp,
-    ListExpr,
     ListRef,
     NamedId,
     Stmt,
-    TupleBinding,
-    TupleExpr,
     Var,
 )
-from ...ast.visitor import DefaultVisitor
 from ...utils import Unionfind
 from .storage import StorageSelectionError, aggregate_storage
 from .types import CppList, CppTuple, CppType
@@ -230,353 +218,6 @@ def _is_external(members: list[Definition]) -> bool:
     return False
 
 
-class _PlaceFloors(DefaultVisitor):
-    """Per-def lower bounds from the places each def's value reaches.
-
-    One place admits one C++ type.  :meth:`emitter._emit_at` builds a
-    *constructor* at the place's type, but a variable cannot be rebuilt that
-    way: changing a list's element type means a new buffer, and a shared list
-    cannot survive one — which is the refusal in ``_convert_storage``.  So raise
-    the variable's own storage instead, and there is nothing left to convert.
-
-    Lists only.  A scalar converts free at the point of use, so widening its
-    declaration would change a signature to no purpose.
-
-    The shape mirrors ``_emit_at`` deliberately: the same set of expressions
-    contribute to a place, and the two must agree about which.
-    """
-
-    def __init__(
-        self,
-        def_use: DefineUseAnalysis,
-        by_def: dict[Definition, FormatBound],
-        by_expr: dict[Expr, FormatBound],
-        ret_fmt: FormatBound,
-        base: 'StorageAnalysis',
-        is_called: bool,
-    ):
-        self.def_use = def_use
-        self.by_def = by_def
-        self.by_expr = by_expr
-        self.ret_fmt = ret_fmt
-        self.base = base
-        self.is_called = is_called
-        self.floors: dict[Definition, FormatBound] = {}
-        self.assigns: list[Assign] = []
-        self.indexed: list[IndexedAssign] = []
-        self.loops: list[ForStmt] = []
-        self.collected = False
-        self.changed = False
-
-    def _pinned(self, d: Definition) -> bool:
-        """Whether *d*'s storage *class* has anything that cannot be raised.
-
-        Asked about the class, not the definition: :meth:`StorageInfer.infer`
-        joins a floor into the whole class's bound, so a floor landing on one
-        member raises every member.  Checking only the def the floor arrived at
-        pins nothing — an ``xs[i] = e`` def shares its class with its ``prev``
-        by the in-place-mutation edge and is itself unpinnable, so it would
-        raise the very parameter or reference binding the check refused.
-        """
-        cls = self.base.def_class[d]
-        return any(
-            self._unraisable(m) for m in self.base.class_members[cls]
-        )
-
-    def _unraisable(self, d: Definition) -> bool:
-        """Whether *d* alone has no storage of its own to raise.
-
-        The line is whether the emitter *spells* the type or lets C++ deduce it,
-        because raising only means anything when something reads ``storage_of``:
-
-        - **Spelled, so raisable.**  A parameter (``_arg_decl``), a loop target
-          and a comprehension target (``_foreach_decl``) all print
-          ``storage_of``, so raising one changes the declaration and the
-          reference follows.
-        - **Deduced, so not.**  ``ys = xs`` and ``row = xss[i]`` are emitted as
-          ``const auto&``, naming storage that already exists.  Raising one only
-          makes ``storage_of`` describe a type the reference does not have, and
-          the ``auto`` hides it until the mismatch surfaces somewhere else.
-
-        One exception: a parameter of a function compiled code *calls*.  Its
-        caller's argument type is already fixed, so raising it underneath emits a
-        call that does not compile — the rule ``unbox`` states for
-        representations, that a called function keeps its signature on both
-        sides.  A native caller is not bound by it.
-        """
-        if isinstance(d.site, Argument):
-            return self.is_called
-        if isinstance(d.site, ForStmt | ListComp):
-            return False
-        return binds_by_reference(
-            self.base, self.def_use, d, allow_projection=True,
-        )
-
-    def _raise(self, d: Definition, fmt: FormatBound) -> None:
-        if self._pinned(d):
-            return
-        cur = self.floors.get(d)
-        raised = fmt if cur is None else _join_bounds(cur, fmt)
-        if raised != cur:
-            self.floors[d] = raised
-            self.changed = True
-
-    def _push(self, e: Expr, fmt: FormatBound) -> None:
-        if not isinstance(fmt, ListFormat):
-            return
-        match e:
-            case Var():
-                self._raise(self.def_use.find_def_from_use(e), fmt)
-            case ListExpr():
-                for elt in e.elts:
-                    self._push(elt, fmt.elt)
-            case ListComp():
-                self._push(e.elt, fmt.elt)
-            case IfExpr():
-                self._push(e.ift, fmt)
-                self._push(e.iff, fmt)
-
-    def _push_tuple(self, e: Expr, fmt: FormatBound) -> None:
-        """A tuple's fields are separate places, each with its own type."""
-        if isinstance(e, TupleExpr) and isinstance(fmt, TupleFormat):
-            if len(e.elts) == len(fmt.elts):
-                for elt, sub in zip(e.elts, fmt.elts):
-                    self._push_tuple(elt, sub)
-                    self._push(elt, sub)
-
-    def _visit_return(self, stmt, ctx):
-        super()._visit_return(stmt, ctx)
-        self._push(stmt.expr, self.ret_fmt)
-        self._push_tuple(stmt.expr, self.ret_fmt)
-
-    def _visit_list_expr(self, e: ListExpr, ctx):
-        super()._visit_list_expr(e, ctx)
-        fmt = self.by_expr.get(e)
-        if isinstance(fmt, ListFormat):
-            for elt in e.elts:
-                self._push(elt, fmt.elt)
-                self._push_tuple(elt, fmt.elt)
-
-    def _visit_tuple_expr(self, e: TupleExpr, ctx):
-        super()._visit_tuple_expr(e, ctx)
-        self._push_tuple(e, self.by_expr.get(e))
-
-    def _visit_if_expr(self, e: IfExpr, ctx):
-        super()._visit_if_expr(e, ctx)
-        fmt = self.by_expr.get(e)
-        self._push(e, fmt)
-        self._push_tuple(e, fmt)
-
-    def _visit_assign(self, stmt: Assign, ctx):
-        super()._visit_assign(stmt, ctx)
-        # Once: the body is walked once per round, and re-appending would grow
-        # the list every time — harmless for the result, since raising a floor
-        # twice is idempotent, but it would make the iteration bound a lie.
-        if not self.collected:
-            self.assigns.append(stmt)
-
-    def _visit_indexed_assign(self, stmt: IndexedAssign, ctx):
-        super()._visit_indexed_assign(stmt, ctx)
-        if not self.collected:
-            self.indexed.append(stmt)
-
-    def _visit_for(self, stmt: ForStmt, ctx):
-        super()._visit_for(stmt, ctx)
-        if not self.collected:
-            self.loops.append(stmt)
-
-    # -- the other direction ------------------------------------------------
-
-    def _class_bound(self, d: Definition) -> FormatBound:
-        """The bound *d*'s C++ variable will actually have.
-
-        Over the whole storage class, because that is the unit
-        :meth:`StorageInfer.infer` joins: a floor on any member decides them
-        all.  Reading one def's own floor is how ``L6`` came out ``double`` while
-        the tuple it was destructured from stayed ``uint8_t`` -- the return
-        raised the ``L6[i] = e`` def, and the destructuring def next to it in the
-        same class had no floor of its own to find.
-        """
-        cls = self.base.def_class[d]
-        out: FormatBound = None
-        for m in self.base.class_members[cls]:
-            for b in (self.by_def.get(m), self.floors.get(m)):
-                if b is None:
-                    continue
-                try:
-                    out = b if out is None else _join_bounds(out, b)
-                except RuntimeError:
-                    return None       # incompatible kinds: not a widening question
-        return out
-
-    def _effective(self, e: Expr) -> FormatBound:
-        """*e*'s bound with the floors its leaves have picked up.
-
-        Raising a variable raises every container built from it: once ``base``
-        is a ``vector<double>``, ``scratch = [base]`` has to be a
-        ``vector<vector<double>>`` or the container's element type and the
-        variable's own declaration disagree — which is the same conflict one
-        level out.
-        """
-        match e:
-            case Var():
-                return self._class_bound(self.def_use.find_def_from_use(e))
-            case ListExpr() if e.elts:
-                elts = [self._effective(x) for x in e.elts]
-                return ListFormat(reduce(_join_bounds, elts))
-            case TupleExpr():
-                return TupleFormat(tuple(self._effective(x) for x in e.elts))
-            case ListComp():
-                return ListFormat(self._effective(e.elt))
-            case IfExpr():
-                return _join_bounds(
-                    self._effective(e.ift), self._effective(e.iff),
-                )
-        return self.by_expr.get(e)
-
-    def _propagate_up(self) -> None:
-        """Carry each floor to the other places that must agree with it."""
-        for stmt in self.assigns:
-            try:
-                eff = self._effective(stmt.expr)
-            except RuntimeError:
-                continue          # incompatible kinds: not a widening question
-            match stmt.target:
-                case NamedId():
-                    if isinstance(eff, ListFormat | TupleFormat):
-                        d = self.def_use.find_def_from_site(stmt.target, stmt)
-                        self._raise(d, eff)
-                case TupleBinding():
-                    self._bind_destructured(stmt, eff)
-        for ix in self.indexed:
-            self._raise_container(ix)
-        for loop in self.loops:
-            self._bind_loop_target(loop)
-
-    def _bind_loop_target(self, stmt: ForStmt) -> None:
-        """``for row in xss`` reads an element, so the two must agree.
-
-        The target's type is spelled from ``storage_of``, so raising the
-        container alone leaves ``for (const fpy::list<float>& row :
-        std::vector<fpy::list<double>>)``.  Both directions, as for a
-        destructuring: neither side can be left behind.
-        """
-        if not isinstance(stmt.target, NamedId):
-            return          # a destructuring target rides on the tuple instead
-        d = self.def_use.find_def_from_site(stmt.target, stmt)
-        try:
-            eff = self._effective(stmt.iterable)
-        except RuntimeError:
-            return
-        if isinstance(eff, ListFormat) and isinstance(
-            eff.elt, ListFormat | TupleFormat,
-        ):
-            self._raise(d, eff.elt)
-        if not isinstance(stmt.iterable, Var):
-            return
-        mine = self._class_bound(d)
-        if isinstance(mine, ListFormat | TupleFormat):
-            self._raise(
-                self.def_use.find_def_from_use(stmt.iterable), ListFormat(mine),
-            )
-
-    def _bind_destructured(self, stmt: Assign, eff: FormatBound) -> None:
-        """``a, b = t`` reads each name with ``std::get``, so its type is the
-        tuple's field type, not one it can choose.
-
-        A name here has no storage of its own to raise -- but it cannot be
-        pinned either, because the *tuple* may be raised and then the field it
-        reads has moved.  So the floor goes down from the tuple's fields to the
-        names, which is the direction the emitter cannot fix.
-        """
-        if not isinstance(eff, TupleFormat):
-            return
-        target = stmt.target
-        if not isinstance(target, TupleBinding):
-            return
-        if len(target.elts) != len(eff.elts):
-            return
-        for sub, field in zip(target.elts, eff.elts):
-            if isinstance(sub, NamedId) and isinstance(
-                field, ListFormat | TupleFormat,
-            ):
-                self._raise(self.def_use.find_def_from_site(sub, stmt), field)
-        # ...and back up.  A name raised from somewhere else -- returned wide,
-        # say -- has to drag the field it reads with it, or the two disagree the
-        # other way round.
-        if not isinstance(stmt.expr, Var):
-            return
-        fields: list[FormatBound] = []
-        for sub, field in zip(target.elts, eff.elts):
-            if not isinstance(sub, NamedId):
-                fields.append(field)
-                continue
-            d = self.def_use.find_def_from_site(sub, stmt)
-            mine = self._class_bound(d)
-            fields.append(field if mine is None else _join_bounds(field, mine))
-        self._raise(
-            self.def_use.find_def_from_use(stmt.expr), TupleFormat(tuple(fields)),
-        )
-
-    def _raise_container(self, stmt: IndexedAssign) -> None:
-        """``xss[i] = e`` puts *e* in a slot, so the container's element level
-        has to hold it.
-
-        The emitter stores straight into the slot and never converts there, so
-        a floor on *e* alone would leave the two disagreeing.  One ``ListFormat``
-        per index peeled.
-        """
-        try:
-            eff = self._effective(stmt.expr)
-        except RuntimeError:
-            return
-        if not isinstance(eff, ListFormat | TupleFormat):
-            return
-        for _ in stmt.indices:
-            eff = ListFormat(eff)
-        self._raise(self.def_use.find_def_from_site(stmt.var, stmt), eff)
-
-
-def place_floors(
-    ast: FuncDef,
-    def_use: DefineUseAnalysis,
-    by_def: dict[Definition, FormatBound],
-    by_expr: dict[Expr, FormatBound],
-    ret_fmt: FormatBound,
-    base: 'StorageAnalysis',
-    is_called: bool = False,
-) -> dict[Definition, FormatBound]:
-    """See :class:`_PlaceFloors`.  *base* is the unraised storage analysis, used
-    only to tell which names the emitter binds by reference.
-
-    The two directions feed each other — a place raises a variable, a raised
-    variable raises the container built from it — so iterate.  One round per
-    statement suffices: a place's own bound is fixed, so every floor originates
-    in the first round and later rounds only carry it along one edge.  The
-    corpus settles in one or two.
-
-    Asserts rather than breaking: leaving the loop with work outstanding would
-    return a *partial* answer, and an under-raised definition resurfaces as a
-    type disagreement the emitter has to refuse.
-    """
-    v = _PlaceFloors(def_use, by_def, by_expr, ret_fmt, base, is_called)
-    v._visit_function(ast, None)          # collects the assignments to revisit
-    v.collected = True
-    for _ in range(len(v.assigns) + len(v.indexed) + len(v.loops) + 2):
-        v.changed = False
-        v._visit_function(ast, None)      # places -> the defs reaching them
-        v._propagate_up()                 # defs -> containers and aliases
-        if not v.changed:
-            break
-    assert not v.changed, (
-        f'place_floors did not settle in '
-        f'{len(v.assigns) + len(v.indexed) + len(v.loops) + 2} rounds over '
-        f'{len(v.assigns)} assignments: a floor is rising without bound, so '
-        f'either a join is not monotone or a cycle is feeding itself'
-    )
-    return v.floors
-
-
 def _is_in_place_assign(d: AssignDef) -> bool:
     """Does *d* come from an in-place ``IndexedAssign`` (``xs[i] = e``)?
 
@@ -603,7 +244,6 @@ class StorageInfer:
     def infer(
         def_use: DefineUseAnalysis,
         def_to_bound: dict[Definition, FormatBound],
-        floors: dict[Definition, FormatBound] | None = None,
     ) -> StorageAnalysis:
         """
         Build a :class:`StorageAnalysis` from def-use info and per-def
@@ -613,10 +253,6 @@ class StorageInfer:
             def_use:      def-use analysis result for the function.
             def_to_bound: format bound for each SSA def (typically
                           ``format_info.by_def``).
-            floors:       per-def lower bounds from the places each def
-                          reaches, from :func:`place_floors`.  A storage
-                          decision, not a format one: the bounds themselves
-                          stay exactly as the analysis reported them.
 
         Returns:
             A :class:`StorageAnalysis` carrying the per-def C++ name and
@@ -663,10 +299,6 @@ class StorageInfer:
         for c, members in class_members.items():
             bounds = [def_to_bound[d] for d in members if d in def_to_bound]
             assert bounds, f'no format bounds for class {c} members={members}'
-            # A class is one C++ variable, so a floor on any member raises all
-            # of them -- which is what makes the widening reach an alias.
-            if floors:
-                bounds += [floors[d] for d in members if d in floors]
             try:
                 class_storage[c] = aggregate_storage(bounds)
             except StorageSelectionError as e:

--- a/fpy2/backend/cpp/storage_infer.py
+++ b/fpy2/backend/cpp/storage_infer.py
@@ -33,23 +33,34 @@ numeric suffixes (``x_1``, ``x_2``, …).
 
 from collections import defaultdict
 from dataclasses import dataclass
+from functools import reduce
 
 from ...analysis import Definition
 from ...analysis.define_use import DefineUseAnalysis
 from ...analysis.format_infer import FormatBound
+from ...analysis.format_infer.analysis import (
+    ListFormat,
+    TupleFormat,
+    _join_bounds,
+)
 from ...analysis.reaching_defs import AssignDef, PhiDef
 from ...ast.fpyast import (
     Argument,
     Assign,
     Expr,
     ForStmt,
+    FuncDef,
+    IfExpr,
     IndexedAssign,
     ListComp,
+    ListExpr,
     ListRef,
     NamedId,
     Stmt,
+    TupleExpr,
     Var,
 )
+from ...ast.visitor import DefaultVisitor
 from ...utils import Unionfind
 from .storage import StorageSelectionError, aggregate_storage
 from .types import CppList, CppTuple, CppType
@@ -218,6 +229,189 @@ def _is_external(members: list[Definition]) -> bool:
     return False
 
 
+class _PlaceFloors(DefaultVisitor):
+    """Per-def lower bounds from the places each def's value reaches.
+
+    One place admits one C++ type.  :meth:`emitter._emit_at` builds a
+    *constructor* at the place's type, but a variable cannot be rebuilt that
+    way: changing a list's element type means a new buffer, and a shared list
+    cannot survive one — which is the refusal in ``_convert_storage``.  So raise
+    the variable's own storage instead, and there is nothing left to convert.
+
+    Lists only.  A scalar converts free at the point of use, so widening its
+    declaration would change a signature to no purpose.
+
+    The shape mirrors ``_emit_at`` deliberately: the same set of expressions
+    contribute to a place, and the two must agree about which.
+    """
+
+    def __init__(
+        self,
+        def_use: DefineUseAnalysis,
+        by_def: dict[Definition, FormatBound],
+        by_expr: dict[Expr, FormatBound],
+        ret_fmt: FormatBound,
+        base: 'StorageAnalysis',
+    ):
+        self.def_use = def_use
+        self.by_def = by_def
+        self.by_expr = by_expr
+        self.ret_fmt = ret_fmt
+        self.base = base
+        self.floors: dict[Definition, FormatBound] = {}
+        self.assigns: list[Assign] = []
+        self.changed = False
+
+    def _pinned(self, d: Definition) -> bool:
+        """Whether *d* has no storage of its own to raise.
+
+        The emitter binds some names as a ``const`` reference to storage that
+        already exists — ``ys = xs``, ``row = xss[i]``, a loop target.  Those are
+        spelled ``auto``, so raising one would make ``storage_of`` describe a
+        type the reference does not have and nothing would catch it until the
+        mismatch surfaced somewhere else.  ``allow_projection`` is on because
+        refusing to raise is the safe direction.
+
+        A *parameter* is also bound by reference but its type is spelled from
+        ``storage_of`` in the signature, so raising it does what it says — the
+        ABI changes, and ``signature()`` reports it.
+        """
+        if isinstance(d.site, Argument):
+            return False
+        return binds_by_reference(
+            self.base, self.def_use, d, allow_projection=True,
+        )
+
+    def _raise(self, d: Definition, fmt: FormatBound) -> None:
+        if self._pinned(d):
+            return
+        cur = self.floors.get(d)
+        raised = fmt if cur is None else _join_bounds(cur, fmt)
+        if raised != cur:
+            self.floors[d] = raised
+            self.changed = True
+
+    def _push(self, e: Expr, fmt: FormatBound) -> None:
+        if not isinstance(fmt, ListFormat):
+            return
+        match e:
+            case Var():
+                self._raise(self.def_use.find_def_from_use(e), fmt)
+            case ListExpr():
+                for elt in e.elts:
+                    self._push(elt, fmt.elt)
+            case ListComp():
+                self._push(e.elt, fmt.elt)
+            case IfExpr():
+                self._push(e.ift, fmt)
+                self._push(e.iff, fmt)
+
+    def _push_tuple(self, e: Expr, fmt: FormatBound) -> None:
+        """A tuple's fields are separate places, each with its own type."""
+        if isinstance(e, TupleExpr) and isinstance(fmt, TupleFormat):
+            if len(e.elts) == len(fmt.elts):
+                for elt, sub in zip(e.elts, fmt.elts):
+                    self._push_tuple(elt, sub)
+                    self._push(elt, sub)
+
+    def _visit_return(self, stmt, ctx):
+        super()._visit_return(stmt, ctx)
+        self._push(stmt.expr, self.ret_fmt)
+        self._push_tuple(stmt.expr, self.ret_fmt)
+
+    def _visit_list_expr(self, e: ListExpr, ctx):
+        super()._visit_list_expr(e, ctx)
+        fmt = self.by_expr.get(e)
+        if isinstance(fmt, ListFormat):
+            for elt in e.elts:
+                self._push(elt, fmt.elt)
+                self._push_tuple(elt, fmt.elt)
+
+    def _visit_tuple_expr(self, e: TupleExpr, ctx):
+        super()._visit_tuple_expr(e, ctx)
+        self._push_tuple(e, self.by_expr.get(e))
+
+    def _visit_if_expr(self, e: IfExpr, ctx):
+        super()._visit_if_expr(e, ctx)
+        fmt = self.by_expr.get(e)
+        self._push(e, fmt)
+        self._push_tuple(e, fmt)
+
+    def _visit_assign(self, stmt: Assign, ctx):
+        super()._visit_assign(stmt, ctx)
+        self.assigns.append(stmt)
+
+    # -- the other direction ------------------------------------------------
+
+    def _effective(self, e: Expr) -> FormatBound:
+        """*e*'s bound with the floors its leaves have picked up.
+
+        Raising a variable raises every container built from it: once ``base``
+        is a ``vector<double>``, ``scratch = [base]`` has to be a
+        ``vector<vector<double>>`` or the container's element type and the
+        variable's own declaration disagree — which is the same conflict one
+        level out.
+        """
+        match e:
+            case Var():
+                d = self.def_use.find_def_from_use(e)
+                own, floor = self.by_def.get(d), self.floors.get(d)
+                return own if floor is None else _join_bounds(own, floor)
+            case ListExpr() if e.elts:
+                elts = [self._effective(x) for x in e.elts]
+                return ListFormat(reduce(_join_bounds, elts))
+            case TupleExpr():
+                return TupleFormat(tuple(self._effective(x) for x in e.elts))
+            case ListComp():
+                return ListFormat(self._effective(e.elt))
+            case IfExpr():
+                return _join_bounds(
+                    self._effective(e.ift), self._effective(e.iff),
+                )
+        return self.by_expr.get(e)
+
+    def _propagate_up(self) -> None:
+        """Floor each assignment target by what its RHS now builds."""
+        for stmt in self.assigns:
+            if not isinstance(stmt.target, NamedId):
+                continue
+            try:
+                eff = self._effective(stmt.expr)
+            except RuntimeError:
+                continue          # incompatible kinds: not a widening question
+            if isinstance(eff, ListFormat | TupleFormat):
+                d = self.def_use.find_def_from_site(stmt.target, stmt)
+                self._raise(d, eff)
+
+
+def place_floors(
+    ast: FuncDef,
+    def_use: DefineUseAnalysis,
+    by_def: dict[Definition, FormatBound],
+    by_expr: dict[Expr, FormatBound],
+    ret_fmt: FormatBound,
+    base: 'StorageAnalysis',
+) -> dict[Definition, FormatBound]:
+    """See :class:`_PlaceFloors`.
+
+    *base* is the unraised storage analysis, needed only to tell which names the
+    emitter binds by reference — those have no storage to raise.
+
+    The two directions feed each other -- a place raises a variable, a raised
+    variable raises the container holding it -- so iterate.  Bounds only ever
+    rise and the ladder is finite, so this settles; the cap is a backstop.
+    """
+    v = _PlaceFloors(def_use, by_def, by_expr, ret_fmt, base)
+    v._visit_function(ast, None)
+    for _ in range(8):
+        if not v.changed:
+            break
+        v.changed = False
+        v._visit_function(ast, None)
+        v._propagate_up()
+    return v.floors
+
+
 def _is_in_place_assign(d: AssignDef) -> bool:
     """Does *d* come from an in-place ``IndexedAssign`` (``xs[i] = e``)?
 
@@ -244,6 +438,7 @@ class StorageInfer:
     def infer(
         def_use: DefineUseAnalysis,
         def_to_bound: dict[Definition, FormatBound],
+        floors: dict[Definition, FormatBound] | None = None,
     ) -> StorageAnalysis:
         """
         Build a :class:`StorageAnalysis` from def-use info and per-def
@@ -253,6 +448,10 @@ class StorageInfer:
             def_use:      def-use analysis result for the function.
             def_to_bound: format bound for each SSA def (typically
                           ``format_info.by_def``).
+            floors:       per-def lower bounds from the places each def
+                          reaches, from :func:`place_floors`.  A storage
+                          decision, not a format one: the bounds themselves
+                          stay exactly as the analysis reported them.
 
         Returns:
             A :class:`StorageAnalysis` carrying the per-def C++ name and
@@ -299,6 +498,10 @@ class StorageInfer:
         for c, members in class_members.items():
             bounds = [def_to_bound[d] for d in members if d in def_to_bound]
             assert bounds, f'no format bounds for class {c} members={members}'
+            # A class is one C++ variable, so a floor on any member raises all
+            # of them -- which is what makes the widening reach an alias.
+            if floors:
+                bounds += [floors[d] for d in members if d in floors]
             try:
                 class_storage[c] = aggregate_storage(bounds)
             except StorageSelectionError as e:

--- a/fpy2/backend/cpp/storage_infer.py
+++ b/fpy2/backend/cpp/storage_infer.py
@@ -375,12 +375,12 @@ class _PlaceFloors(DefaultVisitor):
         for stmt in self.assigns:
             if not isinstance(stmt.target, NamedId):
                 continue
+            d = self.def_use.find_def_from_site(stmt.target, stmt)
             try:
                 eff = self._effective(stmt.expr)
             except RuntimeError:
                 continue          # incompatible kinds: not a widening question
             if isinstance(eff, ListFormat | TupleFormat):
-                d = self.def_use.find_def_from_site(stmt.target, stmt)
                 self._raise(d, eff)
 
 
@@ -402,13 +402,13 @@ def place_floors(
     rise and the ladder is finite, so this settles; the cap is a backstop.
     """
     v = _PlaceFloors(def_use, by_def, by_expr, ret_fmt, base)
-    v._visit_function(ast, None)
+    v._visit_function(ast, None)          # collects the assignments to revisit
     for _ in range(8):
+        v.changed = False
+        v._visit_function(ast, None)      # places -> the defs reaching them
+        v._propagate_up()                 # defs -> containers and aliases
         if not v.changed:
             break
-        v.changed = False
-        v._visit_function(ast, None)
-        v._propagate_up()
     return v.floors
 
 

--- a/fpy2/backend/cpp/storage_infer.py
+++ b/fpy2/backend/cpp/storage_infer.py
@@ -298,11 +298,11 @@ class _PlaceFloors(DefaultVisitor):
           makes ``storage_of`` describe a type the reference does not have, and
           the ``auto`` hides it until the mismatch surfaces somewhere else.
 
-        The one exception is a parameter of a function compiled code calls: its
-        caller's argument type is already fixed, so raising it underneath emits
-        a call that does not compile.  Same rule ``unbox`` states for
-        representations — a function compiled code calls keeps its signature on
-        both sides.  A native caller is not bound by that.
+        One exception: a parameter of a function compiled code *calls*.  Its
+        caller's argument type is already fixed, so raising it underneath emits a
+        call that does not compile — the rule ``unbox`` states for
+        representations, that a called function keeps its signature on both
+        sides.  A native caller is not bound by it.
         """
         if isinstance(d.site, Argument):
             return self.is_called
@@ -546,25 +546,18 @@ def place_floors(
     base: 'StorageAnalysis',
     is_called: bool = False,
 ) -> dict[Definition, FormatBound]:
-    """See :class:`_PlaceFloors`.
+    """See :class:`_PlaceFloors`.  *base* is the unraised storage analysis, used
+    only to tell which names the emitter binds by reference.
 
-    *base* is the unraised storage analysis, needed only to tell which names the
-    emitter binds by reference — those have no storage to raise.
+    The two directions feed each other — a place raises a variable, a raised
+    variable raises the container built from it — so iterate.  One round per
+    statement suffices: a place's own bound is fixed, so every floor originates
+    in the first round and later rounds only carry it along one edge.  The
+    corpus settles in one or two.
 
-    The two directions feed each other -- a place raises a variable, a raised
-    variable raises the container holding it -- so iterate to a fixpoint.
-
-    It terminates in at most one round per assignment.  A place's own bound is
-    fixed (it comes from ``by_expr`` / ``ret_fmt``, which this does not touch),
-    so every floor originates in the first round and later rounds only carry it
-    along assignment edges -- and a chain of those is no longer than the number
-    of assignments.  One extra round detects that nothing moved.
-
-    Measured over the corpus: 175 functions settle in one round, 44 in two, and
-    the largest has 34 assignments.  So the bound is slack by a wide margin,
-    which is why it asserts rather than breaking: falling out of this loop with
-    work left would return a *partial* answer, and an under-raised definition
-    reappears later as a type disagreement the emitter has to refuse.
+    Asserts rather than breaking: leaving the loop with work outstanding would
+    return a *partial* answer, and an under-raised definition resurfaces as a
+    type disagreement the emitter has to refuse.
     """
     v = _PlaceFloors(def_use, by_def, by_expr, ret_fmt, base, is_called)
     v._visit_function(ast, None)          # collects the assignments to revisit

--- a/fpy2/backend/cpp/unbox.py
+++ b/fpy2/backend/cpp/unbox.py
@@ -28,8 +28,15 @@ costs 5 of the 50 functions with a list parameter — the kernels worth unboxing
 entry points a *native* caller invokes, and a native caller is not bound by this.
 
 Refusal means keeping the handle, never failing a compile; reasons are recorded in
-:attr:`UnboxAnalysis.boxed_because`.  A list inside a tuple is always refused:
-:func:`_read` walks only the ``CppList`` spine and cannot reach one.
+:attr:`UnboxAnalysis.boxed_because`.
+
+A list inside a tuple is decided like any other, and :func:`_stamp` is the *only*
+place any of it is decided — for an expression, for the return type, and for a
+storage class's declaration.  There used to be a second traversal for the
+declaration that did not descend into tuples, so ``t = [y, y], 1.0; return t``
+declared ``std::tuple<fpy::list<T>, …>`` and returned
+``std::tuple<std::vector<T>, …>``, which does not compile.  Keep it one
+traversal.
 """
 
 from dataclasses import dataclass, field
@@ -159,9 +166,27 @@ class UnboxAnalysis:
 
         return self._stamp(ty, at, 0)
 
-    def _stamp(self, ty: CppType, regions_at, depth: int) -> CppType:
+    def _stamp(
+        self, ty: CppType, regions_at, depth: int,
+        cls: Definition | None = None,
+    ) -> CppType:
         """*ty* with a representation for each list level, following tuple
-        fields too — a list inside a tuple is decided like any other."""
+        fields too — a list inside a tuple is decided like any other.
+
+        The single place a representation is chosen.  It is used for an
+        expression (:meth:`annotate`), for the return type
+        (:meth:`annotate_return`), and for a storage class's declaration —
+        which must agree, or a variable is declared as one thing and handed
+        over as another.  They did not always: a second traversal used to
+        produce the declaration and it did not descend into tuples, so
+        ``t = [y, y], 1.0; return t`` declared a boxed field and returned an
+        unboxed one.
+
+        *cls* records why a level kept its handle, for a storage class.  Only
+        down the list spine: ``boxed_because`` is keyed by depth, so two list
+        fields of one tuple would collide, and nothing consumes a reason for a
+        tuple field.
+        """
         if isinstance(ty, CppTuple):
             return CppTuple(
                 self._stamp(
@@ -172,10 +197,20 @@ class UnboxAnalysis:
             )
         if not isinstance(ty, CppList):
             return ty
-        elt = self._stamp(ty.elt, regions_at, depth + 1)
+        elt = self._stamp(ty.elt, regions_at, depth + 1, cls)
         regions = regions_at(depth)
         boxed = not regions or any(self.boxed.get(r, True) for r in regions)
+        if boxed and cls is not None:
+            self.boxed_because[(cls, depth)] = self._reason(regions)
         return CppList(elt, boxed=boxed)
+
+    def _reason(self, regions: set[Region]) -> str:
+        """Why a level kept its handle."""
+        if not regions:
+            return 'no alias information'
+        if any(r in self.at_boundary for r in regions):
+            return 'reached across a boundary'
+        return 'shared'
 
 
 class Unbox:
@@ -229,10 +264,13 @@ class Unbox:
         # 2. a called function keeps a parameter's handle only where it
         #    *retains* it; its callers read the same summary, so both ends
         #    reach the same answer.
+        # A tuple is here too: it may hold a list, and that list's
+        # representation has to be decided or the declaration and the return
+        # type disagree about it.
         classes = [
             (cls, _regions(cls, storage, alias))
             for cls, ty in storage.class_storage.items()
-            if isinstance(ty, CppList)
+            if isinstance(ty, CppList | CppTuple)
         ]
         if is_called:
             for cls, per_depth in classes:
@@ -260,10 +298,12 @@ class Unbox:
                             out.boxed[r] = True
                             changed = True
 
-        # 5. read the decision back out per class
+        # 5. read the decision back out per class -- through the same
+        #    traversal `annotate` and `annotate_return` use, so a variable's
+        #    declaration cannot disagree with what is handed through it.
         for cls, per_depth in classes:
             ty = storage.class_storage[cls]
-            out.storage[cls] = _read(ty, per_depth, cls, out, 0)
+            out.storage[cls] = out._stamp(ty, _at_depth(per_depth), 0, cls)
         return out
 
 
@@ -277,11 +317,15 @@ def _regions(
     ``alias._merge_redefinitions`` unions on exactly those two, so a class
     cannot span regions that could answer differently.  Taking a conjunction
     over several would silently repair a violation of that; this reports it.
+
+    A tuple contributes its own region and stops: :func:`_stamp` descends into
+    its fields with :func:`_fields`, which needs the tuple's region rather than
+    a per-depth entry of its own.
     """
     ty = storage.class_storage[cls]
     per_depth: list[Region | None] = []
     depth = 0
-    while isinstance(ty, CppList):
+    while isinstance(ty, CppList | CppTuple):
         found = {
             r for d in storage.class_members[cls]
             if (r := alias.region_of(d, depth)) is not None
@@ -292,6 +336,8 @@ def _regions(
             f'analysis does not mirror'
         )
         per_depth.append(found.pop() if found else None)
+        if isinstance(ty, CppTuple):
+            break
         ty, depth = ty.elt, depth + 1
     return per_depth
 
@@ -303,26 +349,16 @@ def _fields(alias: AliasAnalysis, regions: set[Region], i: int) -> set[Region]:
     }
 
 
-def _read(
-    ty: CppType,
-    per_depth: list[Region | None],
-    cls: Definition,
-    out: UnboxAnalysis,
-    depth: int,
-) -> CppType:
-    if not isinstance(ty, CppList):
-        return ty
-    elt = _read(ty.elt, per_depth, cls, out, depth + 1)
-    region = per_depth[depth]
-    if region is None:
-        out.boxed_because[(cls, depth)] = 'no alias information'
-    elif region in out.at_boundary:
-        out.boxed_because[(cls, depth)] = 'reached across a boundary'
-    elif out.boxed.get(region, True):
-        out.boxed_because[(cls, depth)] = 'shared'
-    else:
-        return CppList(elt, boxed=False)
-    return CppList(elt, boxed=True)
+def _at_depth(per_depth: list[Region | None]):
+    """A ``regions_at`` callback over a storage class's per-depth regions.
+
+    :func:`_stamp`'s other callers key off an expression or the return group;
+    this is the same interface over a class, so all three share one traversal.
+    """
+    def at(depth: int) -> set[Region]:
+        r = per_depth[depth] if depth < len(per_depth) else None
+        return set() if r is None else {r}
+    return at
 
 
 def _parameter_index(ast: FuncDef, members: list[Definition]) -> int | None:

--- a/fpy2/transform/reduce_fusion.py
+++ b/fpy2/transform/reduce_fusion.py
@@ -30,9 +30,9 @@ already-built list.
 Only the boolean reductions are fused.  ``Sum`` / ``AMin`` / ``AMax`` pay the
 same allocation cost, but fusing them is blocked on the cpp emitter accepting
 an implicit narrowing inside ``std::accumulate`` that it rejects at an
-ordinary assignment; see ``docs/todos/reduce-fusion.md``.  Multi-stage
-comprehensions (``[e for a in xs for b in ys]``) would need nested loops and
-are left alone.
+ordinary assignment; tracked under "Open TODOs" in ``docs/todos/backend-cpp.md``,
+where the blocker lives.  Multi-stage comprehensions
+(``[e for a in xs for b in ys]``) would need nested loops and are left alone.
 """
 
 import dataclasses

--- a/fpy2/utils/location.py
+++ b/fpy2/utils/location.py
@@ -32,4 +32,4 @@ class Location:
         return self.__key() == other.__key()
 
     def format(self):
-        return f'`{self.source}:{self.start_line}:{self.start_column}'
+        return f'`{self.source}:{self.start_line}:{self.start_column}`'

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -1903,7 +1903,7 @@ def _test_generated(
         print(f'     known divergence: {note}')
     for note in refused:
         print(f'     not compared: {note}')
-    # A `-k` run tests a subset on purpose, so the floors do not apply.
+    # A `-k` run tests a subset on purpose, so the minimums below do not apply.
     if _select is not None:
         return failures
     if stats.get('nonempty', 0) < 200:

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -1809,13 +1809,14 @@ _GEN_FORMATS = (fp.FP32, fp.FP64)
 # fix cannot leave a stale suppression behind.  That is how this one survived
 # unnoticed in the first place.
 _generated_xfail: dict[str, str] = {
-    # `ys = xs; ys[0] = y` where `y` is wider than `xs`'s elements.  The two
-    # names are one list, so after the store it holds an FP64 value and
-    # `xs[0]` is FP64 -- but `format_infer` widens only `ys`'s def and reports
-    # `ret_fmt` as FP32, which no binary32 can hold.  The backend implements
-    # that faithfully and truncates.  Unsound in the analysis, not in codegen;
-    # see docs/todos/format-infer-aliasing.md.
-    '_gen_alias_then_mutate[32_64]': 'format_infer ignores list aliasing',
+    # Empty, and worth keeping that way: an entry here says the compiler
+    # produces a *wrong answer* for some instantiation, which the correctness
+    # criterion does not allow.  A shape the backend cannot handle belongs in
+    # the "not compared" list below -- refused, not divergent.
+    #
+    # Note a refusal never reaches the strict check, so an entry that starts
+    # being refused rather than diverging goes stale silently.  Re-read this
+    # list when a refusal appears for something listed here.
 }
 
 

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -447,6 +447,16 @@ def _cpp_value(value, cty) -> str:
             # error even though the value is representable.
             t = cty.format()
             v = float(value)
+            if not cty.is_float():
+                # An integral `numeric_limits` has no NaN or infinity —
+                # `quiet_NaN()` returns 0 — so a driver built this way would
+                # pass 0 and the mismatch would read as agreement.  Unreachable
+                # today (no emitted signature narrows a *parameter* to an
+                # integer), so refuse rather than guess.
+                raise ValueError(
+                    f'cannot build a driver value for integer storage {t}: '
+                    f'{value!r} (see _cpp_value)'
+                )
             if math.isnan(v):
                 return f'std::numeric_limits<{t}>::quiet_NaN()'
             if math.isinf(v):
@@ -558,6 +568,7 @@ def _build_and_run(cpp_path: Path) -> str:
 def _run_and_check(
     output_dir: Path, prefix: str, compiler: fp.CppCompiler, func: fp.Function,
     *, ctx=fp.FP64, arg_types: list | None = None, suffix: str = '',
+    stats: dict | None = None,
 ) -> str | None:
     """Run *func* through the interpreter and the compiled binary on the
     same synthesized inputs and compare bit-for-bit.  Returns ``None`` on
@@ -608,6 +619,16 @@ def _run_and_check(
             except Exception:
                 continue
             samples.append((inputs, expected))
+
+    if stats is not None:
+        # How much was actually compared, not just how many programs ran: a
+        # caller's coverage floor is meaningless if every surviving sample
+        # happens to pass an empty list.
+        stats['samples'] = stats.get('samples', 0) + len(samples)
+        stats['nonempty'] = stats.get('nonempty', 0) + sum(
+            1 for inputs, _ in samples
+            if any(isinstance(v, list) and v for v in inputs)
+        )
 
     if not samples:
         return 'skip'
@@ -1794,75 +1815,104 @@ _generated_xfail: dict[str, str] = {
     # `ret_fmt` as FP32, which no binary32 can hold.  The backend implements
     # that faithfully and truncates.  Unsound in the analysis, not in codegen;
     # see docs/todos/format-infer-aliasing.md.
-    '_gen_alias_then_mutate[32_32_64]': 'format_infer ignores list aliasing',
-    '_gen_alias_then_mutate[64_32_64]': 'format_infer ignores list aliasing',
+    '_gen_alias_then_mutate[32_64]': 'format_infer ignores list aliasing',
 }
 
 
 def _test_generated(
     output_dir: Path, mode: str = 'compile',
 ) -> list[tuple[str, str, str]]:
-    """Execute each shape at every combination of list-element format, scalar
-    format, and outer context, bit-comparing against the interpreter.
+    """Execute each shape at every combination of list-element and scalar
+    format, bit-comparing against the interpreter.
 
     Skipped outside ``run`` mode: the point is the comparison, and
     ``test_generated_typecheck.py`` already covers emission over a wider matrix.
     A *refusal* is a legitimate answer here too -- a shared list cannot change
-    element type -- so a ``CppCompileError`` is recorded, not failed.
+    element type -- so a ``CppCompileError`` is recorded, not failed.  Refusals
+    are printed: a shape quietly regressing into one is a loss of coverage that
+    no failure count would show.
+
+    There is deliberately no outer-context axis.  Every shape pins its context
+    with ``with fp.FP64:``, so varying it produced byte-identical programs and
+    only inflated the counts.  Making it mean something needs two changes
+    together -- drop the ``with`` from some shapes *and* pass ``ctx`` into
+    ``_interp``, which hardcodes ``fp.FP64`` -- or the oracle and the binary
+    disagree for a reason that is not a bug.
     """
     if mode != 'run' or _CXX is None:
         return []
     compiler = fp.CppCompiler(unsafe_cast_int=True)
     failures: list[tuple[str, str, str]] = []
     xfailed: list[str] = []
+    refused: list[str] = []
+    stats: dict[str, int] = {}
     ran = 0
     for func, sig, n_scalars in _generated_funcs:
         if not _selected(func.name):
             continue
-        for ctx in _GEN_FORMATS:
-            for elt_fmt in _GEN_FORMATS:
-                for scalar_fmt in _GEN_FORMATS:
-                    elt = fp.types.RealType(elt_fmt)
-                    lst = (
-                        fp.types.ListType(elt) if sig == 'flat'
-                        else fp.types.ListType(fp.types.ListType(elt))
+        for elt_fmt in _GEN_FORMATS:
+            for scalar_fmt in _GEN_FORMATS:
+                elt = fp.types.RealType(elt_fmt)
+                lst = (
+                    fp.types.ListType(elt) if sig == 'flat'
+                    else fp.types.ListType(fp.types.ListType(elt))
+                )
+                arg_types = [
+                    lst,
+                    *[fp.types.RealType(scalar_fmt)] * n_scalars,
+                ]
+                tag = f'{elt_fmt.nbits}_{scalar_fmt.nbits}'
+                label = f'{func.name}[{tag}]'
+                try:
+                    err = _run_and_check(
+                        output_dir, 'generated', compiler, func,
+                        arg_types=arg_types, suffix=tag, stats=stats,
                     )
-                    arg_types = [
-                        lst,
-                        *[fp.types.RealType(scalar_fmt)] * n_scalars,
-                    ]
-                    tag = f'{ctx.nbits}_{elt_fmt.nbits}_{scalar_fmt.nbits}'
-                    label = f'{func.name}[{tag}]'
-                    try:
-                        err = _run_and_check(
-                            output_dir, 'generated', compiler, func,
-                            ctx=ctx, arg_types=arg_types, suffix=tag,
-                        )
-                    except fp.backend.CppCompileError:
-                        continue      # a refusal is an answer, not a failure
-                    except Exception as e:
-                        failures.append(('generated', label, str(e)))
-                        continue
-                    if err == 'skip':
-                        continue
-                    known = _generated_xfail.get(label)
-                    if known is not None:
-                        if err is None:
-                            failures.append((
-                                'generated', label,
-                                f'now agrees with the interpreter -- remove the '
-                                f'_generated_xfail entry ({known})',
-                            ))
-                        else:
-                            xfailed.append(f'{label}: {known}')
-                        continue
-                    if err is not None:
-                        failures.append(('generated', label, err))
+                except fp.backend.CppCompileError as e:
+                    # A refusal is an answer, not a failure -- but say so.
+                    refused.append(f'{label}: {str(e).split(": ")[-1][:70]}')
+                    continue
+                except Exception as e:
+                    failures.append(('generated', label, str(e)))
+                    continue
+                if err == 'skip':
+                    refused.append(f'{label}: no sample the interpreter accepts')
+                    continue
+                known = _generated_xfail.get(label)
+                if known is not None:
+                    if err is None:
+                        failures.append((
+                            'generated', label,
+                            f'now agrees with the interpreter -- remove the '
+                            f'_generated_xfail entry ({known})',
+                        ))
                     else:
-                        ran += 1
-    print(f'=== generated format matrix: {ran} instantiations bit-compared ===')
+                        xfailed.append(f'{label}: {known}')
+                    continue
+                if err is not None:
+                    failures.append(('generated', label, err))
+                else:
+                    ran += 1
+    print(
+        f'=== generated format matrix: {ran} instantiations, '
+        f'{stats.get("samples", 0)} samples bit-compared '
+        f'({stats.get("nonempty", 0)} with a non-empty list) ==='
+    )
     for note in xfailed:
         print(f'     known divergence: {note}')
+    for note in refused:
+        print(f'     not compared: {note}')
+    # A `-k` run tests a subset on purpose, so the floors do not apply.
+    if _select is not None:
+        return failures
+    if stats.get('nonempty', 0) < 200:
+        failures.append((
+            'generated', '<coverage>',
+            f'only {stats.get("nonempty", 0)} samples with a non-empty list '
+            f'were compared; the counts above can stay high while every '
+            f'comparison is on an empty list, which touches none of the '
+            f'join/widening/aliasing behaviour this stage exists for',
+        ))
     if ran < 20:
         failures.append((
             'generated', '<coverage>',

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -376,6 +376,31 @@ def _rand_value(ty, rng: random.Random, list_len: int, int_mode: bool):
             raise ValueError(f'cannot generate input for type: {ty.format()}')
 
 
+def _round_to_format(value, ty):
+    """*value*, rounded to whatever format *ty* declares.
+
+    The driver declares each parameter at the backend's storage type, so an
+    FP32 parameter rounds whatever literal it is handed — while the interpreter
+    would keep the value unrounded.  The two would then disagree for a reason
+    that is not a bug.  Rounding here means both sides start from the same
+    number.
+
+    Identity for FP64, which is every corpus program: the pool is already
+    binary64, and the round preserves ``-0.0`` and NaN.
+    """
+    match ty:
+        case fp.types.RealType():
+            return float(ty.ctx.round(value))
+        case fp.types.ListType():
+            return [_round_to_format(v, ty.elt) for v in value]
+        case fp.types.TupleType():
+            return tuple(
+                _round_to_format(v, t) for v, t in zip(value, ty.elts)
+            )
+        case _:
+            return value
+
+
 def _cpp_type(ty) -> str:
     """C++ storage type for an (instantiated) argument type — must match the
     backend's choice (FP64 real -> ``double``, etc.)."""
@@ -416,16 +441,23 @@ def _cpp_value(value, cty) -> str:
         case CppScalar.BOOL:
             return 'true' if value else 'false'
         case _:
+            # Spelled at the *target* scalar, not at ``double``: these go inside
+            # braced initializers, which reject a narrowing conversion.  A
+            # `double` infinity handed to a `std::vector<float>{...}` is a hard
+            # error even though the value is representable.
+            t = cty.format()
             v = float(value)
             if math.isnan(v):
-                return 'std::numeric_limits<double>::quiet_NaN()'
+                return f'std::numeric_limits<{t}>::quiet_NaN()'
             if math.isinf(v):
-                inf = 'std::numeric_limits<double>::infinity()'
+                inf = f'std::numeric_limits<{t}>::infinity()'
                 return f'-{inf}' if v < 0 else inf
             # ``repr`` is the shortest round-tripping decimal; C++ parses it
             # (correctly-rounded) to the identical double.  Decimal — not a
-            # hex-float literal — keeps the driver valid under C++11.
-            return repr(v)
+            # hex-float literal — keeps the driver valid under C++11.  A cast
+            # for a narrower target, for the same braced-init reason; the value
+            # is representable there (see ``_round_to_format``), so it is exact.
+            return repr(v) if t == 'double' else f'static_cast<{t}>({repr(v)})'
 
 
 def _cpp_literal(value, ty) -> str:
@@ -458,6 +490,7 @@ def _cpp_literal(value, ty) -> str:
 def _emit_driver(
     output_dir: Path, prefix: str, compiler: fp.CppCompiler,
     func: fp.Function, arg_types: list, samples: list,
+    ctx=fp.FP64, suffix: str = '',
 ) -> Path:
     """Write a self-contained translation unit: headers, helpers, the
     compiled function, and a ``main`` that calls it once per sample and
@@ -465,12 +498,15 @@ def _emit_driver(
 
     *samples* is a list of ``(inputs, expected)``; each ``inputs`` is the
     list of Python argument values to pass (empty for a nullary function).
+
+    *suffix* distinguishes several instantiations of one function, which
+    otherwise hash to the same file name.
     """
-    name = hashlib.md5(func.name.encode()).hexdigest()
+    name = hashlib.md5((func.name + suffix).encode()).hexdigest()
     cpp_path = output_dir / f'{prefix}_{name}_run.cpp'
-    body = compiler.compile(func, ctx=fp.FP64, arg_types=arg_types)
+    body = compiler.compile(func, ctx=ctx, arg_types=arg_types)
     params, ret_ty = compiler.signature(
-        func, ctx=fp.FP64, arg_types=arg_types,
+        func, ctx=ctx, arg_types=arg_types,
     )
     counter = [0]
     main_lines = ['int main() {']
@@ -521,13 +557,21 @@ def _build_and_run(cpp_path: Path) -> str:
 
 def _run_and_check(
     output_dir: Path, prefix: str, compiler: fp.CppCompiler, func: fp.Function,
+    *, ctx=fp.FP64, arg_types: list | None = None, suffix: str = '',
 ) -> str | None:
     """Run *func* through the interpreter and the compiled binary on the
     same synthesized inputs and compare bit-for-bit.  Returns ``None`` on
     agreement, an error string on mismatch, or ``'skip'`` when the
-    interpreter rejects every sampled input (nothing to compare against)."""
-    ty_info = fp.analysis.TypeInfer.check(func.ast)
-    arg_types = [_inst_type(ty) for ty in ty_info.arg_types]
+    interpreter rejects every sampled input (nothing to compare against).
+
+    *arg_types* overrides the default all-FP64 instantiation, so a caller can
+    execute a program whose lists are at some other format — a shape no corpus
+    program has.  Inputs are rounded to whatever formats it declares; see
+    :func:`_round_to_format`.
+    """
+    if arg_types is None:
+        ty_info = fp.analysis.TypeInfer.check(func.ast)
+        arg_types = [_inst_type(ty) for ty in ty_info.arg_types]
 
     # Generate deterministic samples; keep only those the oracle accepts so
     # the compiled binary is never run on inputs the interpreter rejects.
@@ -536,7 +580,10 @@ def _run_and_check(
     for k in range(n):
         # `lseed=k` is shared across args (paired lists stay equal-length);
         # `vseed=k + i` decorrelates values between argument positions.
-        inputs = [_gen_value(ty, k + i, k) for i, ty in enumerate(arg_types)]
+        inputs = [
+            _round_to_format(_gen_value(ty, k + i, k), ty)
+            for i, ty in enumerate(arg_types)
+        ]
         try:
             expected = _interp(func, inputs)
         except Exception:
@@ -550,7 +597,12 @@ def _run_and_check(
         rng = random.Random(0)
         for s in range(_RANDOM_SAMPLES):
             list_len = rng.randint(0, _MAX_RANDOM_LEN)
-            inputs = [_rand_value(ty, rng, list_len, s % 2 == 0) for ty in arg_types]
+            inputs = [
+                _round_to_format(
+                    _rand_value(ty, rng, list_len, s % 2 == 0), ty,
+                )
+                for ty in arg_types
+            ]
             try:
                 expected = _interp(func, inputs)
             except Exception:
@@ -560,7 +612,10 @@ def _run_and_check(
     if not samples:
         return 'skip'
 
-    driver = _emit_driver(output_dir, prefix, compiler, func, arg_types, samples)
+    driver = _emit_driver(
+        output_dir, prefix, compiler, func, arg_types, samples,
+        ctx=ctx, suffix=suffix,
+    )
     out = _build_and_run(driver)
     lines = [ln for ln in out.splitlines() if ln.strip()]
     if len(lines) != len(samples):
@@ -1629,6 +1684,196 @@ def _test_regressions(
     )
 
 ###########################################################
+# Generated format matrix
+#
+# Every function above is instantiated at FP64, because `_inst_type` is what
+# fills in a free `Real`.  So no executed program has ever had a list at
+# another format -- and the join/widening machinery in `storage_infer` and
+# `emitter._emit_at` exists precisely to reconcile two formats meeting at one
+# place.  `tests/unit/backend/cpp/test_generated_typecheck.py` covers the same
+# matrix for *ill-typed emission*; this covers it for *wrong answers*, which is
+# the class only execution can catch.
+
+
+@fp.fpy
+def _gen_return_param_or_literal(
+    xs: list[fp.Real], c: fp.Real, y: fp.Real,
+) -> list[fp.Real]:
+    with fp.FP64:
+        if c > 0:
+            return xs
+        else:
+            return [y]
+
+
+@fp.fpy
+def _gen_ternary_param(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        zs = xs if c > 0 else [y, y]
+        return zs[0]
+
+
+@fp.fpy
+def _gen_write_then_return(
+    xs: list[fp.Real], c: fp.Real, y: fp.Real,
+) -> list[fp.Real]:
+    with fp.FP64:
+        if c > 0:
+            xs[0] = y
+        return xs
+
+
+@fp.fpy
+def _gen_nested_param_sum(xss: list[list[fp.Real]], y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        acc = y
+        for row in xss:
+            for x in row:
+                acc = acc + x
+        return acc
+
+
+@fp.fpy
+def _gen_row_write(xss: list[list[fp.Real]], y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        xss[0][0] = y
+        return xss[0][0]
+
+
+@fp.fpy
+def _gen_alias_then_mutate(xs: list[fp.Real], y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        ys = xs
+        ys[0] = y
+        return xs[0]
+
+
+@fp.fpy
+def _gen_list_into_tuple(xs: list[fp.Real], y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        t = (xs, y)
+        zs = fp.fst(t)
+        zs[0] = y
+        return xs[0]
+
+
+@fp.fpy
+def _gen_comprehension_of_rows(
+    xss: list[list[fp.Real]], y: fp.Real,
+) -> fp.Real:
+    with fp.FP64:
+        rows = [row for row in xss]
+        rows[0][0] = y
+        return xss[0][0]
+
+
+# ``'flat'`` takes one ``list[Real]``, ``'nested'`` one ``list[list[Real]]``;
+# the remaining parameters are scalars, in declaration order.
+_generated_funcs: list[tuple[fp.Function, str, int]] = [
+    (_gen_return_param_or_literal, 'flat', 2),
+    (_gen_ternary_param, 'flat', 2),
+    (_gen_write_then_return, 'flat', 2),
+    (_gen_nested_param_sum, 'nested', 1),
+    (_gen_row_write, 'nested', 1),
+    (_gen_alias_then_mutate, 'flat', 1),
+    (_gen_list_into_tuple, 'flat', 1),
+    (_gen_comprehension_of_rows, 'nested', 1),
+]
+
+_GEN_FORMATS = (fp.FP32, fp.FP64)
+
+# Instantiations known to disagree with the interpreter, keyed by label so the
+# *other* combinations of the same shape still run -- this shape passes at 6 of
+# its 8.  Strict: an entry that starts agreeing is reported as a failure, so a
+# fix cannot leave a stale suppression behind.  That is how this one survived
+# unnoticed in the first place.
+_generated_xfail: dict[str, str] = {
+    # `ys = xs; ys[0] = y` where `y` is wider than `xs`'s elements.  The two
+    # names are one list, so after the store it holds an FP64 value and
+    # `xs[0]` is FP64 -- but `format_infer` widens only `ys`'s def and reports
+    # `ret_fmt` as FP32, which no binary32 can hold.  The backend implements
+    # that faithfully and truncates.  Unsound in the analysis, not in codegen;
+    # see docs/todos/format-infer-aliasing.md.
+    '_gen_alias_then_mutate[32_32_64]': 'format_infer ignores list aliasing',
+    '_gen_alias_then_mutate[64_32_64]': 'format_infer ignores list aliasing',
+}
+
+
+def _test_generated(
+    output_dir: Path, mode: str = 'compile',
+) -> list[tuple[str, str, str]]:
+    """Execute each shape at every combination of list-element format, scalar
+    format, and outer context, bit-comparing against the interpreter.
+
+    Skipped outside ``run`` mode: the point is the comparison, and
+    ``test_generated_typecheck.py`` already covers emission over a wider matrix.
+    A *refusal* is a legitimate answer here too -- a shared list cannot change
+    element type -- so a ``CppCompileError`` is recorded, not failed.
+    """
+    if mode != 'run' or _CXX is None:
+        return []
+    compiler = fp.CppCompiler(unsafe_cast_int=True)
+    failures: list[tuple[str, str, str]] = []
+    xfailed: list[str] = []
+    ran = 0
+    for func, sig, n_scalars in _generated_funcs:
+        if not _selected(func.name):
+            continue
+        for ctx in _GEN_FORMATS:
+            for elt_fmt in _GEN_FORMATS:
+                for scalar_fmt in _GEN_FORMATS:
+                    elt = fp.types.RealType(elt_fmt)
+                    lst = (
+                        fp.types.ListType(elt) if sig == 'flat'
+                        else fp.types.ListType(fp.types.ListType(elt))
+                    )
+                    arg_types = [
+                        lst,
+                        *[fp.types.RealType(scalar_fmt)] * n_scalars,
+                    ]
+                    tag = f'{ctx.nbits}_{elt_fmt.nbits}_{scalar_fmt.nbits}'
+                    label = f'{func.name}[{tag}]'
+                    try:
+                        err = _run_and_check(
+                            output_dir, 'generated', compiler, func,
+                            ctx=ctx, arg_types=arg_types, suffix=tag,
+                        )
+                    except fp.backend.CppCompileError:
+                        continue      # a refusal is an answer, not a failure
+                    except Exception as e:
+                        failures.append(('generated', label, str(e)))
+                        continue
+                    if err == 'skip':
+                        continue
+                    known = _generated_xfail.get(label)
+                    if known is not None:
+                        if err is None:
+                            failures.append((
+                                'generated', label,
+                                f'now agrees with the interpreter -- remove the '
+                                f'_generated_xfail entry ({known})',
+                            ))
+                        else:
+                            xfailed.append(f'{label}: {known}')
+                        continue
+                    if err is not None:
+                        failures.append(('generated', label, err))
+                    else:
+                        ran += 1
+    print(f'=== generated format matrix: {ran} instantiations bit-compared ===')
+    for note in xfailed:
+        print(f'     known divergence: {note}')
+    if ran < 20:
+        failures.append((
+            'generated', '<coverage>',
+            f'only {ran} instantiations executed; the matrix has stopped '
+            f'covering anything (refusals and skips are not failures, so this '
+            f'check is what keeps the stage honest)',
+        ))
+    return failures
+
+
+###########################################################
 # Name filter
 
 _select: 're.Pattern[str] | None' = None
@@ -1699,6 +1944,7 @@ def test_compile_cpp(delete: bool = True, mode: str = 'compile'):
     failures += _test_libraries(output_dir, mode=mode)
     failures += _test_regressions(output_dir, mode=mode, cov=cov)
     failures += _test_typed_regressions(output_dir, mode=mode)
+    failures += _test_generated(output_dir, mode=mode)
 
     if delete:
         shutil.rmtree(output_dir)

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1392,6 +1392,73 @@ class TestFormatInfer:
             f'expected REAL_FORMAT among s bounds with widening, got {s_bounds}'
         )
 
+    def test_literal_bound_reports_a_format_only_for_a_signed_zero(self):
+        """``_literal_bound`` may only answer ``FP32`` for a value ``FP32``
+        contains.
+
+        A signed zero is the one literal value ``SetFormat`` cannot state, so it
+        gets a format bound instead.  ``as_real`` returns a ``Float`` for
+        exactly that case today -- but that invariant lives in
+        ``fpy2.ast.fpyast``, and answering ``FP32`` on the strength of the
+        *type* would be a false bound the moment some other ``Float`` came
+        back: ``1e-400`` is a ``Float`` and is not in ``FP32``, and no consumer
+        of the bound could detect the lie.  So the discriminator has to be the
+        value.
+        """
+        from fpy2.analysis.format_infer.analysis import _literal_bound
+        from fpy2.number import Float
+
+        class _FakeLiteral:
+            """A literal whose ``as_real`` hands back the ``Float`` given."""
+            def __init__(self, real, rational):
+                self._real, self._rational = real, rational
+
+            def as_real(self):
+                return self._real
+
+            def as_rational(self):
+                return self._rational
+
+        neg_zero = _FakeLiteral(Float(s=True, exp=0, c=0), Fraction(0))
+        assert _literal_bound(neg_zero) == fp.FP32.format()
+
+        # Not a zero, so `FP32` is not known to contain it -- and it does not:
+        # `2**-400` is far below `FP32`'s smallest subnormal.  A `Float` is an
+        # exact rational whenever it is finite, so the set states it exactly.
+        tiny = Float(s=False, exp=-400, c=1)
+        assert _literal_bound(_FakeLiteral(tiny, tiny.as_rational())) != fp.FP32.format()
+        assert _literal_bound(_FakeLiteral(tiny, tiny.as_rational())) == \
+            SetFormat.from_value(tiny.as_rational())
+
+        # No rational value at all: the honest bound is the scalar top.
+        assert _literal_bound(_FakeLiteral(Float(isinf=True), None)) == REAL_FORMAT
+        assert _literal_bound(_FakeLiteral(Float(isnan=True), None)) == REAL_FORMAT
+
+    def test_a_negative_zero_literal_gets_a_float_bound(self):
+        """The end-to-end direction, through the real AST rather than a fake.
+
+        ``SetFormat`` holds ``Fraction``s and a ``Fraction`` has no signed zero,
+        so ``SetFormat({0})`` would claim ``-0.0`` and ``+0.0`` are one value.
+        They are distinguishable by ``copysign`` and by division.
+        """
+        @fp.fpy
+        def neg() -> fp.Real:
+            with fp.FP64:
+                return -0.0
+
+        @fp.fpy
+        def pos() -> fp.Real:
+            with fp.FP64:
+                return 0.0
+
+        neg_info = FormatInfer.analyze(neg.ast)
+        pos_info = FormatInfer.analyze(pos.ast)
+        # `-0.0` reports a format; `+0.0` is exactly the integer 0, so it keeps
+        # the precise singleton set and nothing about it regresses.
+        assert neg_info.fn_fmt.ret_fmt == fp.FP32.format(), neg_info.fn_fmt.ret_fmt
+        assert pos_info.fn_fmt.ret_fmt == SetFormat.from_value(Fraction(0)), \
+            pos_info.fn_fmt.ret_fmt
+
     def test_exact_binop_mul_by_zero_set_stays_set(self):
         """``Mul(loose_format, SetFormat({0}))`` short-circuits to
         ``SetFormat({0})`` rather than producing a degenerate

--- a/tests/unit/backend/cpp/test_emit_round.py
+++ b/tests/unit/backend/cpp/test_emit_round.py
@@ -10,9 +10,12 @@ Phase 5c tests for the cpp emitter — ``Round`` and ``Cast``.
   so no cast and no assertion are emitted.
 """
 
+import pytest
+
 import fpy2 as fp
 
 from fpy2.backend.cpp import CppCompiler
+from fpy2.backend.cpp.compiler import CppCompileError
 from fpy2.types import RealType
 
 
@@ -46,6 +49,64 @@ class TestRound:
         # Same-type round → no static_cast.
         assert 'static_cast' not in out
         assert 'return x;' in out
+
+
+class TestInexactLiterals:
+    """An FPy literal is an exact rational; C++ has no such thing.
+
+    So the only inexact constant that can be emitted is one the program
+    rounded, and ``fp.round`` is where the rounding happens — at compile time,
+    under the context that asked for it.
+    """
+
+    def test_a_literal_the_program_never_rounded_is_refused(self):
+        """``num / denom`` would be an *operation* where FPy has a constant:
+        it rounds under whatever mode is set rather than the program's, and
+        ``-O2`` folds it to nearest regardless."""
+        @fp.fpy
+        def f(x: fp.Real) -> fp.Real:
+            with fp.FP64:
+                return x * fp.rational(1, 3)
+
+        with pytest.raises(CppCompileError, match='unsupported literal'):
+            CppCompiler().compile(
+                f, ctx=fp.FP64, arg_types=[RealType(fp.FP64)],
+            )
+
+    def test_round_of_an_inexact_literal_is_folded(self):
+        @fp.fpy
+        def f() -> fp.Real:
+            with fp.FP64:
+                return fp.round(3.14159265359)
+
+        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[])
+        assert 'return 3.14159265359;' in out
+        assert 'static_cast' not in out
+
+    def test_the_fold_uses_the_contexts_rounding_mode(self):
+        """The reason to fold rather than cast: ``static_cast<double>(1/3)``
+        gets the mode that happens to be set, and at ``-O2`` not even that."""
+        toward_zero = fp.IEEEContext(11, 64, fp.RM.RTZ)
+
+        @fp.fpy
+        def f() -> fp.Real:
+            with toward_zero:
+                return fp.round(0.1)
+
+        out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[])
+        # 0x1.9999999999999p-4, one ulp below the nearest double to 0.1.
+        assert 'return 0.09999999999999999;' in out
+
+    def test_a_narrower_target_still_gets_its_cast(self):
+        """Rounded at FP32, printed as the double that holds it exactly, then
+        cast — a conversion no mode can change."""
+        @fp.fpy
+        def f() -> fp.Real:
+            with fp.FP32:
+                return fp.round(0.1)
+
+        out = CppCompiler().compile(f, ctx=fp.FP32, arg_types=[])
+        assert 'static_cast<float>(0.10000000149011612)' in out
 
 
 class TestRoundExact:

--- a/tests/unit/backend/cpp/test_emit_scalar.py
+++ b/tests/unit/backend/cpp/test_emit_scalar.py
@@ -179,3 +179,49 @@ class TestIfExpr:
         # The narrow branch (F32 ``x``) widens to ``double``; the
         # wide branch (``y``) stays as-is.
         assert '? static_cast<double>(x) : y' in out
+
+
+class TestNegativeZero:
+    """``-0.0`` is a distinct value, and an integer storage cannot hold it.
+
+    ``format_infer`` bounds a literal by the singleton set of its exact value,
+    but a ``Fraction`` has no signed zero -- so ``-0.0`` and ``+0.0`` both give
+    ``SetFormat({0})``, and the narrowest type containing that is ``uint8_t``.
+    A negative-zero literal therefore reports the narrowest *float* format
+    instead (``format_infer._literal_bound``).
+    """
+
+    def test_a_returned_negative_zero_keeps_its_sign(self, cc):
+        """Regression: this returned `+0.0`.  The sign is observable --
+        `x / -0.0` is `-inf` where `x / 0.0` is `+inf`."""
+        @fp.fpy
+        def f() -> fp.Real:
+            return -0.0
+
+        out = cc.compile(f, ctx=fp.FP64, arg_types=[])
+        assert 'uint8_t' not in out, out
+        assert 'float f()' in out or 'double f()' in out, out
+        # The interpreter is the reference, and it keeps the sign.
+        import math
+        got = float(f(ctx=fp.FP64))
+        assert got == 0.0 and math.copysign(1.0, got) < 0, got
+
+    def test_a_negative_zero_in_a_list_literal_compiles(self, cc):
+        """Regression: `std::vector<uint8_t>{-0.0}` is a hard `-Wnarrowing`
+        error, so this did not compile at all."""
+        @fp.fpy
+        def f() -> list[fp.Real]:
+            with fp.FP64:
+                return [-0.0, -0.0]
+
+        out = cc.compile(f, ctx=fp.FP64, arg_types=[])
+        assert 'uint8_t' not in out, out
+
+    def test_a_positive_zero_still_narrows(self, cc):
+        """The guard is for the *negative* literal only: `+0.0` is exactly the
+        integer 0, so it keeps the narrow storage and nothing regresses."""
+        @fp.fpy
+        def f() -> fp.Real:
+            return 0.0
+
+        assert 'uint8_t' in cc.compile(f, ctx=fp.FP64, arg_types=[])

--- a/tests/unit/backend/cpp/test_generated_typecheck.py
+++ b/tests/unit/backend/cpp/test_generated_typecheck.py
@@ -120,6 +120,21 @@ def s_two_lists_in_a_tuple(xs: list[fp.Real], c: fp.Real, y: fp.Real):
 
 
 @fp.fpy
+def s_tuple_with_list_via_a_local(c: fp.Real, y: fp.Real):
+    """Bound to a local first, which is the whole point.
+
+    A tuple's *declaration* comes from `unbox`'s `_read` and its *return type*
+    from `_stamp`, and only `_stamp` descends into a tuple -- so the two
+    disagree about the list field and no conversion between them exists.
+    Returned inline the two paths agree, which is why every other tuple shape
+    here compiles.
+    """
+    with fp.FP64:
+        t = [y, y], 1.0
+        return t
+
+
+@fp.fpy
 def s_alias_then_return(
     xs: list[fp.Real], c: fp.Real, y: fp.Real,
 ) -> list[fp.Real]:
@@ -233,6 +248,7 @@ SHAPES = [
     (s_nested_returns, SCALARS),
     (s_list_in_a_tuple, SCALARS),
     (s_two_lists_in_a_tuple, FLAT),
+    (s_tuple_with_list_via_a_local, SCALARS),
     (s_alias_then_return, FLAT),
     (s_projection_then_return, NESTED),
     (s_loop_target, NESTED),

--- a/tests/unit/backend/cpp/test_generated_typecheck.py
+++ b/tests/unit/backend/cpp/test_generated_typecheck.py
@@ -14,8 +14,8 @@ Two axes:
 - **Shape** -- hand-enumerated below, because a failure has to be readable.
   Adding one is a single function plus an entry in ``SHAPES``.
 - **Format** -- generated.  This is where the corpus has nothing, and it is also
-  the cheap axis: a program's formats come entirely from ``arg_types`` and
-  ``ctx``, so one source function yields eight programs.
+  the cheap axis: a program's formats come entirely from ``arg_types``, so
+  one source function yields four programs.
 
 The assertion is deliberately weak on purpose: a program may legitimately be
 *refused* (``CppEmitError``) -- a shared list cannot change element type, and
@@ -123,11 +123,10 @@ def s_two_lists_in_a_tuple(xs: list[fp.Real], c: fp.Real, y: fp.Real):
 def s_tuple_with_list_via_a_local(c: fp.Real, y: fp.Real):
     """Bound to a local first, which is the whole point.
 
-    A tuple's *declaration* comes from `unbox`'s `_read` and its *return type*
-    from `_stamp`, and only `_stamp` descends into a tuple -- so the two
-    disagree about the list field and no conversion between them exists.
-    Returned inline the two paths agree, which is why every other tuple shape
-    here compiles.
+    `unbox` used to stamp representations in two places and only one descended
+    into a tuple, so the declaration and the return type disagreed about the
+    list field.  Returned inline both went through the same path and agreed,
+    which is why every other tuple shape here compiled and this one did not.
     """
     with fp.FP64:
         t = [y, y], 1.0
@@ -277,16 +276,16 @@ def _arg_types(sig: str, elt_fmt, y_fmt):
 
 
 def _matrix():
-    """Every (shape, ctx, element format, scalar format) combination."""
+    """Every (shape, element format, scalar format) combination.
+
+    No outer-context axis: every shape pins its context with ``with fp.FP64:``,
+    so varying it produced byte-identical programs and only doubled the count.
+    """
     for func, sig in SHAPES:
-        for ctx in FORMATS:
-            for elt_fmt in FORMATS:
-                for y_fmt in FORMATS:
-                    label = (
-                        f'{func.name}__{ctx.__class__.__name__}'
-                        f'{ctx.nbits}_{elt_fmt.nbits}_{y_fmt.nbits}'
-                    )
-                    yield label, func, ctx, _arg_types(sig, elt_fmt, y_fmt)
+        for elt_fmt in FORMATS:
+            for y_fmt in FORMATS:
+                label = f'{func.name}__{elt_fmt.nbits}_{y_fmt.nbits}'
+                yield label, func, _arg_types(sig, elt_fmt, y_fmt)
 
 
 @pytest.fixture(scope='module')
@@ -300,10 +299,10 @@ def emitted():
     """
     sources: list[str] = []
     refused: list[str] = []
-    for i, (label, func, ctx, arg_types) in enumerate(_matrix()):
+    for i, (label, func, arg_types) in enumerate(_matrix()):
         m = Module()
         try:
-            m.add(func, ctx=ctx, arg_types=list(arg_types))
+            m.add(func, ctx=fp.FP64, arg_types=list(arg_types))
             body = CppCompiler().compile_module(m)
         except CppCompileError as e:
             refused.append(f'{label}: {" ".join(str(e).split())[:100]}')
@@ -344,7 +343,7 @@ def test_enough_of_the_matrix_compiles(emitted):
     """
     sources, refused = emitted
     total = len(sources) + len(refused)
-    assert total > 100, f'the matrix shrank to {total} programs'
+    assert total > 60, f'the matrix shrank to {total} programs'
     assert len(sources) >= total * 0.6, (
         f'only {len(sources)}/{total} generated programs compile; the rest are '
         f'refused, so the typecheck above is checking less than it looks.\n  '

--- a/tests/unit/backend/cpp/test_generated_typecheck.py
+++ b/tests/unit/backend/cpp/test_generated_typecheck.py
@@ -1,0 +1,336 @@
+"""Generated coverage for the shapes the corpus does not have.
+
+Every bug found while building the join/widening machinery lived in one of four
+shapes, and the corpus barely contains them.  Of its 217 functions: 6 have more
+than one ``return``, 6 have a ternary, 7 have a nested list literal, and **none**
+has a list at a format other than FP64.  So the differential harness stayed green
+through a nested-literal miscompile, a return-join type disagreement, a
+``signature()`` mismatch, and a reference-bound name reporting a storage type its
+reference did not have.  Each was found by hand-writing a shape, which is the
+thing to automate.
+
+Two axes:
+
+- **Shape** -- hand-enumerated below, because a failure has to be readable.
+  Adding one is a single function plus an entry in ``SHAPES``.
+- **Format** -- generated.  This is where the corpus has nothing, and it is also
+  the cheap axis: a program's formats come entirely from ``arg_types`` and
+  ``ctx``, so one source function yields eight programs.
+
+The assertion is deliberately weak on purpose: a program may legitimately be
+*refused* (``CppEmitError``) -- a shared list cannot change element type, and
+saying so is correct.  What may never happen is emitting C++ that does not
+typecheck.  Since "everything refused" would satisfy that vacuously,
+:func:`test_enough_of_the_matrix_compiles` pins the floor.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import fpy2 as fp
+
+from fpy2.backend.cpp.compiler import CppCompileError, CppCompiler
+from fpy2.module import Module
+from fpy2.types import ListType, RealType
+
+_CXX = shutil.which('c++') or shutil.which('g++') or shutil.which('clang++')
+_OPTS = ['-std=c++11', '-O0', '-Wall', '-Wextra', '-Werror=return-type']
+
+pytestmark = pytest.mark.skipif(_CXX is None, reason='no C++ compiler')
+
+
+# --------------------------------------------------------------------------
+# Shapes.  Each takes one of the four signatures in `SIGS`, so `arg_types` can
+# be generated for it.
+
+@fp.fpy
+def s_two_literal_returns(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    with fp.FP64:
+        if c > 0:
+            return [1.5, 2.5]
+        else:
+            return [y]
+
+
+@fp.fpy
+def s_return_param_or_literal(
+    xs: list[fp.Real], c: fp.Real, y: fp.Real,
+) -> list[fp.Real]:
+    with fp.FP64:
+        if c > 0:
+            return xs
+        else:
+            return [y]
+
+
+@fp.fpy
+def s_ternary_literals(c: fp.Real, y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        zs = [1.5, 2.5] if c > 0 else [y]
+        return zs[0]
+
+
+@fp.fpy
+def s_ternary_param(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        zs = xs if c > 0 else [y]
+        return zs[0]
+
+
+@fp.fpy
+def s_nested_literal(c: fp.Real, y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        zss = [[1.5], [y, 3.0]]
+        return zss[0][0]
+
+
+@fp.fpy
+def s_three_deep_literal(c: fp.Real, y: fp.Real) -> fp.Real:
+    with fp.FP64:
+        zsss = [[[1.5]], [[y, 3.0]]]
+        return zsss[0][0][0]
+
+
+@fp.fpy
+def s_nested_returns(c: fp.Real, y: fp.Real) -> list[list[fp.Real]]:
+    with fp.FP64:
+        if c > 0:
+            return [[1.5], [2.5]]
+        else:
+            return [[y]]
+
+
+@fp.fpy
+def s_list_in_a_tuple(c: fp.Real, y: fp.Real):
+    with fp.FP64:
+        if c > 0:
+            return ([1.5, 2.5], 1.5)
+        else:
+            return ([y], y)
+
+
+@fp.fpy
+def s_two_lists_in_a_tuple(xs: list[fp.Real], c: fp.Real, y: fp.Real):
+    with fp.FP64:
+        return (xs, [y])
+
+
+@fp.fpy
+def s_alias_then_return(
+    xs: list[fp.Real], c: fp.Real, y: fp.Real,
+) -> list[fp.Real]:
+    with fp.FP64:
+        ys = xs
+        if c > 0:
+            return ys
+        else:
+            return [y]
+
+
+@fp.fpy
+def s_projection_then_return(
+    xss: list[list[fp.Real]], c: fp.Real, y: fp.Real,
+) -> list[fp.Real]:
+    with fp.FP64:
+        row = xss[0]
+        if c > 0:
+            return row
+        else:
+            return [y]
+
+
+@fp.fpy
+def s_loop_target(
+    xss: list[list[fp.Real]], c: fp.Real, y: fp.Real,
+) -> list[fp.Real]:
+    with fp.FP64:
+        out = [y]
+        for row in xss:
+            if c > 0:
+                out = row
+        return out
+
+
+@fp.fpy
+def s_comprehension_or_literal(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    with fp.FP64:
+        if c > 0:
+            return [1.5 for _ in range(3)]
+        else:
+            return [y]
+
+
+@fp.fpy
+def s_slice_or_literal(
+    xs: list[fp.Real], c: fp.Real, y: fp.Real,
+) -> list[fp.Real]:
+    with fp.FP64:
+        if c > 0:
+            return xs[0:1]
+        else:
+            return [y]
+
+
+@fp.fpy
+def s_name_and_container(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    with fp.FP64:
+        zs = [1.5, 2.5]
+        zss = [zs]
+        zss[0][0] = 1.0
+        if c > 0:
+            return zs
+        else:
+            return [y]
+
+
+@fp.fpy
+def s_indexed_write_then_return(
+    xs: list[fp.Real], c: fp.Real, y: fp.Real,
+) -> list[fp.Real]:
+    with fp.FP64:
+        xs[0] = y
+        if c > 0:
+            return xs
+        else:
+            return [y]
+
+
+@fp.fpy
+def s_nested_param_returned(
+    xss: list[list[fp.Real]], c: fp.Real, y: fp.Real,
+) -> list[list[fp.Real]]:
+    with fp.FP64:
+        if c > 0:
+            return xss
+        else:
+            return [[y]]
+
+
+@fp.fpy
+def s_write_a_row(
+    xss: list[list[fp.Real]], c: fp.Real, y: fp.Real,
+) -> fp.Real:
+    with fp.FP64:
+        xss[0][0] = y
+        return xss[0][0]
+
+
+# `SCALARS`: (c, y).  The list parameter's element format and `y`'s format are
+# what make two contributors disagree; `c` is only a condition.
+SCALARS, FLAT, NESTED = 'scalars', 'flat', 'nested'
+
+SHAPES = [
+    (s_two_literal_returns, SCALARS),
+    (s_return_param_or_literal, FLAT),
+    (s_ternary_literals, SCALARS),
+    (s_ternary_param, FLAT),
+    (s_nested_literal, SCALARS),
+    (s_three_deep_literal, SCALARS),
+    (s_nested_returns, SCALARS),
+    (s_list_in_a_tuple, SCALARS),
+    (s_two_lists_in_a_tuple, FLAT),
+    (s_alias_then_return, FLAT),
+    (s_projection_then_return, NESTED),
+    (s_loop_target, NESTED),
+    (s_comprehension_or_literal, SCALARS),
+    (s_slice_or_literal, FLAT),
+    (s_name_and_container, SCALARS),
+    (s_indexed_write_then_return, FLAT),
+    (s_nested_param_returned, NESTED),
+    (s_write_a_row, NESTED),
+]
+
+FORMATS = [fp.FP32, fp.FP64]
+
+
+def _arg_types(sig: str, elt_fmt, y_fmt):
+    """*sig*'s parameters, at the given formats."""
+    scalars = [RealType(fp.FP64), RealType(y_fmt)]      # c, y
+    match sig:
+        case 'scalars':
+            return scalars
+        case 'flat':
+            return [ListType(RealType(elt_fmt)), *scalars]
+        case 'nested':
+            return [ListType(ListType(RealType(elt_fmt))), *scalars]
+    raise AssertionError(sig)
+
+
+def _matrix():
+    """Every (shape, ctx, element format, scalar format) combination."""
+    for func, sig in SHAPES:
+        for ctx in FORMATS:
+            for elt_fmt in FORMATS:
+                for y_fmt in FORMATS:
+                    label = (
+                        f'{func.name}__{ctx.__class__.__name__}'
+                        f'{ctx.nbits}_{elt_fmt.nbits}_{y_fmt.nbits}'
+                    )
+                    yield label, func, ctx, _arg_types(sig, elt_fmt, y_fmt)
+
+
+@pytest.fixture(scope='module')
+def emitted():
+    """``(namespaced sources, refusals)`` over the whole matrix.
+
+    A refusal is a legitimate answer, so it is collected rather than raised.
+    Each program goes in its own ``namespace`` -- two specializations of one
+    shape are both named after it, and this is also what lets a few hundred
+    programs share a single compiler invocation.
+    """
+    sources: list[str] = []
+    refused: list[str] = []
+    for i, (label, func, ctx, arg_types) in enumerate(_matrix()):
+        m = Module()
+        try:
+            m.add(func, ctx=ctx, arg_types=list(arg_types))
+            body = CppCompiler().compile_module(m)
+        except CppCompileError as e:
+            refused.append(f'{label}: {" ".join(str(e).split())[:100]}')
+            continue
+        sources.append(f'namespace p{i:04d} {{\n{body}\n}}  // {label}')
+    return sources, refused
+
+
+def test_every_emitted_program_typechecks(emitted):
+    """The property nothing else checks.
+
+    A refusal is fine; C++ that does not compile is not.  One translation unit
+    for the whole matrix, so this costs a single compiler invocation.
+    """
+    sources, _refused = emitted
+    cc = CppCompiler()
+    tu = '\n\n'.join([*cc.headers(), cc.helpers(), *sources])
+    with tempfile.TemporaryDirectory() as td:
+        cpp = Path(td) / 'generated.cpp'
+        cpp.write_text(tu)
+        r = subprocess.run(
+            [_CXX, *_OPTS, '-fsyntax-only', str(cpp)],
+            capture_output=True, text=True,
+        )
+    assert r.returncode == 0, (
+        f'{len(sources)} generated programs, and the emitted C++ does not '
+        f'compile.  The failing namespace names the shape and its formats.\n\n'
+        + r.stderr[:4000]
+    )
+
+
+def test_enough_of_the_matrix_compiles(emitted):
+    """A guard on the guard.
+
+    Everything above passes vacuously if every program is refused, and a change
+    that turns compiles into refusals is a regression even though no C++ breaks.
+    The bound is loose -- it is here to catch a collapse, not to pin a number.
+    """
+    sources, refused = emitted
+    total = len(sources) + len(refused)
+    assert total > 100, f'the matrix shrank to {total} programs'
+    assert len(sources) >= total * 0.6, (
+        f'only {len(sources)}/{total} generated programs compile; the rest are '
+        f'refused, so the typecheck above is checking less than it looks.\n  '
+        + '\n  '.join(refused[:20])
+    )

--- a/tests/unit/backend/cpp/test_unbox.py
+++ b/tests/unit/backend/cpp/test_unbox.py
@@ -276,23 +276,6 @@ class TestInvisibleToTheHarness:
         storage, _ = _decide(k, [ListType(R), R])
         assert _levels(storage['xs']) == [True]
 
-    def test_a_list_inside_a_tuple_keeps_its_handle(self):
-        """``Unbox`` walks the ``CppList`` spine and stops at a tuple.
-        Undecided is not the same as boxed — the two representations then do
-        not compile together."""
-        from fpy2.types import TupleType
-
-        @fp.fpy
-        def f(t: tuple[list[fp.Real], fp.Real]) -> fp.Real:
-            with fp.FP64:
-                return fp.fst(t)[0]
-
-        out = CppCompiler().compile(
-            f, ctx=fp.FP64, arg_types=[TupleType(ListType(R), R)],
-        )
-        assert 'std::tuple<fpy::list<double>, double>' in out
-        assert 'std::vector' not in out
-
     def test_signature_agrees_with_what_the_module_emits(self):
         """A function another compiled function calls keeps its handles, so a
         signature computed for it *alone* is not the one it gets in company —
@@ -678,3 +661,25 @@ class TestListsInsideTuples:
         out = CppCompiler().compile(f, ctx=fp.FP64, arg_types=[ListType(R)])
         assert 'std::tuple<fpy::list<double>, uint8_t>' in out, out
         assert f([1.0, 2.0], ctx=fp.FP64) == 55
+
+    def test_a_read_only_tuple_parameter_unboxes(self):
+        """A tuple *parameter* holding a list, only read.
+
+        The caller owns the vector and we take the tuple by ``const`` reference,
+        so there is nothing to share and no allocation to make.  This case was
+        pinned the other way until the declaration stopped being decided by a
+        traversal that skipped tuples -- and the two tests contradicted each
+        other, which is how the skip survived.
+        """
+        from fpy2.types import TupleType
+
+        @fp.fpy
+        def f(t: tuple[list[fp.Real], fp.Real]) -> fp.Real:
+            with fp.FP64:
+                return fp.fst(t)[0]
+
+        out = CppCompiler().compile(
+            f, ctx=fp.FP64, arg_types=[TupleType(ListType(R), R)],
+        )
+        assert 'const std::tuple<std::vector<double>, double>&' in out, out
+        assert 'fpy::list' not in out, out

--- a/tests/unit/backend/cpp/test_unbox_typecheck.py
+++ b/tests/unit/backend/cpp/test_unbox_typecheck.py
@@ -12,6 +12,7 @@ representation is chosen, and a `return` whose type disagrees with the
 function's is a compile error, not a wrong answer.
 """
 
+import re
 import shutil
 import subprocess
 import tempfile
@@ -20,7 +21,7 @@ from pathlib import Path
 import fpy2 as fp
 import pytest
 
-from fpy2.backend.cpp.compiler import CppCompiler
+from fpy2.backend.cpp.compiler import CppCompileError, CppCompiler
 from fpy2.backend.cpp.types import CppList
 from fpy2.module import Module
 from fpy2.types import ListType, RealType
@@ -194,30 +195,171 @@ def test_a_fresh_nested_result_is_fully_unboxed():
 
 
 # --------------------------------------------------------------------------
-# Found while writing the tests above: a *pre-existing* emitter bug, not an
-# unbox one -- it reproduces identically with `unbox=False`.  Reported here
-# because it is the first thing that fell out of running a C++ compiler over
-# emitted code, which no unit test does today.
+# Found while writing the tests above, and none of it is an unbox bug -- all of
+# it reproduces with `unbox=False`.  It is the first thing that fell out of
+# running a C++ compiler over emitted code, which nothing else does.
+#
+# `format_infer` picks a bound per expression and joins where several values
+# reach one place.  The join was never pushed back *down*, so each contributor
+# kept its own narrower bound and the backend gave one place two storages.
+# Scalars survive that on implicit conversion; `std::vector` has no converting
+# constructor across element types, so these are hard errors.
 
-@pytest.mark.xfail(
-    reason='pre-existing: a returned list literal takes the literal\'s own '
-           'element format instead of the declared return element type; '
-           'reproduces with unbox=False',
-    strict=True,
+@fp.fpy
+def j_two_returned_literals(c: fp.Real) -> list[fp.Real]:
+    """Two returns: `{1.5, 2.5}` narrows differently from `{3}`."""
+    with fp.FP64:
+        if c > 0:
+            return [1.5, 2.5]
+        else:
+            return [3.0]
+
+
+@fp.fpy
+def j_nested_literal() -> fp.Real:
+    """No returns involved -- a nested literal's own rows disagree."""
+    with fp.FP64:
+        xss = [[1.5], [3.0, 4.0]]
+        return xss[0][0]
+
+
+@fp.fpy
+def j_ternary_over_lists(c: fp.Real) -> fp.Real:
+    """One C++ ternary, so one type across both arms."""
+    with fp.FP64:
+        xs = [1.5, 2.5] if c > 0 else [3.0]
+        return xs[0]
+
+
+@fp.fpy
+def j_list_inside_a_returned_tuple(c: fp.Real):
+    """`std::tuple` does convert across element types -- but only when its
+    elements do, and two `std::vector`s do not."""
+    with fp.FP64:
+        if c > 0:
+            return ([1.5, 2.5], 1.5)
+        else:
+            return ([3.0], 3.0)
+
+
+@fp.fpy
+def j_comprehension_against_a_literal(c: fp.Real) -> list[fp.Real]:
+    """A comprehension builds its vector element by element, so its body is a
+    contributor too."""
+    with fp.FP64:
+        if c > 0:
+            return [1.5 for _ in range(3)]
+        else:
+            return [3.0]
+
+
+JOIN_CASES = [
+    (j_two_returned_literals, [R]),
+    (j_nested_literal, []),
+    (j_ternary_over_lists, [R]),
+    (j_list_inside_a_returned_tuple, [R]),
+    (j_comprehension_against_a_literal, [R]),
+]
+
+
+@pytest.mark.parametrize('unbox', [True, False])
+@pytest.mark.parametrize(
+    'func,arg_types', JOIN_CASES, ids=[f.name for f, _ in JOIN_CASES],
 )
-def test_returned_list_literal_uses_the_declared_element_type():
-    """`-> list[fp.Real]` returning `[1.0, 2.0]` emits
-    `std::vector<uint8_t>{1, 2}`, and two branches returning differently
-    valued literals emit two *different* element types from one function.
-    Neither typechecks."""
-    @fp.fpy
-    def bad(c: fp.Real) -> list[fp.Real]:
-        with fp.FP64:
-            if c > 0:
-                return [1.5, 2.5]
-            else:
-                return [3.0]
-
+def test_a_joined_place_has_one_element_type(func, arg_types, unbox):
     m = Module()
-    m.add(bad, ctx=fp.FP64, arg_types=[R])
+    m.add(func, ctx=fp.FP64, arg_types=list(arg_types))
+    _typecheck(m, unbox=unbox)
+    # One element type throughout -- which one it is, is storage selection's
+    # business, and `unbox=False` spells the same list `fpy::list`.  Read off
+    # the function alone; the runtime helpers are templates and would
+    # contribute a `T`.
+    body = CppCompiler(unbox=unbox).compile_module(m)
+    elts = re.findall(r'(?:std::vector|fpy::(?:list|make_list))<(\w+)>', body)
+    assert len(set(elts)) == 1, body
+
+
+# --------------------------------------------------------------------------
+# The other half: a *variable* reaching a joined place.  `_push_format` cannot
+# re-decide one -- its storage was fixed by its own definition -- so the
+# backend converts at the boundary instead.
+
+@fp.fpy
+def v_narrower_variable(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """`xs` narrows to `uint8_t` on its own; the other return is `double`."""
+    with fp.FP64:
+        xs = [1.0, 2.0]
+        if c > 0:
+            return xs
+        else:
+            return [y]
+
+
+@fp.fpy
+def v_narrower_variable_nested(c: fp.Real, y: fp.Real) -> list[list[fp.Real]]:
+    """Nested, where the range constructor does not reach -- the rows need
+    converting too."""
+    with fp.FP64:
+        xss = [[1.0, 2.0]]
+        if c > 0:
+            return xss
+        else:
+            return [[y]]
+
+
+CONVERT_CASES = [v_narrower_variable, v_narrower_variable_nested]
+
+
+@pytest.mark.parametrize(
+    'func', CONVERT_CASES, ids=[f.name for f in CONVERT_CASES],
+)
+def test_a_narrower_variable_is_converted_at_the_boundary(func):
+    m = Module()
+    m.add(func, ctx=fp.FP64, arg_types=[R, R])
     _typecheck(m)
+
+
+# A boxed list is the one thing conversion must not rebuild: a new allocation
+# is a different object, and the handle is there precisely so FPy's aliasing
+# survives.  Both cases below are refused; only the first is refused for a
+# reason that will not go away.
+
+@fp.fpy
+def r_genuinely_shared(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """`xs` is a name *and* a container slot, so rebuilding it would hand the
+    caller something `zss` no longer aliases."""
+    with fp.FP64:
+        xs = [1.0, 2.0]
+        zss = [xs]
+        zss[0][0] = 1.0
+        if c > 0:
+            return xs
+        else:
+            return [y]
+
+
+@fp.fpy
+def r_boxed_only_by_conservatism(c: fp.Real, y: fp.Real):
+    """Nothing here outlives the return -- `xs` keeps its handle only because
+    a name plus a container field reads as two places.  That is the
+    `named_in_tuple` entry in `docs/todos/unboxing-gaps.md`; closing it turns
+    this case into a conversion."""
+    with fp.FP64:
+        xs = [1.0, 2.0]
+        if c > 0:
+            return (xs, 1.0)
+        else:
+            return ([y], y)
+
+
+REFUSE_CASES = [r_genuinely_shared, r_boxed_only_by_conservatism]
+
+
+@pytest.mark.parametrize(
+    'func', REFUSE_CASES, ids=[f.name for f in REFUSE_CASES],
+)
+def test_a_shared_list_is_refused_rather_than_unshared(func):
+    m = Module()
+    m.add(func, ctx=fp.FP64, arg_types=[R, R])
+    with pytest.raises(CppCompileError, match='rebuilding a shared list'):
+        CppCompiler().compile_module(m)

--- a/tests/unit/backend/cpp/test_unbox_typecheck.py
+++ b/tests/unit/backend/cpp/test_unbox_typecheck.py
@@ -319,15 +319,15 @@ def test_a_narrower_variable_is_converted_at_the_boundary(func):
     _typecheck(m)
 
 
-# A boxed list is the one thing conversion must not rebuild: a new allocation
-# is a different object, and the handle is there precisely so FPy's aliasing
-# survives.  Both cases below are refused; only the first is refused for a
-# reason that will not go away.
+# A local's storage is raised to the places it reaches
+# (`storage_infer.place_floors`), so a narrower *local* never has to be
+# rebuilt.  These would all have been refused before that landed.
 
 @fp.fpy
-def r_genuinely_shared(c: fp.Real, y: fp.Real) -> list[fp.Real]:
-    """`xs` is a name *and* a container slot, so rebuilding it would hand the
-    caller something `zss` no longer aliases."""
+def w_shared_local(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """`xs` is a name *and* a container slot, so it keeps its handle -- and a
+    handle cannot be rebuilt.  Raising `xs` to `double` means there is nothing
+    to rebuild, and raising it also raises `zss`, which holds it."""
     with fp.FP64:
         xs = [1.0, 2.0]
         zss = [xs]
@@ -339,11 +339,7 @@ def r_genuinely_shared(c: fp.Real, y: fp.Real) -> list[fp.Real]:
 
 
 @fp.fpy
-def r_boxed_only_by_conservatism(c: fp.Real, y: fp.Real):
-    """Nothing here outlives the return -- `xs` keeps its handle only because
-    a name plus a container field reads as two places.  That is the
-    `named_in_tuple` entry in `docs/todos/unboxing-gaps.md`; closing it turns
-    this case into a conversion."""
+def w_shared_local_in_a_tuple(c: fp.Real, y: fp.Real):
     with fp.FP64:
         xs = [1.0, 2.0]
         if c > 0:
@@ -352,14 +348,143 @@ def r_boxed_only_by_conservatism(c: fp.Real, y: fp.Real):
             return ([y], y)
 
 
-REFUSE_CASES = [r_genuinely_shared, r_boxed_only_by_conservatism]
+@fp.fpy
+def w_mixed_precision_local(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """The format the program asked for, not a narrowing accident: `lo`'s
+    elements are FP32-rounded *values* living in a `vector<double>`."""
+    with fp.FP32:
+        lo = [fp.round(y), fp.round(y)]
+    with fp.FP64:
+        zss = [lo]
+        if c > 0:
+            return lo
+        else:
+            return [y]
+
+
+WIDEN_CASES = [
+    w_shared_local,
+    w_shared_local_in_a_tuple,
+    w_mixed_precision_local,
+]
 
 
 @pytest.mark.parametrize(
-    'func', REFUSE_CASES, ids=[f.name for f in REFUSE_CASES],
+    'func', WIDEN_CASES, ids=[f.name for f in WIDEN_CASES],
 )
-def test_a_shared_list_is_refused_rather_than_unshared(func):
+def test_a_shared_local_is_widened_not_rebuilt(func):
     m = Module()
     m.add(func, ctx=fp.FP64, arg_types=[R, R])
-    with pytest.raises(CppCompileError, match='rebuilding a shared list'):
+    _typecheck(m)
+
+
+def test_a_widened_parameter_is_reported_in_the_signature():
+    """A parameter is raised like any other def, which changes the ABI -- so
+    the caller has to be told.  Already the policy for a store (`xs[0] = y`
+    widens via `_list_set_widen`); this is the same answer at a join."""
+    @fp.fpy
+    def widen(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+        with fp.FP64:
+            if c > 0:
+                return xs
+            else:
+                return [y]
+
+    args = [ListType(RealType(fp.FP32)), R, R]
+    m = Module()
+    m.add(widen, ctx=fp.FP64, arg_types=args)
+    _typecheck(m)
+    params, ret = CppCompiler().signature(widen, ctx=fp.FP64, arg_types=args)
+    assert 'double' in params[0].format(), params[0].format()
+    assert params[0].format() == ret.format()
+
+
+@fp.fpy
+def p_alias(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """`ys = xs` binds `const auto&`."""
+    with fp.FP64:
+        ys = xs
+        if c > 0:
+            return ys
+        else:
+            return [y]
+
+
+@fp.fpy
+def p_projection(xss: list[list[fp.Real]], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """`row = xss[0]` binds `const auto&` to a slot."""
+    with fp.FP64:
+        row = xss[0]
+        if c > 0:
+            return row
+        else:
+            return [y]
+
+
+@fp.fpy
+def p_loop_target(xss: list[list[fp.Real]], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """A loop target binds `const auto&` to each element."""
+    with fp.FP64:
+        out = [y]
+        for row in xss:
+            if c > 0:
+                out = row
+        return out
+
+
+PINNED_CASES = [
+    (p_alias, [ListType(RealType(fp.FP32)), R, R]),
+    (p_projection, [ListType(ListType(RealType(fp.FP32))), R, R]),
+    (p_loop_target, [ListType(ListType(RealType(fp.FP32))), R, R]),
+]
+
+
+@pytest.mark.parametrize(
+    'func,arg_types', PINNED_CASES, ids=[f.name for f, _ in PINNED_CASES],
+)
+def test_a_reference_bound_name_is_not_raised(func, arg_types):
+    """A name the emitter binds as `const auto&` has no storage of its own.
+
+    Regression: `place_floors` raised these, so `storage_of` reported a type the
+    reference did not have.  The binding is spelled `auto`, so nothing caught it
+    -- `const auto& ys = xs;` then `return ys;` emitted `fpy::list<float>` as
+    `fpy::list<double>` and only the C++ compiler objected.  Refusing is right:
+    the reference names a shared list, and a rebuild would unshare it.
+    """
+    m = Module()
+    m.add(func, ctx=fp.FP64, arg_types=list(arg_types))
+    with pytest.raises(CppCompileError, match='is shared'):
         CppCompiler().compile_module(m)
+
+
+def test_a_callee_result_is_refused_rather_than_unshared():
+    """What raising a definition cannot reach.
+
+    `g`'s return representation is fixed by `g`'s own body, so nothing on the
+    caller's side can raise it -- and rebuilding it would copy a shared list
+    out of its aliases.  The only remaining reachable refusal.
+    """
+    @fp.fpy
+    def g(zs: list[fp.Real]) -> list[fp.Real]:
+        with fp.FP32:
+            return zs
+
+    @fp.fpy
+    def f(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+        with fp.FP64:
+            ws = g(xs)
+            if c > 0:
+                return ws
+            else:
+                return [y]
+
+    L32 = ListType(RealType(fp.FP32))
+    m = Module()
+    m.add(g, ctx=fp.FP32, arg_types=[L32])
+    m.add(f, ctx=fp.FP64, arg_types=[L32, R, R])
+    with pytest.raises(CppCompileError, match='is shared') as exc:
+        CppCompiler().compile_module(m)
+    # Actionable: name the callee, since that is the only place it can be fixed.
+    msg = str(exc.value)
+    assert '`g`' in msg, msg
+    assert 'element type' in msg, msg

--- a/tests/unit/backend/cpp/test_unbox_typecheck.py
+++ b/tests/unit/backend/cpp/test_unbox_typecheck.py
@@ -488,3 +488,33 @@ def test_a_callee_result_is_refused_rather_than_unshared():
     msg = str(exc.value)
     assert '`g`' in msg, msg
     assert 'element type' in msg, msg
+
+
+def test_widening_the_call_site_is_a_real_workaround():
+    """The escape hatch the refusal above recommends, pinned.
+
+    A callee's formats already follow its call site, so passing the wider list
+    specializes `g` at the wider format and nothing needs converting.  Since
+    that is the only advice the error can give, it must not quietly stop being
+    true -- if specialization ever stopped tracking argument formats, the
+    message would become a lie and this is what would notice.
+    """
+    @fp.fpy
+    def g(zs: list[fp.Real]) -> list[fp.Real]:
+        with fp.FP32:
+            return zs
+
+    @fp.fpy
+    def f(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+        with fp.FP64:
+            ws = g(xs)
+            return ws if c > 0 else [y]
+
+    m = Module()
+    m.add(f, ctx=fp.FP64, arg_types=[L, R, R])      # a *FP64* list, not FP32
+    _typecheck(m)
+    # `g` came along specialized at the caller's format: had it stayed FP32 the
+    # body would say `float` somewhere, and the refusal would have fired.
+    body = CppCompiler().compile_module(m)
+    assert 'float' not in body, body
+    assert 'double' in body, body

--- a/tests/unit/backend/cpp/test_unbox_typecheck.py
+++ b/tests/unit/backend/cpp/test_unbox_typecheck.py
@@ -280,9 +280,9 @@ def test_a_joined_place_has_one_element_type(func, arg_types, unbox):
 
 
 # --------------------------------------------------------------------------
-# The other half: a *variable* reaching a joined place.  `_push_format` cannot
-# re-decide one -- its storage was fixed by its own definition -- so the
-# backend converts at the boundary instead.
+# The other half: a *variable* reaching a joined place.  Emitting the
+# contributors at the place's type cannot reach one -- a variable's storage was
+# fixed by its own definition -- so the backend converts at the boundary.
 
 @fp.fpy
 def v_narrower_variable(c: fp.Real, y: fp.Real) -> list[fp.Real]:
@@ -319,15 +319,20 @@ def test_a_narrower_variable_is_converted_at_the_boundary(func):
     _typecheck(m)
 
 
-# A local's storage is raised to the places it reaches
-# (`storage_infer.place_floors`), so a narrower *local* never has to be
-# rebuilt.  These would all have been refused before that landed.
+# --------------------------------------------------------------------------
+# And the boundary of that: a narrower list something *else* also names.
+#
+# The conversion above rebuilds the list, which is invisible only because
+# nothing else holds that buffer.  Once something does, the rebuilt copy is a
+# different list from the one the other references see, and there is no sound
+# lowering -- so the compiler refuses.  These are all legal FPy programs; the
+# limitation is the C++ backend's.  `docs/todos/cpp-narrower-variable-at-a-join.md`
+# records what it would take to compile them.
 
 @fp.fpy
-def w_shared_local(c: fp.Real, y: fp.Real) -> list[fp.Real]:
-    """`xs` is a name *and* a container slot, so it keeps its handle -- and a
-    handle cannot be rebuilt.  Raising `xs` to `double` means there is nothing
-    to rebuild, and raising it also raises `zss`, which holds it."""
+def s_local_in_a_list(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """`xs` is a name *and* a slot of `zss`, so it keeps its handle -- and a
+    handle cannot be rebuilt without `zss` still naming the old buffer."""
     with fp.FP64:
         xs = [1.0, 2.0]
         zss = [xs]
@@ -339,7 +344,8 @@ def w_shared_local(c: fp.Real, y: fp.Real) -> list[fp.Real]:
 
 
 @fp.fpy
-def w_shared_local_in_a_tuple(c: fp.Real, y: fp.Real):
+def s_local_in_a_tuple(c: fp.Real, y: fp.Real):
+    """The same, one level in: the tuple's field fixes the list's type."""
     with fp.FP64:
         xs = [1.0, 2.0]
         if c > 0:
@@ -349,9 +355,9 @@ def w_shared_local_in_a_tuple(c: fp.Real, y: fp.Real):
 
 
 @fp.fpy
-def w_mixed_precision_local(c: fp.Real, y: fp.Real) -> list[fp.Real]:
+def s_mixed_precision_local(c: fp.Real, y: fp.Real) -> list[fp.Real]:
     """The format the program asked for, not a narrowing accident: `lo`'s
-    elements are FP32-rounded *values* living in a `vector<double>`."""
+    elements are FP32-rounded *values*, and `zss` holds the same buffer."""
     with fp.FP32:
         lo = [fp.round(y), fp.round(y)]
     with fp.FP64:
@@ -362,46 +368,20 @@ def w_mixed_precision_local(c: fp.Real, y: fp.Real) -> list[fp.Real]:
             return [y]
 
 
-WIDEN_CASES = [
-    w_shared_local,
-    w_shared_local_in_a_tuple,
-    w_mixed_precision_local,
-]
-
-
-@pytest.mark.parametrize(
-    'func', WIDEN_CASES, ids=[f.name for f in WIDEN_CASES],
-)
-def test_a_shared_local_is_widened_not_rebuilt(func):
-    m = Module()
-    m.add(func, ctx=fp.FP64, arg_types=[R, R])
-    _typecheck(m)
-
-
-def test_a_widened_parameter_is_reported_in_the_signature():
-    """A parameter is raised like any other def, which changes the ABI -- so
-    the caller has to be told.  Already the policy for a store (`xs[0] = y`
-    widens via `_list_set_widen`); this is the same answer at a join."""
-    @fp.fpy
-    def widen(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
-        with fp.FP64:
-            if c > 0:
-                return xs
-            else:
-                return [y]
-
-    args = [ListType(RealType(fp.FP32)), R, R]
-    m = Module()
-    m.add(widen, ctx=fp.FP64, arg_types=args)
-    _typecheck(m)
-    params, ret = CppCompiler().signature(widen, ctx=fp.FP64, arg_types=args)
-    assert 'double' in params[0].format(), params[0].format()
-    assert params[0].format() == ret.format()
+@fp.fpy
+def s_parameter(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """A parameter: the caller holds the same list, and the signature already
+    committed to its element type, so neither side can move."""
+    with fp.FP64:
+        if c > 0:
+            return xs
+        else:
+            return [y]
 
 
 @fp.fpy
-def p_alias(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
-    """`ys = xs` binds `const auto&`."""
+def s_alias(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+    """`ys = xs` binds `const auto&`, so `ys` has no buffer of its own."""
     with fp.FP64:
         ys = xs
         if c > 0:
@@ -411,7 +391,7 @@ def p_alias(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
 
 
 @fp.fpy
-def p_projection(xss: list[list[fp.Real]], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+def s_projection(xss: list[list[fp.Real]], c: fp.Real, y: fp.Real) -> list[fp.Real]:
     """`row = xss[0]` binds `const auto&` to a slot."""
     with fp.FP64:
         row = xss[0]
@@ -422,7 +402,7 @@ def p_projection(xss: list[list[fp.Real]], c: fp.Real, y: fp.Real) -> list[fp.Re
 
 
 @fp.fpy
-def p_loop_target(xss: list[list[fp.Real]], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+def s_loop_target(xss: list[list[fp.Real]], c: fp.Real, y: fp.Real) -> list[fp.Real]:
     """A loop target binds `const auto&` to each element."""
     with fp.FP64:
         out = [y]
@@ -432,24 +412,31 @@ def p_loop_target(xss: list[list[fp.Real]], c: fp.Real, y: fp.Real) -> list[fp.R
         return out
 
 
-PINNED_CASES = [
-    (p_alias, [ListType(RealType(fp.FP32)), R, R]),
-    (p_projection, [ListType(ListType(RealType(fp.FP32))), R, R]),
-    (p_loop_target, [ListType(ListType(RealType(fp.FP32))), R, R]),
+L32 = ListType(RealType(fp.FP32))
+N32 = ListType(L32)
+
+SHARED_CASES = [
+    (s_local_in_a_list, [R, R]),
+    (s_local_in_a_tuple, [R, R]),
+    (s_mixed_precision_local, [R, R]),
+    (s_parameter, [L32, R, R]),
+    (s_alias, [L32, R, R]),
+    (s_projection, [N32, R, R]),
+    (s_loop_target, [N32, R, R]),
 ]
 
 
 @pytest.mark.parametrize(
-    'func,arg_types', PINNED_CASES, ids=[f.name for f, _ in PINNED_CASES],
+    'func,arg_types', SHARED_CASES, ids=[f.name for f, _ in SHARED_CASES],
 )
-def test_a_reference_bound_name_is_not_raised(func, arg_types):
-    """A name the emitter binds as `const auto&` has no storage of its own.
+def test_a_shared_narrower_list_is_refused(func, arg_types):
+    """Refusing is the whole point: the alternative is silently unsharing.
 
-    Regression: `place_floors` raised these, so `storage_of` reported a type the
-    reference did not have.  The binding is spelled `auto`, so nothing caught it
-    -- `const auto& ys = xs;` then `return ys;` emitted `fpy::list<float>` as
-    `fpy::list<double>` and only the C++ compiler objected.  Refusing is right:
-    the reference names a shared list, and a rebuild would unshare it.
+    The last three matter most, because there the mismatch would be invisible.
+    A reference binding is spelled `const auto&`, so nothing in the emitted text
+    states its element type -- `const auto& ys = xs;` followed by `return ys;`
+    would hand back an `fpy::list<float>` as an `fpy::list<double>` and only the
+    C++ compiler would object.
     """
     m = Module()
     m.add(func, ctx=fp.FP64, arg_types=list(arg_types))
@@ -458,11 +445,12 @@ def test_a_reference_bound_name_is_not_raised(func, arg_types):
 
 
 def test_a_callee_result_is_refused_rather_than_unshared():
-    """What raising a definition cannot reach.
+    """The refusal names the callee, since that is the only place to fix it.
 
-    `g`'s return representation is fixed by `g`'s own body, so nothing on the
-    caller's side can raise it -- and rebuilding it would copy a shared list
-    out of its aliases.  The only remaining reachable refusal.
+    `g`'s return type is fixed by `g`'s own body, so nothing on the caller's
+    side can change it, and rebuilding the result would copy a list out of its
+    aliases.  Returned straight out of the call there is no local to blame, so
+    the message has to reach for the callee's name instead.
     """
     @fp.fpy
     def g(zs: list[fp.Real]) -> list[fp.Real]:
@@ -472,39 +460,29 @@ def test_a_callee_result_is_refused_rather_than_unshared():
     @fp.fpy
     def f(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
         with fp.FP64:
-            ws = g(xs)
             if c > 0:
-                return ws
+                return g(xs)
             else:
                 return [y]
 
-    L32 = ListType(RealType(fp.FP32))
     m = Module()
     m.add(g, ctx=fp.FP32, arg_types=[L32])
     m.add(f, ctx=fp.FP64, arg_types=[L32, R, R])
     with pytest.raises(CppCompileError, match='is shared') as exc:
         CppCompiler().compile_module(m)
-    # Actionable: name the callee, since that is the only place it can be fixed.
     msg = str(exc.value)
     assert '`g`' in msg, msg
     assert 'element type' in msg, msg
 
 
-def test_a_called_functions_parameter_is_not_raised():
-    """Raising a parameter changes the ABI, so only an entry point may have it.
+def test_a_callees_parameter_at_a_join_is_refused():
+    """The refusal fires inside a callee too, reached through the call.
 
-    Regression: `place_floors` raised *any* parameter, including one belonging
-    to a function compiled code calls -- so the callee's signature moved out
-    from under the call site, and this emitted
-    `g(const fpy::list<double>&)` called with an `fpy::list<float>`.  It does
-    not compile, and before `place_floors` existed the same program was
-    correctly refused.
-
-    Same rule `unbox` already states for representations: a function compiled
-    code calls keeps its signature on both sides.  The caller can pass a wider
-    list instead -- `test_a_widened_parameter_is_reported_in_the_signature`
-    covers the entry-point direction, where raising *is* allowed because a
-    native caller is not bound by an existing signature.
+    A function compiled code calls keeps one signature on both sides -- the same
+    rule `unbox` states for representations -- so the callee's narrower list
+    parameter is as immovable as an entry point's.  The fix is on the caller's
+    side: pass the wider list and specialization carries the format down, which
+    `test_widening_the_call_site_is_a_real_workaround` pins.
     """
     @fp.fpy
     def g(zs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
@@ -518,7 +496,7 @@ def test_a_called_functions_parameter_is_not_raised():
             return w[0]
 
     m = Module()
-    m.add(f, ctx=fp.FP64, arg_types=[ListType(RealType(fp.FP32)), R, R])
+    m.add(f, ctx=fp.FP64, arg_types=[L32, R, R])
     with pytest.raises(CppCompileError, match='is shared'):
         CppCompiler().compile_module(m)
 

--- a/tests/unit/backend/cpp/test_unbox_typecheck.py
+++ b/tests/unit/backend/cpp/test_unbox_typecheck.py
@@ -490,7 +490,44 @@ def test_a_callee_result_is_refused_rather_than_unshared():
     assert 'element type' in msg, msg
 
 
-def test_widening_the_call_site_is_a_real_workaround():
+@fp.fpy
+def m_tuple_with_list_via_a_local(y: fp.Real):
+    """A tuple holding a list, bound to a local before being returned."""
+    with fp.FP64:
+        t = [y, y], 1.0
+        return t
+
+
+def test_a_declaration_agrees_with_what_is_handed_through_it():
+    """One representation per place, including a list inside a tuple.
+
+    Regression: `unbox` had *two* traversals stamping representations onto a
+    type, and only one descended into tuples.  The declaration came from the one
+    that did not, the return type from the one that did, so this emitted
+
+        std::tuple<std::vector<double>, uint8_t> f() {
+            std::tuple<fpy::list<double>, uint8_t> t = ...;   // disagrees
+            return t;
+        }
+
+    which no C++ compiler accepts.  Returned *inline* both paths agreed, which is
+    why every other tuple case compiled and this one did not.
+    """
+    m = Module()
+    m.add(m_tuple_with_list_via_a_local, ctx=fp.FP64, arg_types=[R])
+    _typecheck(m)
+
+    # The point is agreement, not which answer: the two spellings of the tuple
+    # type in the emitted function must be the same one.  Read the function
+    # alone -- the runtime helpers legitimately use `make_shared` for
+    # `fpy::make_list`.
+    body = CppCompiler().compile_module(m)
+    tuples = set(re.findall(r'std::tuple<[^>]*>', body))
+    assert len(tuples) == 1, f'declaration and return type disagree: {tuples}'
+    # ...and here the answer should be unboxed: nothing else holds the list, so
+    # a handle would be a pointless allocation.
+    assert 'fpy::list' not in body, body
+    assert 'make_shared' not in body, body
     """The escape hatch the refusal above recommends, pinned.
 
     A callee's formats already follow its call site, so passing the wider list

--- a/tests/unit/backend/cpp/test_unbox_typecheck.py
+++ b/tests/unit/backend/cpp/test_unbox_typecheck.py
@@ -490,6 +490,39 @@ def test_a_callee_result_is_refused_rather_than_unshared():
     assert 'element type' in msg, msg
 
 
+def test_a_called_functions_parameter_is_not_raised():
+    """Raising a parameter changes the ABI, so only an entry point may have it.
+
+    Regression: `place_floors` raised *any* parameter, including one belonging
+    to a function compiled code calls -- so the callee's signature moved out
+    from under the call site, and this emitted
+    `g(const fpy::list<double>&)` called with an `fpy::list<float>`.  It does
+    not compile, and before `place_floors` existed the same program was
+    correctly refused.
+
+    Same rule `unbox` already states for representations: a function compiled
+    code calls keeps its signature on both sides.  The caller can pass a wider
+    list instead -- `test_a_widened_parameter_is_reported_in_the_signature`
+    covers the entry-point direction, where raising *is* allowed because a
+    native caller is not bound by an existing signature.
+    """
+    @fp.fpy
+    def g(zs: list[fp.Real], c: fp.Real, y: fp.Real) -> list[fp.Real]:
+        with fp.FP64:
+            return zs if c > 0 else [y]
+
+    @fp.fpy
+    def f(xs: list[fp.Real], c: fp.Real, y: fp.Real) -> fp.Real:
+        with fp.FP64:
+            w = g(xs, c, y)
+            return w[0]
+
+    m = Module()
+    m.add(f, ctx=fp.FP64, arg_types=[ListType(RealType(fp.FP32)), R, R])
+    with pytest.raises(CppCompileError, match='is shared'):
+        CppCompiler().compile_module(m)
+
+
 @fp.fpy
 def m_tuple_with_list_via_a_local(y: fp.Real):
     """A tuple holding a list, bound to a local before being returned."""
@@ -528,6 +561,9 @@ def test_a_declaration_agrees_with_what_is_handed_through_it():
     # a handle would be a pointless allocation.
     assert 'fpy::list' not in body, body
     assert 'make_shared' not in body, body
+
+
+def test_widening_the_call_site_is_a_real_workaround():
     """The escape hatch the refusal above recommends, pinned.
 
     A callee's formats already follow its call site, so passing the wider list

--- a/tests/unit/utils/test_location.py
+++ b/tests/unit/utils/test_location.py
@@ -1,0 +1,27 @@
+"""``Location.format`` is a message fragment, so its quoting is a contract.
+
+Two diagnostics embed it and add punctuation around it:
+``CppEmitError`` prepends it to the message, and ``ReachabilityError`` wraps it
+in ``at <loc>: `stmt```.  It shipped for a while opening a backtick it never
+closed, which left every FPy error message with an unbalanced quote.
+"""
+
+from fpy2.utils.location import Location
+
+LOC = Location('foo.py', 11, 13, 11, 20)
+
+
+def test_format_names_the_source_and_the_start_position():
+    assert LOC.format() == '`foo.py:11:13`'
+
+
+def test_format_is_balanced():
+    """The property the bug violated.  Both callers add their own delimiters
+    around it, so an unclosed quote there is an unclosed quote in the whole
+    message."""
+    assert LOC.format().count('`') % 2 == 0
+
+
+def test_format_reads_as_a_prefix():
+    """How ``CppEmitError`` uses it -- the shape a user actually sees."""
+    assert f'{LOC.format()}: unsupported' == '`foo.py:11:13`: unsupported'


### PR DESCRIPTION
Multiples fixes:
 - multiple return statements now agree on type or refuse to compile
 - unboxing lists through tuples
 - actually compile the literal `-0`
 - refuse compiling literals that are not representable in C++
 - formatting of AST location