### PR TITLE
Various fixes

### DIFF
--- a/fpy2/number/context/fixed.py
+++ b/fpy2/number/context/fixed.py
@@ -85,6 +85,13 @@ class FixedFormat(MPBFixedFormat, EncodableFormat):
     def total_bits(self) -> int:
         return self.nbits
 
+    def representable_in(self, x: RealFloat | Float) -> bool:
+        # unlike sign-magnitude, two's complement has a single encoding
+        # of zero, so a negative zero is not representable
+        if isinstance(x, Float | RealFloat) and x.is_zero() and x.s:
+            return False
+        return super().representable_in(x)
+
     def encode(self, x: Float) -> int:
         if not isinstance(x, Float):
             raise TypeError(f'Expected \'Float\', got x={x}')
@@ -237,6 +244,15 @@ class FixedContext(MPBFixedContext, EncodableContext):
 
     def format(self) -> FixedFormat:
         return FixedFormat(self.signed, self.scale, self.nbits)
+
+    def _round_at(self, x: RealFloat | Float, n: int | None, exact: bool) -> Float:
+        r = super()._round_at(x, n, exact)
+        if r.is_zero() and r.s:
+            # rounding a negative value toward zero produces a negative zero,
+            # which two's complement cannot represent; normalize it away so
+            # that `self.round()` always returns a representable value
+            return Float(x=r, s=False, ctx=self)
+        return r
 
     @classmethod
     def from_format(

--- a/fpy2/number/context/mp_fixed.py
+++ b/fpy2/number/context/mp_fixed.py
@@ -420,8 +420,9 @@ class MPFixedContext(OrdinalContext):
                 raise RuntimeError(f'unreachable {x}')
 
         # step 2. shortcut for exact zero values
+        # the sign is preserved: this format has a negative zero
         if xr.is_zero():
-            return Float(ctx=self)
+            return Float(s=xr.s, ctx=self)
 
         # step 3. round value based on rounding parameters
         xr = xr.round(min_n=n, rm=self.rm, num_randbits=self.num_randbits, rng=self.rng, exact=exact)

--- a/fpy2/number/context/mpb_fixed.py
+++ b/fpy2/number/context/mpb_fixed.py
@@ -520,8 +520,11 @@ class MPBFixedContext(SizedContext):
                 raise RuntimeError(f'unreachable {x}')
 
         # step 2. shortcut for exact zero values
+        # the sign is preserved: this format has a negative zero.
+        # `FixedContext` overrides `_round_at` to strip it, since two's
+        # complement does not.
         if xr.is_zero():
-            return Float(ctx=self)
+            return Float(s=xr.s, ctx=self)
 
         # step 3. round value based on rounding parameters
         xr = xr.round(min_n=n, rm=self.rm, num_randbits=self.num_randbits, rng=self.rng, exact=exact)

--- a/fpy2/number/number/floats.py
+++ b/fpy2/number/number/floats.py
@@ -8,6 +8,7 @@ an arbitrary-precision floating-point number.
 from __future__ import annotations
 
 import math
+import sys
 from fractions import Fraction
 from typing import TYPE_CHECKING, Optional, Self
 
@@ -159,10 +160,11 @@ class Float:
         # Complex has __hash__ = None, so mypy thinks there's a type mismatch.
         if self._isnan:
             # ensure that all NaN values have the same hash
-            return hash(float('nan'))
+            return 271828
         elif self._isinf:
-            # ensure that all Inf values have the same hash
-            return hash(float('inf')) if not self._real._s else hash(float('-inf'))
+            # ensure that all Inf values have the same hash;
+            # this is the hash Python gives `float('inf')`
+            return -sys.hash_info.inf if self._real._s else sys.hash_info.inf
         else:
             # hash the underlying RealFloat value
             return hash(self._real)

--- a/fpy2/number/number/floats.py
+++ b/fpy2/number/number/floats.py
@@ -157,7 +157,15 @@ class Float:
 
     def __hash__(self): # type: ignore
         # Complex has __hash__ = None, so mypy thinks there's a type mismatch.
-        return hash((self._isinf, self._isnan, self._real))
+        if self._isnan:
+            # ensure that all NaN values have the same hash
+            return hash(float('nan'))
+        elif self._isinf:
+            # ensure that all Inf values have the same hash
+            return hash(float('inf')) if not self._real._s else hash(float('-inf'))
+        else:
+            # hash the underlying RealFloat value
+            return hash(self._real)
 
     def __eq__(self, other):
         if not isinstance(other, Float | RealFloat | int | float | Fraction):

--- a/fpy2/number/number/reals.py
+++ b/fpy2/number/number/reals.py
@@ -24,7 +24,6 @@ from ...utils import (
     float_to_bits,
     is_dyadic,
     is_power_of_two,
-    trailing_zeros,
 )
 from ..globals import get_current_float_converter, get_current_str_converter
 from ..round import RoundingDirection, RoundingMode
@@ -173,14 +172,14 @@ class RealFloat(numbers.Rational):
         return fn(self)
 
     def __hash__(self): # type: ignore[override]
-        # we want numerically equivalent values to have the same hash
-        if self._c == 0:
-            # all zeros are numerically equivalent, even if they have different signs and exponents
-            return hash(())
-        else:
-            # normalize by shifting off trailing zeros to ensure that values with different
-            tzc = trailing_zeros(self._c)
-            return hash((self._s, self._exp + tzc, self._c >> tzc))
+        # first, try hashing as an integer
+        try:
+            i = int(self)
+            return hash(i)
+        except ValueError:
+            # fallback to hashing as a rational
+            q = self.as_rational()
+            return hash(q)
 
     def __eq__(self, other):
         if not isinstance(other, RealFloat | int | float | Fraction):
@@ -536,12 +535,14 @@ class RealFloat(numbers.Rational):
         return self._flags.underflow_post
 
     def as_rational(self) -> Fraction:
+        # scale by shifting rather than `2 ** exp`: the latter goes through
+        # `pow`, which is dramatically slower for a large exponent
         if self._c == 0: # case: zero
             return Fraction(0)
         elif self._exp >= 0: # case: definitely integer
-            return Fraction(self.m * (2 ** self._exp))
+            return Fraction(self.m << self._exp)
         else: # case: likely fractional
-            return Fraction(self.m, 2 ** (-self._exp))
+            return Fraction(self.m, 1 << -self._exp)
 
     @staticmethod
     def from_int(x: int):
@@ -611,9 +612,10 @@ class RealFloat(numbers.Rational):
                 return RealFloat.from_int(n)
             else:
                 # case: has fractional bits
+                # `x` is dyadic, so `d` is a power of two and `n` is
+                # already the significand at position `-exp`
                 exp = d.bit_length() - 1
-                m = n * (2 ** exp) // d
-                return RealFloat(m=m, exp=-exp)
+                return RealFloat(m=n, exp=-exp)
 
     @staticmethod
     def zero(s: bool = False):

--- a/fpy2/transform/specialize.py
+++ b/fpy2/transform/specialize.py
@@ -36,9 +36,19 @@ from ..ast import Call, FuncDef
 from ..ast.visitor import DefaultTransformVisitor
 from ..function import Function
 from ..module import Module
-from ..number import Context
+from ..number import Context, RoundingMode
+from ..number.context.efloat import EFloatContext, EFloatFormat
+from ..number.context.exponential import ExpContext, ExpFormat
+from ..number.context.fixed import FixedContext, FixedFormat
 from ..number.context.format import Format
-from ..number.context.real import REAL_FORMAT
+from ..number.context.ieee754 import IEEEContext, IEEEFormat
+from ..number.context.mp_fixed import MPFixedContext, MPFixedFormat
+from ..number.context.mp_float import MPFloatContext, MPFloatFormat
+from ..number.context.mpb_fixed import MPBFixedContext, MPBFixedFormat
+from ..number.context.mpb_float import MPBFloatContext, MPBFloatFormat
+from ..number.context.mps_float import MPSFloatContext, MPSFloatFormat
+from ..number.context.real import REAL_FORMAT, RealFormat
+from ..number.context.sm_fixed import SMFixedContext, SMFixedFormat
 from ..types import BoolType, ListType, RealType, TupleType, Type
 from .monomorphize import Monomorphize
 
@@ -47,63 +57,62 @@ from .monomorphize import Monomorphize
 # to feed `Monomorphize` at callees — the spec key does *not* go through
 # this conversion).
 
-
-_FORMAT_TO_CTX: dict[Format, Context] | None = None
-
-
 def _format_to_ctx(fmt: Format) -> Context | None:
-    """Best-effort recovery of a canonical :class:`Context` from a
-    :class:`Format`.  Returns ``None`` for formats outside the canonical
-    registry — the caller falls back to ``RealType(None)``."""
-    global _FORMAT_TO_CTX
-    if _FORMAT_TO_CTX is None:
-        from ..libraries.base import (
-            BF16,
-            FP8P1,
-            FP8P2,
-            FP8P3,
-            FP8P4,
-            FP8P5,
-            FP8P6,
-            FP8P7,
-            FP16,
-            FP32,
-            FP64,
-            FP128,
-            FP256,
-            INTEGER,
-            MX_E2M1,
-            MX_E2M3,
-            MX_E3M2,
-            MX_E4M3,
-            MX_E5M2,
-            MX_E8M0,
-            MX_INT8,
-            S1E4M3,
-            S1E5M2,
-            SINT8,
-            SINT16,
-            SINT32,
-            SINT64,
-            TF32,
-            UINT8,
-            UINT16,
-            UINT32,
-            UINT64,
-        )
-        canonical = (
-            FP16, FP32, FP64, FP128, FP256, BF16, TF32, INTEGER,
-            SINT8, SINT16, SINT32, SINT64,
-            UINT8, UINT16, UINT32, UINT64,
-            S1E5M2, S1E4M3,
-            MX_E5M2, MX_E4M3, MX_E3M2, MX_E2M3, MX_E2M1,
-            MX_E8M0, MX_INT8,
-            FP8P1, FP8P2, FP8P3, FP8P4, FP8P5, FP8P6, FP8P7,
-        )
-        _FORMAT_TO_CTX = {}
-        for ctx in canonical:
-            _FORMAT_TO_CTX.setdefault(ctx.format(), ctx)
-    return _FORMAT_TO_CTX.get(fmt)
+    """Best-effort recovery of a :class:`Context` from a :class:`Format`.
+
+    Each format is paired with the context class that describes it, and the
+    context is rebuilt via that class's ``from_format``.  Returns ``None``
+    when no context can describe the format — the caller falls back to
+    ``RealType(None)``.
+
+    The cases are ordered most-derived first, since ``IEEEFormat`` is an
+    ``EFloatFormat`` and ``FixedFormat``/``SMFixedFormat`` are both
+    ``MPBFixedFormat``\\s.
+    """
+    # A `Format` describes a set of values, not how to round into it, so the
+    # rounding mode has to be chosen here.  RNE is `from_format`'s default and
+    # matches every canonical float context; the fixed-point family instead
+    # uses RTZ, which is what every canonical integer context (`SINT*`,
+    # `UINT*`, `INTEGER`) is built with and what the cpp backend requires of
+    # integer storage, since C++ integer arithmetic truncates.
+    if isinstance(fmt, MPFixedFormat | MPBFixedFormat):
+        rm = RoundingMode.RTZ
+    else:
+        rm = RoundingMode.RNE
+
+    try:
+        match fmt:
+            # `IEEEFormat` before `EFloatFormat`
+            case IEEEFormat():
+                return IEEEContext.from_format(fmt, rm=rm)
+            case EFloatFormat():
+                return EFloatContext.from_format(fmt, rm=rm)
+            # `FixedFormat` and `SMFixedFormat` before `MPBFixedFormat`
+            case FixedFormat():
+                return FixedContext.from_format(fmt, rm=rm)
+            case SMFixedFormat():
+                return SMFixedContext.from_format(fmt, rm=rm)
+            case MPBFixedFormat():
+                return MPBFixedContext.from_format(fmt, rm=rm)
+            case MPFixedFormat():
+                return MPFixedContext.from_format(fmt, rm=rm)
+            case ExpFormat():
+                return ExpContext.from_format(fmt, rm=rm)
+            case MPBFloatFormat():
+                return MPBFloatContext.from_format(fmt, rm=rm)
+            case MPSFloatFormat():
+                return MPSFloatContext.from_format(fmt, rm=rm)
+            case MPFloatFormat():
+                return MPFloatContext.from_format(fmt, rm=rm)
+            case RealFormat():
+                # the polymorphic top: callers treat it as "no context"
+                return None
+            case _:
+                return None
+    except (NotImplementedError, TypeError, ValueError):
+        # some `from_format`s reject formats their context cannot express
+        # (e.g. NaN/Inf disabled); recovery is best-effort
+        return None
 
 
 def _bound_to_type(bound: FormatBound) -> Type | None:

--- a/tests/unit/number/fixed/test_negative_zero.py
+++ b/tests/unit/number/fixed/test_negative_zero.py
@@ -76,6 +76,52 @@ class TestSignMagnitudeKeepsNegativeZero():
         assert ctx.decode(encoded).s
         assert ctx.decode(encoded).is_zero()
 
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    def test_round_preserves_negative_zero(self, rm: fp.RoundingMode):
+        # sign-magnitude can hold `-0`, so rounding must not discard the sign
+        ctx = fp.SMFixedContext(0, 8, rm)
+        r = ctx.round(_NEG_ZERO)
+        assert r.is_zero() and r.s, f'round(-0) under {rm} lost its sign'
+        assert ctx.representable_under(r)
+        assert ctx.encode(r) == ctx.encode(_NEG_ZERO)
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    def test_round_preserves_positive_zero(self, rm: fp.RoundingMode):
+        ctx = fp.SMFixedContext(0, 8, rm)
+        r = ctx.round(_ZERO)
+        assert r.is_zero() and not r.s
+        assert ctx.encode(r) == ctx.encode(_ZERO)
+
+    def test_round_negative_zero_from_float(self):
+        ctx = fp.SMFixedContext(0, 8)
+        assert ctx.round(-0.0).s
+        assert not ctx.round(0.0).s
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    @given(real_floats(prec_max=8, exp_min=-8, exp_max=8))
+    def test_round_is_always_representable(self, rm: fp.RoundingMode, x: fp.RealFloat):
+        ctx = fp.SMFixedContext(0, 8, rm)
+        r = ctx.round(x)
+        assert ctx.representable_under(r)
+        assert ctx.decode(ctx.encode(r)) == r
+
+
+class TestMPFixedKeepsNegativeZero():
+    """`MPFixedContext` also reports `-0` as representable, so it must keep it."""
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    def test_round_preserves_negative_zero(self, rm: fp.RoundingMode):
+        ctx = fp.MPFixedContext(-1, rm)
+        r = ctx.round(_NEG_ZERO)
+        assert ctx.representable_under(_NEG_ZERO)
+        assert r.is_zero() and r.s, f'round(-0) under {rm} lost its sign'
+        assert ctx.representable_under(r)
+
+    def test_round_preserves_positive_zero(self):
+        ctx = fp.MPFixedContext(-1)
+        r = ctx.round(_ZERO)
+        assert r.is_zero() and not r.s
+
 
 class TestRoundNeverProducesNegativeZero():
 

--- a/tests/unit/number/fixed/test_negative_zero.py
+++ b/tests/unit/number/fixed/test_negative_zero.py
@@ -1,0 +1,142 @@
+"""
+Testing that two's complement fixed-point formats have no negative zero.
+
+Two's complement has a single encoding of zero, so `-0` is not representable
+under a `FixedContext`, and `FixedContext.round()` must never produce one.
+Sign-magnitude (`SMFixedContext`) does have a distinct `-0`, so it must be
+unaffected.
+"""
+
+import fpy2 as fp
+import pytest
+
+from hypothesis import given, strategies as st
+
+from ...generators import real_floats
+
+_ZERO = fp.Float(s=False, exp=0, c=0)
+_NEG_ZERO = fp.Float(s=True, exp=0, c=0)
+
+_ROUNDING_MODES = [
+    fp.RoundingMode.RNE,
+    fp.RoundingMode.RNA,
+    fp.RoundingMode.RTP,
+    fp.RoundingMode.RTN,
+    fp.RoundingMode.RTZ,
+    fp.RoundingMode.RAZ,
+    fp.RoundingMode.RTO,
+    fp.RoundingMode.RTE,
+]
+
+_INT_CONTEXTS = [fp.SINT8, fp.SINT16, fp.SINT32, fp.UINT8, fp.UINT16, fp.UINT32]
+
+
+class TestNegativeZeroNotRepresentable():
+
+    @pytest.mark.parametrize('ctx', _INT_CONTEXTS)
+    def test_negative_zero_unrepresentable(self, ctx: fp.FixedContext):
+        assert not ctx.format().representable_in(_NEG_ZERO)
+        assert not ctx.representable_under(_NEG_ZERO)
+
+    @pytest.mark.parametrize('ctx', _INT_CONTEXTS)
+    def test_positive_zero_representable(self, ctx: fp.FixedContext):
+        assert ctx.format().representable_in(_ZERO)
+        assert ctx.representable_under(_ZERO)
+
+    @given(st.booleans(), st.integers(min_value=1, max_value=8),
+           st.integers(min_value=-4, max_value=4), st.integers(min_value=-8, max_value=8))
+    def test_any_negative_zero_encoding(self, signed: bool, nbits: int, scale: int, exp: int):
+        # a negative zero at any exponent, in any two's complement format
+        ctx = fp.FixedContext(signed, scale, nbits + 1)
+        assert not ctx.format().representable_in(fp.Float(s=True, exp=exp, c=0))
+        assert not ctx.format().representable_in(fp.RealFloat(s=True, exp=exp, c=0))
+        assert ctx.format().representable_in(fp.Float(s=False, exp=exp, c=0))
+
+    @pytest.mark.parametrize('ctx', _INT_CONTEXTS)
+    def test_negative_zero_rejected_by_encode(self, ctx: fp.FixedContext):
+        # `encode` would otherwise silently drop the sign, since `-0` and `+0`
+        # share the encoding `0`
+        assert ctx.encode(_ZERO) == 0
+        with pytest.raises(ValueError):
+            ctx.encode(_NEG_ZERO)
+
+
+class TestSignMagnitudeKeepsNegativeZero():
+    """Sign-magnitude has a distinct `-0` encoding, so it must be unaffected."""
+
+    def test_negative_zero_representable(self):
+        ctx = fp.SMFixedContext(0, 8)
+        assert ctx.format().representable_in(_NEG_ZERO)
+        assert ctx.representable_under(_NEG_ZERO)
+
+    def test_negative_zero_roundtrips(self):
+        ctx = fp.SMFixedContext(0, 8)
+        encoded = ctx.encode(_NEG_ZERO)
+        assert encoded != ctx.encode(_ZERO)
+        assert ctx.decode(encoded).s
+        assert ctx.decode(encoded).is_zero()
+
+
+class TestRoundNeverProducesNegativeZero():
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    @pytest.mark.parametrize('v', [-0.0, -1e-9, -0.25, -0.5, -0.75, -0.999])
+    def test_round_small_negatives(self, rm: fp.RoundingMode, v: float):
+        # every one of these rounds to zero in a scale-0 format
+        ctx = fp.FixedContext(True, 0, 8, rm)
+        r = ctx.round(v)
+        assert not (r.is_zero() and r.s), f'round({v}) under {rm} gave -0'
+        assert ctx.representable_under(r)
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    @given(real_floats(prec_max=8, exp_min=-8, exp_max=8))
+    def test_round_is_always_representable(self, rm: fp.RoundingMode, x: fp.RealFloat):
+        # the core invariant: `round` lands on a representable value
+        ctx = fp.FixedContext(True, 0, 8, rm)
+        r = ctx.round(x)
+        assert ctx.representable_under(r)
+        assert not (r.is_zero() and r.s)
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    @given(real_floats(prec_max=8, exp_min=-8, exp_max=8))
+    def test_rounded_values_encode(self, rm: fp.RoundingMode, x: fp.RealFloat):
+        # a rounded value must always be encodable, which is what a stricter
+        # `representable_in` would otherwise break
+        ctx = fp.FixedContext(True, 0, 8, rm)
+        r = ctx.round(x)
+        assert ctx.decode(ctx.encode(r)) == r
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    def test_round_preserves_negative_magnitudes(self, rm: fp.RoundingMode):
+        # normalizing `-0` must not disturb genuinely negative results;
+        # these are all exactly representable, so rounding is the identity
+        ctx = fp.FixedContext(True, 0, 8, rm)
+        for v in (-1.0, -2.0, -64.0, -127.0, -128.0):
+            r = ctx.round(v)
+            assert r.s, f'round({v}) under {rm} lost its sign'
+            assert r == v, f'round({v}) under {rm} gave {float(r)}'
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    def test_round_of_negative_half(self, rm: fp.RoundingMode):
+        # -0.5 lands on 0, -1, or (for RTO) -1 depending on the mode, but
+        # never on -0
+        ctx = fp.FixedContext(True, 0, 8, rm)
+        r = ctx.round(-0.5)
+        assert r == 0 or r == -1, f'round(-0.5) under {rm} gave {float(r)}'
+        assert not (r.is_zero() and r.s)
+
+    def test_round_preserves_flags(self):
+        # the fixup must not drop status flags from the rounded result
+        ctx = fp.FixedContext(True, 0, 8, fp.RoundingMode.RTZ)
+        r = ctx.round(-0.5)
+        assert r.is_zero() and not r.s
+        assert r.inexact
+
+    @pytest.mark.parametrize('rm', _ROUNDING_MODES)
+    def test_round_at_never_produces_negative_zero(self, rm: fp.RoundingMode):
+        # `round_at` shares the same path as `round`
+        ctx = fp.FixedContext(True, 0, 8, rm)
+        for v in (-0.5, -0.25, -1e-9):
+            r = ctx.round_at(v, 0)
+            assert not (r.is_zero() and r.s), f'round_at({v}, 0) under {rm} gave -0'
+            assert ctx.representable_under(r)

--- a/tests/unit/number/number/test_hash.py
+++ b/tests/unit/number/number/test_hash.py
@@ -1,0 +1,227 @@
+"""
+Testing `RealFloat.__hash__` and `Float.__hash__`.
+
+The key invariant is Python's hash/equality contract: whenever `a == b`,
+`hash(a) == hash(b)`. Since `RealFloat` and `Float` compare equal to `int`,
+`float`, and `Fraction`, their hashes must agree with the hashes those types
+produce, i.e., they must follow the numeric hash specification.
+"""
+
+from fractions import Fraction
+
+import fpy2 as fp
+import pytest
+from hypothesis import given, strategies as st
+
+from ...generators import floats, real_floats
+
+_PREC = 8
+_EXP_MIN = -10
+_EXP_MAX = 10
+
+
+@st.composite
+def number(draw):
+    """
+    Returns a strategy for generating an `int`, `float`, `Fraction`,
+    `Float`, or `RealFloat`, all drawn from a narrow range of magnitudes
+    so that distinct types collide on equal values often.
+    """
+    choice = draw(st.integers(min_value=0, max_value=4))
+    if choice == 0:
+        return draw(st.integers(min_value=-64, max_value=64))
+    elif choice == 1:
+        return draw(st.sampled_from([
+            0.0, -0.0, 0.5, -0.5, 1.0, -1.0, 2.0, 0.25, -0.75, 3.5, 64.0,
+            float('inf'), float('-inf'), float('nan'),
+        ]))
+    elif choice == 2:
+        return draw(st.fractions(min_value=-64, max_value=64, max_denominator=16))
+    elif choice == 3:
+        return draw(floats(
+            prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX,
+            allow_nan=True, allow_infinity=True,
+        ))
+    else:
+        return draw(real_floats(
+            prec_max=_PREC, signed=True, exp_min=_EXP_MIN, exp_max=_EXP_MAX,
+        ))
+
+
+class TestHashEqContract:
+    """`a == b` implies `hash(a) == hash(b)`."""
+
+    @given(number(), number())
+    def test_eq_implies_same_hash(self, a, b):
+        if a == b:
+            assert hash(a) == hash(b), f'{a!r} == {b!r} but hashes differ'
+
+    @given(real_floats(prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX))
+    def test_real_float_hash_is_stable(self, x):
+        assert hash(x) == hash(x)
+
+    @given(floats(prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX,
+                  allow_nan=False))
+    def test_float_hash_is_stable(self, x):
+        h1 = hash(x)
+        keepalive = [float('nan')]  # noqa: F841
+        h2 = hash(x)
+        assert h1 == h2
+
+
+class TestNumericHashSpec:
+    """`RealFloat`/`Float` hashes agree with the numeric tower."""
+
+    @given(real_floats(prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX))
+    def test_real_float_matches_rational(self, x):
+        assert hash(x) == hash(x.as_rational())
+
+    @given(floats(prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX,
+                  allow_nan=False, allow_infinity=False))
+    def test_finite_float_matches_rational(self, x):
+        assert hash(x) == hash(x.as_rational())
+
+    @given(st.integers())
+    def test_integer_valued_matches_int(self, i):
+        assert hash(fp.RealFloat.from_int(i)) == hash(i)
+        assert hash(fp.Float.from_int(i)) == hash(i)
+
+    @given(st.floats(allow_nan=False, allow_infinity=False))
+    def test_float_valued_matches_float(self, f):
+        assert hash(fp.RealFloat.from_float(f)) == hash(f)
+        assert hash(fp.Float.from_float(f)) == hash(f)
+
+    @given(st.integers(min_value=-64, max_value=64), st.integers(min_value=0, max_value=32))
+    def test_dyadic_matches_fraction(self, m, k):
+        # m / 2**k, exactly representable
+        x = fp.RealFloat(m=m, exp=-k)
+        assert hash(x) == hash(Fraction(m, 2 ** k))
+
+    def test_scaled_by_power_of_two(self):
+        # exercises both exp >= 0 and exp < 0 over a wide range
+        for exp in range(-64, 65):
+            x = fp.RealFloat(s=False, exp=exp, c=3)
+            assert hash(x) == hash(Fraction(3) * Fraction(2) ** exp), f'exp={exp}'
+            assert hash(-x) == hash(Fraction(-3) * Fraction(2) ** exp), f'exp={exp}'
+
+
+class TestNumericEquivalence:
+    """Numerically equal values hash equally regardless of encoding."""
+
+    @given(
+        real_floats(prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX),
+        st.integers(min_value=0, max_value=32),
+    )
+    def test_shift_invariant(self, x, shift):
+        # (s, exp, c) and (s, exp - shift, c << shift) denote the same value
+        y = fp.RealFloat(s=x.s, exp=x.exp - shift, c=x.c << shift)
+        assert x == y
+        assert hash(x) == hash(y)
+
+    @given(st.booleans(), st.integers(min_value=-32, max_value=32))
+    def test_all_zeros_hash_as_zero(self, s, exp):
+        # every zero, of either sign and any exponent, is numerically 0
+        x = fp.RealFloat(s=s, exp=exp, c=0)
+        assert x == 0
+        assert hash(x) == hash(0)
+        assert hash(fp.Float(x=x)) == hash(0)
+
+    def test_negative_zero_hashes_as_zero(self):
+        assert hash(fp.RealFloat(s=True, exp=0, c=0)) == hash(-0.0) == hash(0)
+        assert hash(fp.Float.zero(s=True)) == hash(0)
+
+    def test_flags_do_not_affect_hash(self):
+        # flags are not part of equality, so they must not be part of the hash
+        x = fp.RealFloat(s=False, exp=-2, c=5)
+        y = fp.RealFloat(x=x, inexact=True, overflow=True, carry=True)
+        assert x == y
+        assert hash(x) == hash(y)
+
+    def test_context_does_not_affect_hash(self):
+        # the rounding context is not part of equality either
+        x = fp.RealFloat(s=False, exp=-2, c=5)
+        a = fp.Float.from_real(x)
+        b = fp.Float.from_real(x, fp.FP64)
+        assert a == b
+        assert hash(a) == hash(b)
+
+    @given(real_floats(prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX))
+    def test_float_agrees_with_real_float(self, x):
+        # a finite `Float` and its `RealFloat` payload are equal
+        assert fp.Float.from_real(x) == x
+        assert hash(fp.Float.from_real(x)) == hash(x)
+
+
+class TestSpecialValues:
+
+    def test_infinities(self):
+        assert hash(fp.Float.inf()) == hash(float('inf'))
+        assert hash(fp.Float.inf(s=True)) == hash(float('-inf'))
+        assert hash(fp.Float.inf()) != hash(fp.Float.inf(s=True))
+        # and the hashes are consistent with equality
+        assert fp.Float.inf() == float('inf')
+        assert fp.Float.inf(s=True) == float('-inf')
+
+    @pytest.mark.xfail(reason=(
+        '`Float.__hash__` returns `hash(float(\'nan\'))` for NaN, which is '
+        'identity-based since Python 3.10 (bpo-43475) and so is not a '
+        'constant: it varies per call, per NaN value, and per process'
+    ))
+    def test_nan_hash_is_constant(self):
+        # NaN is not equal to itself, so no *particular* hash is required, but
+        # the hash must at least be a constant: otherwise a NaN key cannot be
+        # found in a dict, even by identity.
+        nans = [fp.Float.nan(), fp.Float.nan(s=True), fp.Float(isnan=True)]
+        hashes = []
+        keepalive = []
+        for n in nans:
+            hashes.append(hash(n))
+            # claim the address the previous temporary `float('nan')` used, so
+            # the next one is not handed the same id
+            keepalive.append(float('nan'))
+        assert len(set(hashes)) == 1, f'NaN hashes differ: {hashes}'
+
+    @pytest.mark.xfail(reason='same cause as `test_nan_hash_is_constant`')
+    def test_nan_survives_dict_roundtrip(self):
+        nan = fp.Float.nan()
+        d = {nan: 'value'}
+        keepalive = [float('nan') for _ in range(4)]  # noqa: F841
+        assert nan in d
+        assert d[nan] == 'value'
+
+
+class TestContainers:
+    """Hash-based containers behave as the equality relation implies."""
+
+    def test_lookup_across_types(self):
+        d = {fp.RealFloat(s=False, exp=-2, c=3): 'three quarters'}
+        assert d[0.75] == 'three quarters'
+        assert d[Fraction(3, 4)] == 'three quarters'
+        assert d[fp.Float(s=False, exp=-4, c=12)] == 'three quarters'
+
+        d2 = {7: 'seven'}
+        assert d2[fp.RealFloat.from_int(7)] == 'seven'
+        assert d2[fp.Float.from_int(7)] == 'seven'
+
+    def test_set_dedups_equal_values(self):
+        # all four denote 1
+        vals = [
+            1,
+            1.0,
+            Fraction(1),
+            fp.RealFloat(s=False, exp=0, c=1),
+            fp.RealFloat(s=False, exp=-3, c=8),
+            fp.Float(s=False, exp=-1, c=2),
+        ]
+        assert len(set(vals)) == 1
+
+    def test_set_keeps_distinct_values(self):
+        vals = [
+            fp.RealFloat(s=False, exp=0, c=1),
+            fp.RealFloat(s=True, exp=0, c=1),
+            fp.RealFloat(s=False, exp=-1, c=1),
+            fp.Float.inf(),
+            fp.Float.inf(s=True),
+            fp.Float.zero(),
+        ]
+        assert len(set(vals)) == len(vals)

--- a/tests/unit/number/number/test_hash.py
+++ b/tests/unit/number/number/test_hash.py
@@ -10,7 +10,6 @@ produce, i.e., they must follow the numeric hash specification.
 from fractions import Fraction
 
 import fpy2 as fp
-import pytest
 from hypothesis import given, strategies as st
 
 from ...generators import floats, real_floats
@@ -60,9 +59,10 @@ class TestHashEqContract:
     def test_real_float_hash_is_stable(self, x):
         assert hash(x) == hash(x)
 
-    @given(floats(prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX,
-                  allow_nan=False))
+    @given(floats(prec_max=_PREC, exp_min=_EXP_MIN, exp_max=_EXP_MAX))
     def test_float_hash_is_stable(self, x):
+        # NaN included: the allocation between the two calls claims the address
+        # an identity-based NaN hash would otherwise be handed twice in a row
         h1 = hash(x)
         keepalive = [float('nan')]  # noqa: F841
         h2 = hash(x)
@@ -162,11 +162,6 @@ class TestSpecialValues:
         assert fp.Float.inf() == float('inf')
         assert fp.Float.inf(s=True) == float('-inf')
 
-    @pytest.mark.xfail(reason=(
-        '`Float.__hash__` returns `hash(float(\'nan\'))` for NaN, which is '
-        'identity-based since Python 3.10 (bpo-43475) and so is not a '
-        'constant: it varies per call, per NaN value, and per process'
-    ))
     def test_nan_hash_is_constant(self):
         # NaN is not equal to itself, so no *particular* hash is required, but
         # the hash must at least be a constant: otherwise a NaN key cannot be
@@ -181,7 +176,6 @@ class TestSpecialValues:
             keepalive.append(float('nan'))
         assert len(set(hashes)) == 1, f'NaN hashes differ: {hashes}'
 
-    @pytest.mark.xfail(reason='same cause as `test_nan_hash_is_constant`')
     def test_nan_survives_dict_roundtrip(self):
         nan = fp.Float.nan()
         d = {nan: 'value'}

--- a/tests/unit/number/number/test_real_float.py
+++ b/tests/unit/number/number/test_real_float.py
@@ -31,6 +31,43 @@ class TestRealFloatConstructors():
         assert isinstance(x, fp.RealFloat)
         assert x == a
 
+    @given(real_floats(prec_max=16, exp_min=-32, exp_max=32))
+    def test_from_rational_roundtrip(self, x: fp.RealFloat):
+        # `from_rational` recovers the value, though not necessarily the encoding
+        y = fp.RealFloat.from_rational(x.as_rational())
+        assert y == x
+
+
+class TestRealFloatAsRational():
+    """Testing `RealFloat.as_rational`, which must be exact."""
+
+    @given(real_floats(prec_max=16, exp_min=-64, exp_max=64))
+    def test_exact(self, x: fp.RealFloat):
+        q = x.as_rational()
+        assert isinstance(q, Fraction)
+        assert q == x
+        # the value is `(-1)^s * c * 2**exp`, computed independently here
+        assert q == Fraction(x.m) * Fraction(2) ** x.exp
+
+    @given(st.integers(min_value=-64, max_value=64), st.integers(min_value=-64, max_value=64))
+    def test_scaling_by_power_of_two(self, m: int, exp: int):
+        # covers both the `exp >= 0` and `exp < 0` branches
+        x = fp.RealFloat(m=m, exp=exp)
+        assert x.as_rational() == Fraction(m) * Fraction(2) ** exp
+
+    @given(st.booleans(), st.integers(min_value=-32, max_value=32))
+    def test_zero(self, s: bool, exp: int):
+        # zero of either sign, at any exponent
+        assert fp.RealFloat(s=s, exp=exp, c=0).as_rational() == 0
+
+    @pytest.mark.parametrize('exp', [-(10 ** 6), 10 ** 6])
+    def test_large_exponent_is_tractable(self, exp: int):
+        # `2 ** exp` routes through `pow` and is dramatically slower than a
+        # shift at this magnitude; guard against reintroducing it
+        x = fp.RealFloat(s=False, exp=exp, c=3)
+        assert x.as_rational() == Fraction(3) * Fraction(2) ** exp
+        assert hash(x) == hash(x.as_rational())
+
 
 class TestRealFloatReprMethods():
     """Testing `RealFloat` representation methods"""

--- a/tests/unit/transform/test_format_to_ctx.py
+++ b/tests/unit/transform/test_format_to_ctx.py
@@ -1,0 +1,178 @@
+"""
+Testing `Format -> Context` recovery in `fpy2.transform.specialize`.
+
+`_format_to_ctx` rebuilds a `Context` from a `Format` by dispatching on the
+format type and calling that context class's `from_format`. The properties
+that matter downstream are that the recovered context describes the *same*
+format, that it is the right context class, and that the canonical contexts
+in `fpy2.libraries.base` recover as themselves.
+"""
+
+import fpy2 as fp
+import pytest
+
+from fpy2.number.context.efloat import EFloatContext, EFloatFormat
+from fpy2.number.context.exponential import ExpContext, ExpFormat
+from fpy2.number.context.fixed import FixedContext, FixedFormat
+from fpy2.number.context.ieee754 import IEEEContext, IEEEFormat
+from fpy2.number.context.mp_fixed import MPFixedContext, MPFixedFormat
+from fpy2.number.context.mp_float import MPFloatContext, MPFloatFormat
+from fpy2.number.context.mpb_fixed import MPBFixedContext, MPBFixedFormat
+from fpy2.number.context.real import REAL_FORMAT
+from fpy2.number.context.sm_fixed import SMFixedContext, SMFixedFormat
+from fpy2.transform.specialize import _format_to_ctx
+
+# every canonical context, by name, from `fpy2.libraries.base`
+_CANONICAL = [
+    'FP16', 'FP32', 'FP64', 'FP128', 'FP256', 'BF16', 'TF32', 'INTEGER',
+    'SINT8', 'SINT16', 'SINT32', 'SINT64',
+    'UINT8', 'UINT16', 'UINT32', 'UINT64',
+    'S1E5M2', 'S1E4M3',
+    'MX_E5M2', 'MX_E4M3', 'MX_E3M2', 'MX_E2M3', 'MX_E2M1',
+    'MX_E8M0', 'MX_INT8',
+    'FP8P1', 'FP8P2', 'FP8P3', 'FP8P4', 'FP8P5', 'FP8P6', 'FP8P7',
+]
+
+
+def _canonical(name: str):
+    from fpy2 import libraries
+    return getattr(libraries.base, name)
+
+
+class TestFormatRoundTrip():
+    """The recovered context must describe the format it came from."""
+
+    @pytest.mark.parametrize('name', _CANONICAL)
+    def test_canonical_format_roundtrips(self, name: str):
+        fmt = _canonical(name).format()
+        ctx = _format_to_ctx(fmt)
+        assert ctx is not None, f'{name} did not recover'
+        assert ctx.format() == fmt
+
+    @pytest.mark.parametrize('ctx', [
+        fp.FixedContext(True, 3, 12),
+        fp.FixedContext(False, -2, 5),
+        fp.FixedContext(True, 0, 2),
+        fp.SMFixedContext(0, 9),
+        fp.SMFixedContext(-3, 16),
+        fp.MPFloatContext(37),
+        fp.MPFixedContext(-7),
+        fp.IEEEContext(6, 23),
+        fp.IEEEContext(4, 8),
+    ])
+    def test_non_canonical_format_roundtrips(self, ctx):
+        # recovery is not limited to a fixed registry of known contexts
+        rec = _format_to_ctx(ctx.format())
+        assert rec is not None, f'{ctx} did not recover'
+        assert rec.format() == ctx.format()
+
+
+class TestContextClassDispatch():
+    """Each format must map to the context class that describes it."""
+
+    @pytest.mark.parametrize('ctx,fmt_cls,ctx_cls', [
+        (fp.IEEEContext(8, 32), IEEEFormat, IEEEContext),
+        (fp.FixedContext(True, 0, 8), FixedFormat, FixedContext),
+        (fp.SMFixedContext(0, 8), SMFixedFormat, SMFixedContext),
+        (fp.MPFixedContext(-1), MPFixedFormat, MPFixedContext),
+        (fp.MPFloatContext(53), MPFloatFormat, MPFloatContext),
+    ])
+    def test_dispatch(self, ctx, fmt_cls, ctx_cls):
+        fmt = ctx.format()
+        assert isinstance(fmt, fmt_cls)
+        assert type(_format_to_ctx(fmt)) is ctx_cls
+
+    def test_ieee_before_efloat(self):
+        # `IEEEFormat` is an `EFloatFormat`, so case order decides this
+        fmt = fp.FP64.format()
+        assert isinstance(fmt, IEEEFormat) and isinstance(fmt, EFloatFormat)
+        assert type(_format_to_ctx(fmt)) is IEEEContext
+
+    def test_plain_efloat_recovers_as_efloat(self):
+        from fpy2.libraries.base import MX_E4M3
+        fmt = MX_E4M3.format()
+        assert isinstance(fmt, EFloatFormat) and not isinstance(fmt, IEEEFormat)
+        assert type(_format_to_ctx(fmt)) is EFloatContext
+
+    def test_fixed_before_mpb_fixed(self):
+        # `FixedFormat` is an `MPBFixedFormat`, so case order decides this
+        fmt = fp.SINT8.format()
+        assert isinstance(fmt, FixedFormat) and isinstance(fmt, MPBFixedFormat)
+        assert type(_format_to_ctx(fmt)) is FixedContext
+
+    def test_sm_fixed_before_mpb_fixed(self):
+        fmt = fp.SMFixedContext(0, 8).format()
+        assert isinstance(fmt, SMFixedFormat) and isinstance(fmt, MPBFixedFormat)
+        assert type(_format_to_ctx(fmt)) is SMFixedContext
+
+    def test_plain_mpb_fixed_recovers_as_mpb_fixed(self):
+        ctx = fp.MPBFixedContext(-1, fp.RealFloat(exp=0, c=127),
+                                 neg_maxval=fp.RealFloat(s=True, exp=0, c=128))
+        fmt = ctx.format()
+        assert not isinstance(fmt, FixedFormat | SMFixedFormat)
+        assert type(_format_to_ctx(fmt)) is MPBFixedContext
+
+    def test_exp_format(self):
+        from fpy2.libraries.base import MX_E8M0
+        fmt = MX_E8M0.format()
+        assert isinstance(fmt, ExpFormat)
+        assert type(_format_to_ctx(fmt)) is ExpContext
+
+
+class TestCanonicalContextsRecover():
+
+    @pytest.mark.parametrize('name', [n for n in _CANONICAL if n != 'MX_INT8'])
+    def test_canonical_recovers_exactly(self, name: str):
+        ctx = _canonical(name)
+        assert _format_to_ctx(ctx.format()) == ctx
+
+    def test_integer_contexts_recover_rtz(self):
+        # a `Format` carries no rounding mode, so RTZ is chosen for the
+        # fixed-point family; the cpp backend requires it of integer storage
+        for name in ('INTEGER', 'SINT8', 'SINT16', 'SINT32', 'SINT64',
+                     'UINT8', 'UINT16', 'UINT32', 'UINT64'):
+            ctx = _canonical(name)
+            rec = _format_to_ctx(ctx.format())
+            assert rec is not None
+            assert rec.rm == fp.RoundingMode.RTZ, name
+            assert rec.rm == ctx.rm, name
+
+    def test_float_contexts_recover_rne(self):
+        for name in ('FP16', 'FP32', 'FP64', 'BF16', 'TF32', 'MX_E4M3'):
+            ctx = _canonical(name)
+            rec = _format_to_ctx(ctx.format())
+            assert rec is not None
+            assert rec.rm == fp.RoundingMode.RNE, name
+            assert rec.rm == ctx.rm, name
+
+    def test_mx_int8_rounding_mode_differs(self):
+        # documented deviation: `MX_INT8` is built with RNE, but a
+        # `FixedFormat` recovers as RTZ like the other fixed-point formats.
+        # It uses float storage, so the integer-RTZ requirement is not in play.
+        from fpy2.libraries.base import MX_INT8
+        rec = _format_to_ctx(MX_INT8.format())
+        assert rec is not None
+        assert rec.format() == MX_INT8.format()
+        assert MX_INT8.rm == fp.RoundingMode.RNE
+        assert rec.rm == fp.RoundingMode.RTZ
+
+
+class TestUnrecoverableFormats():
+
+    def test_real_format_is_none(self):
+        # the polymorphic top; the caller falls back to `RealType(None)`
+        assert _format_to_ctx(REAL_FORMAT) is None
+
+    def test_unknown_format_is_none(self):
+        # a `Format` subclass no context knows how to build
+        class _Bogus(fp.number.context.format.Format):
+            def __eq__(self, other): return isinstance(other, _Bogus)
+            def __hash__(self): return hash(_Bogus)
+            def is_close_to(self, other): return False
+            def representable_in(self, x): return False
+            def canonical_under(self, x): return False
+            def normal_under(self, x): return False
+            def normalize(self, x): return x
+            def round_params(self): return (None, None)
+
+        assert _format_to_ctx(_Bogus()) is None


### PR DESCRIPTION
- `Float`/`RealFloat`: make `__hash__` consistent with other number types
- `FixedFormat`: negative zero should not be representable
- `Specialize`: make `_format_to_ctx` work for any format 