### PR TITLE
Extend format inference

### DIFF
--- a/docs/todos/backend-cpp.md
+++ b/docs/todos/backend-cpp.md
@@ -22,9 +22,11 @@ bottom. Narrower questions have their own documents:
 
 - `unboxing-gaps.md` — what stays boxed, and why.
 - `cpp-narrower-variable-at-a-join.md` — two element types meeting at one place.
-- `format-infer-aliasing.md` — an unsound bound the backend inherits.
-- **`reals-in-integer-storage.md`** — the largest open correctness problem: a
-  real narrowed into an integer holds neither `-0.0` nor NaN.
+- **`format-infer-aliasing.md`** — the largest open correctness problem: an
+  unsound bound the backend inherits, currently held back by a refusal.
+- `reals-in-integer-storage.md` — a real narrowed into an integer holds neither
+  `-0.0` nor NaN. Mostly closed: the narrowing is now gated on the bound
+  genuinely excluding those. One case remains, plus a latent bypass.
 - `cpp-literal-tokens-and-sum.md` — three smaller disagreements between the
   emitted C++ and the interpreter.
 

--- a/docs/todos/backend-cpp.md
+++ b/docs/todos/backend-cpp.md
@@ -22,13 +22,14 @@ bottom. Narrower questions have their own documents:
 
 - `unboxing-gaps.md` — what stays boxed, and why.
 - `cpp-narrower-variable-at-a-join.md` — two element types meeting at one place.
-- **`format-infer-aliasing.md`** — the largest open correctness problem: an
-  unsound bound the backend inherits, currently held back by a refusal.
+- `format-infer-aliasing.md` — a store widens every name in its alias region.
+  Closed: the bound is sound, and the shape it used to refuse now compiles. A
+  callee's list parameter still refuses, on ABI grounds.
 - `reals-in-integer-storage.md` — a real narrowed into an integer holds neither
   `-0.0` nor NaN. Mostly closed: the narrowing is now gated on the bound
   genuinely excluding those. One case remains, plus a latent bypass.
-- `cpp-literal-tokens-and-sum.md` — three smaller disagreements between the
-  emitted C++ and the interpreter.
+- **`cpp-literal-tokens-and-sum.md`** — the largest remaining set of known
+  divergences between the emitted C++ and the interpreter.
 
 The correctness criterion those last three are measured against: *if the
 compiler succeeds, the emitted C++ must compile and must behave as the FPy

--- a/docs/todos/format-infer-aliasing.md
+++ b/docs/todos/format-infer-aliasing.md
@@ -1,68 +1,78 @@
-# `format_infer` ignores list aliasing
+# `format_infer` and list aliasing
 
-The analysis reports a bound the program can exceed. It no longer produces a
-wrong answer — the backend refuses these programs — but the imprecision is real
-and the refusal is a rough edge, not a fix.
+A store mutates the list that *every* name in its alias region refers to.
+`reaching_defs` refreshes only the name it was written through, so the analysis
+used to report a bound the program could exceed:
 
 ```python
 def alias_then_mutate(xs: list[fp.Real], y: fp.Real) -> fp.Real:  # xs FP32, y FP64
     with fp.FP64:
         ys = xs
         ys[0] = y
-        return xs[0]
+        return xs[0]        # holds FP64; the bound said FP32
 ```
 
-`ys` and `xs` are one list, so after `ys[0] = y` it holds an FP64 value and
-`xs[0]` is FP64. `_list_set_widen` widens the def that `ys[0] = y` produces, but
-`xs`'s def keeps FP32 — `format_infer` has no aliasing model, so nothing connects
-them, and `fn_fmt.ret_fmt` claims binary32 can hold the result.
+`ys` was widened, `xs` was not. Every consumer inherited that — any pass that
+trusts a bound to decide a rounding is eliminable, a constant foldable, or an
+error bound computable was being told something false.
 
-Every consumer inherits this, not just the C++ backend: any pass that trusts a
-bound to decide a rounding is eliminable, a constant foldable, or an error bound
-computable is being told something false about an aliased list.
+## What it does now
 
-## Why the backend refuses instead of miscompiling
+`format_infer` consumes `Alias` as a fifth member of `PreAnalyses`. An
+`IndexedAssign` records its insert against the base's alias *region*, and every
+bound write replays the region's record.
 
-The store is where it becomes observable, and the C++ slot is narrower than the
-value:
+Replaying rather than editing bounds in place is what makes it order-independent:
+a def computed after the store picks the widening up when it is first set, and one
+computed before is re-widened when the store is recorded. Widening only ever
+raises a bound, so a loop fixpoint still converges.
+
+No import cycle — `Alias` consumes only define-use, reaching-defs and type info.
+
+**Flow-sensitivity comes from an exclusion.** The two defs `reaching_defs` already
+refreshes — the one the store reads and the one it creates — are skipped. The
+first is the list's state *before* the store, so a read that precedes it keeps its
+narrow bound. Without the exclusion this over-widens even a direct `xs[0] = x`,
+marking the pre-store state with the inserted format.
+
+Pinned by four tests in `test_format_infer.py`: the aliased store widens, a
+read-only alias does not, a read before the store stays narrow, and a read after
+a store *across a loop back-edge* is widened. The last is the one that would be a
+wrong answer rather than a refusal.
+
+It turned a refusal into a correct program rather than trading one for another:
+`_gen_alias_then_mutate` left the harness's "not compared" list and the generated
+matrix went from 27 to 28 bit-compared instantiations. The corpus emits
+byte-identical C++ for all 54 compiling functions. An earlier version of this
+document argued the element type could not be widened here because "another name
+may already alias it" — with the alias fact every name widens together, so nothing
+is left to disagree.
+
+## What is left
+
+**A called function's list parameter still refuses.** Widening it moves the
+signature out from under the call site:
 
 ```
-unsupported: storing a `double` into a slot of `float` would narrow it, and the
-list would then not hold the value FPy says it does.  Round the value to the
-list's format, or build the list at the wider one.
+unsupported: this value is `std::vector<float>` where `std::vector<double>` is
+needed, and C++ has no conversion between them.
 ```
 
-C++ *would* accept that store and narrow silently, which is the one shape where
-a format disagreement is a wrong answer rather than a compile error — so
-`_visit_indexed_assign` checks `scalar_fits_in` and refuses. The container's
-element type cannot simply be widened from there: another name may already alias
-it, and that is exactly the fact `format_infer` does not track.
+That is the existing guard doing its job — a refusal, not a miscompile. The
+workaround is the same one `cpp-narrower-variable-at-a-join.md` describes: pass
+the wider list, and `Specialize` instantiates the callee at the wider format.
+It does not apply here, because the argument is the *narrower* one.
 
-## Fixing it properly
+**Flow-sensitivity is by exclusion, not by construction.** The upstream
+alternative is to have an `IndexedAssign` refresh a def for every may-alias rather
+than only the syntactic base — `DefineUse` already does exactly that for the
+syntactic one, which is what `storage_infer`'s in-place mutation edge relies on.
+That would make this exact by construction and would benefit every analysis, not
+just this one. Worth doing if the exclusion turns out to be too blunt; nothing
+measured so far says it is.
 
-Three options, in increasing cost:
-
-**Widen only on a store.** When an `IndexedAssign` widens a def, also widen
-anything that may alias its base. Keeps read-only aliases precise and targets
-exactly the unsound case. Needs the next option's fact.
-
-**Use the alias analysis.** `fpy2.analysis.alias` already answers "may these name
-one list", which is the missing input. Costs a dependency from `format_infer`
-onto another analysis — check for a cycle, since `alias` consumes type info.
-
-**Union aliased defs.** Treat `ys = xs` as making the two share one bound.
-Simple and sound, and it costs precision for every consumer even where nothing is
-ever stored.
-
-The first, using the second's fact, looks right. Note the parallel with
-`cpp-narrower-variable-at-a-join.md`: a store already widens a def there too, and
-this is the same widening failing to cross an *alias* edge rather than a call
-edge.
-
-## Where it is pinned
-
-`tests/infra/backend/cpp.py::_gen_alias_then_mutate`, which is now *refused*
-rather than compared — it appears in the harness's "not compared" list. The bug
-predates the branch's C++ work (reproduces at `50fd6aa`); it survived because no
-corpus program has a list at a format other than FP64, so nothing executed the
-shape until the generated matrix did.
+**`Alias` runs without escape summaries.** `format_infer` calls it with none, so
+it is maximally conservative about what a call may retain. That over-approximates
+the aliasing, which is the safe direction here (more aliasing means more
+widening), but it is imprecise: a callee that provably does not retain its
+argument still forces a widening at the caller.

--- a/docs/todos/format-infer-aliasing.md
+++ b/docs/todos/format-infer-aliasing.md
@@ -71,6 +71,20 @@ That would make this exact by construction and would benefit every analysis, not
 just this one. Worth doing if the exclusion turns out to be too blunt; nothing
 measured so far says it is.
 
+**A list aliased through a tuple still refuses, now in the backend.**
+`_gen_list_into_tuple` — `t = (xs, y); zs = fp.fst(t); zs[0] = y; return xs[0]` —
+gets a sound bound: `xs` widens to `fpy::list<double>` and so does the tuple's
+field. But the emitter still wants a `float` element somewhere and refuses:
+
+```
+unsupported: `xs` holds `double` elements where `float` is needed.
+```
+
+The refusal predates this work (it was the mirror of this message, `float` where
+`double` was needed). What changed is which half is wrong: the analysis is now
+consistent, so the remaining disagreement is the backend computing a stale
+element type for the tuple field.
+
 **`Alias` runs without escape summaries.** `format_infer` calls it with none, so
 it is maximally conservative about what a call may retain. That over-approximates
 the aliasing, which is the safe direction here (more aliasing means more

--- a/docs/todos/reals-in-integer-storage.md
+++ b/docs/todos/reals-in-integer-storage.md
@@ -1,74 +1,122 @@
 # A real stored in an integer
 
-The C++ backend narrows a `RealType` value to an integer type when its bound is a
-set of small integers — `acc = 0.0` becomes `uint8_t`, and a list of integral
-constants becomes `std::vector<uint8_t>`. That is unsound, and it is the root
-cause of several wrong answers.
+The C++ backend narrows a `RealType` value to an integer type when its bound says
+every value is a small integer — `acc = 0.0` becomes `uint8_t`, and a list of
+integral constants becomes `std::vector<uint8_t>`. An integer holds neither a
+**signed zero** nor a **NaN**, so this used to be the root cause of several wrong
+answers.
 
-An integer holds neither a **signed zero** nor a **NaN**, and both are reachable:
+It no longer is. The narrowing is now gated on the bound genuinely excluding those
+values, and the gate is in the analysis rather than the backend.
+
+## The wrong answers this caused, re-measured
 
 ```python
 def f(y: fp.Real) -> fp.Real:
-    return 0.0 * y                  # uint8_t
-```
-```cpp
-uint8_t f(double y) {
-    uint8_t _t = 0;
-    uint8_t _t1 = static_cast<uint8_t>((static_cast<double>(_t) * y));
-    return _t1;
-}
+    return 0.0 * y
 ```
 
 | `y` | interpreter | compiled |
 |---|---|---|
-| `inf` | `nan` | `0` |
-| `nan` | `nan` | `0` |
-| `-0.0` | `-0.0` | `+0.0` |
+| `inf` | `nan` | `nan` |
+| `nan` | `nan` | `nan` |
+| `-0.0` | `-0.0` | `-0.0` |
 
-`static_cast<uint8_t>` of a NaN is undefined behaviour, so the `0` is not even a
-reliable wrong answer.
+All three agree, and the emitted signature is `double f(double y)`, not
+`uint8_t f(double y)`. Two mechanisms did it, one per format domain:
 
-Two things conspire. `exact_binop` reports `SetFormat({0})` for `0 * x` — knowingly
-unsound, see the comment there; it is kept because the alternative is a degenerate
-abstract format. And the storage ladder then picks the narrowest type containing
-`{0}`, which is `uint8_t`.
+**`SetFormat` states which zero it holds.** Its element type is
+`SetValue = Fraction | NegZero`. A `Fraction` has no signed zero, so `Fraction(0)`
+*is* `+0.0` and the sentinel carries `-0.0`. Arithmetic over the domain
+(`format_infer._SET_BINOPS`) follows IEEE 754 §6.3, checked against the
+interpreter: a sum is `-0.0` only when both addends are; `a - b` is `a + (-b)`; a
+zero product takes the XOR of the operand signs. So `neg({+0.0})` is exactly
+`{-0.0}` and `{+0.0} * {-1}` is exactly `{-0.0}`.
 
-## The fix has to be uniform
+**`AbstractFormat` carries signed-zero membership.** `has_neg_zero` joins
+`has_pos_inf` / `has_neg_inf` / `has_nan` as a fourth membership implication in
+containment. Since the C++ ladder is built by abstracting each type's own
+`Format`, the integer rungs report `has_neg_zero=False` and reject any bound that
+carries one — which is what keeps such a value off an integer storage. The
+operators derive it: `add` conjoins, `sub` takes the left operand, `mul`
+disjoins, `neg` carries over, `abs` clears.
+
+`Format` gained `enable_neg_zero` (on `MPFixedFormat` / `MPBFixedFormat`) so the
+flag survives `AbstractFormat.format()` and back. Without it every
+integer-valued bound materialized on the way to storage selection acquired a
+signed zero and lost its integer storage — `int8 + int8` became `float`.
+
+## What is still broken
+
+**Negating an integer whose zero is not statically known.**
+
+```python
+def f(x: fp.Real) -> fp.Real:      # x : INTEGER
+    with fp.INTEGER:
+        return -x
+```
+
+For `x == 0` the interpreter returns `-0.0` and compiled code returns `0`. FPy's
+`INTEGER` (an `MPFixedFormat`) deliberately *has* a signed zero, but no C++
+integer type does.
+
+The analysis declines to believe it — see the `TODO` on
+`AbstractFormat.from_format` — because taking the format at its word costs
+integer storage everywhere: measured, it retypes every `range` counter as `float`
+and diverges the loop fixpoint in `test_while{5,6,7}_rounded` all the way to
+`REAL_FORMAT`, which no C++ type can hold. Two honest fixes, either of which
+retires the carve-out:
+
+- `MPFixedContext` flattens signed zeros, as `FixedContext` already does (its
+  comment: *"two's complement has a single encoding of zero"*).
+- The backend stops storing `INTEGER`-bounded reals in `int64_t`.
+
+`test_unbounded_fixed_point_is_not_believed_about_neg_zero` is written to **fail**
+when this is fixed, so the carve-out cannot outlive its justification.
+
+A *literal* zero is fine: its bound is a `SetFormat`, which states the sign and so
+reaches a float storage.
+
+**A latent bypass.** `choose_storage_scalar` falls back to `S64` for an unbounded
+`MPFixedFormat` after the ladder search fails, and that fallback does not re-check
+the membership flags. An `MPFixedFormat` carrying a NaN would land in `int64_t`.
+Not reachable today — `_INTEGER_FORMAT` has `enable_nan=False` — but the path is
+unguarded.
+
+## Retired: "the fix has to be uniform"
+
+This document used to argue:
 
 > **A `RealType` value is stored in a float. Never in an integer.**
 
-Half-measures do not work, and this was measured rather than guessed. Refusing an
-integer storage only for a zero-containing set costs 9 corpus functions;
-restricting it to *exactly* `{0}` costs 7. In both cases the failures are
-*disagreements* rather than missing features — some zeros became `float` while
-others stayed `uint8_t`, and then they met:
+on the grounds that half-measures produce *disagreements* — some zeros becoming
+`float` while others stayed `uint8_t`, then meeting:
 
 ```
 test_ife2:      cannot implicitly cast `float` to `uint8_t`: conversion is lossy
 test_list_set1: storing a `float` into a slot of `uint8_t` would narrow it
 ```
 
-Applied to every real, nothing disagrees: there are no integer-stored reals left
-to meet. It also makes the inexact `{0}` bound harmless, because a float holds
-whatever the multiply actually produced.
+That argument applied to gating the narrowing on a *syntactic* condition (does the
+set contain a zero). Measured then: refusing an integer storage for any
+zero-containing set cost 9 corpus functions; restricting it to exactly `{0}` cost
+7. Gating on the *value* instead — is this zero negative, can this bound hold a
+NaN — produces no disagreement, because the two zeros are now different values and
+every consumer asks the same question about them. The corpus is unchanged across
+the whole change (54/54 compiling, byte-identical emitted C++ except one
+improvement) and the differential harness is clean at 111/116.
 
-## What it costs
+So the blanket rule is not needed. Keep it in mind only if the per-value gate
+turns out to have a hole this document has not found.
 
-The narrowing is a size optimization, and dropping it is visible: 21 of the
-corpus's 112 list element types are value-narrowed reals (all in `test_list*`,
+## Whether to keep the narrowing at all
+
+Still an open question, on size rather than correctness. Measured earlier: 21 of
+the corpus's 112 list element types are value-narrowed reals (all in `test_list*`,
 `test_range*`, `test_list_comp*`), plus scalars like `uint8_t acc` inside FP64
-functions. So expect test churn proportional to that, and larger emitted objects
-in those cases — against emitted code that finally says `double` where FPy says
-real.
+functions. Dropping it would trade smaller objects for emitted code that says
+`double` wherever FPy says real.
 
-*Integer*-typed FPy values keep integer storage; this is only about reals.
-`range(...)` needs an integer list and must stay one — that is what the first
-measured attempt broke.
-
-## Already fixed, separately
-
-A **negative-zero literal** no longer reports `SetFormat({0})`; it reports the
-narrowest float format (`format_infer._literal_bound`), so `return -0.0` keeps its
-sign and `[-0.0, -0.0]` compiles. That was free — no corpus change — because it
-only touches the one literal whose exact value a `Fraction` cannot represent.
-Pinned by `test_emit_scalar.py::TestNegativeZero`.
+*Integer*-typed FPy values keep integer storage regardless; this is only about
+reals. `range(...)` needs an integer list and must stay one — that is what an
+early measured attempt broke.

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -31,7 +31,10 @@ The analysis tracks a **format** that mirrors the basic-type structure::
   any other expression for which a number format is not meaningful.
 - :class:`SetFormat` describes an expression with a known, finite set of real
   values (e.g. a numeric literal or a join of numeric literals).  It is more
-  precise than any :class:`Format` containing all of its values.
+  precise than any :class:`Format` containing all of its values.  Its values are
+  :class:`Fraction`\\ s, which have no signed zero, so it carries the invariant
+  that ``Fraction(0)`` means exactly ``+0.0``; anything that could produce a
+  ``-0.0`` reports a :class:`Format` instead (see :func:`_zero_result_is_positive`).
 - A scalar :class:`Format` (e.g. ``IEEEFormat(es=8, nbits=32)``) describes a
   real-valued expression.  ``REAL_FORMAT`` is the **scalar top** — unrestricted
   real values (the format is unknown or unconstrained).
@@ -209,7 +212,12 @@ def _free_var_format(val: object) -> 'FormatBound':
         case Fraction():
             return SetFormat.from_value(val)
         case Float():
-            return SetFormat.from_value(val.as_rational()) if val.is_finite() else None
+            # A negative zero is finite but not statable as a `Fraction`, so it
+            # gets no set bound either -- see :func:`_zero_result_is_positive` for the
+            # invariant, and :func:`_literal_bound` for the written-out case.
+            if not val.is_finite() or (val.is_zero() and val.s):
+                return None
+            return SetFormat.from_value(val.as_rational())
         case RealFloat():
             return SetFormat.from_value(Fraction(val))
         case int() | float():
@@ -471,8 +479,62 @@ def _to_abstract(f: AbstractableFormatBound | SetFormat) -> AbstractFormat | Non
 _ZERO_SET: 'SetFormat' = SetFormat.from_value(Fraction(0))
 
 
+def _zero_result_is_positive(
+    op: Callable[..., Any], *operands: Fraction,
+) -> bool:
+    """For an application of *op* over *operands* whose exact result is zero:
+    is that zero provably ``+0.0``?
+
+    **The invariant this exists to maintain:** ``Fraction(0)`` in a
+    :class:`SetFormat` means exactly ``+0.0``.  A ``Fraction`` has no signed
+    zero, so a set cannot say which zero it holds — and consumers read it
+    literally.  The C++ backend picks the narrowest type containing ``{0}``,
+    which is ``uint8_t``, and an integer holds neither sign.  So an operation
+    that may have produced a ``-0.0`` reports a :class:`Format` instead of a
+    set: sound, and it costs only precision, because the caller then falls back
+    to the active scope's format (:meth:`_bound_if_fits` → :meth:`_op_bound`),
+    which contains the value whichever zero it is.
+
+    The verdict is per *application*, not per result value: the sign of a zero
+    is a property of the operands that produced it, not of the zero sitting in
+    the result set.
+
+    Every ``Fraction(0)`` *operand* is therefore a ``+0.0``, which leaves only
+    IEEE 754 §6.3 to read:
+
+    - **product**: the sign is the XOR of the operand signs, in every rounding
+      mode.  So a zero product is ``+0.0`` exactly when neither operand is
+      negative.
+    - **sum**: when the operands have the same sign, so does the result.  Both
+      operands zero means both are ``+0.0``, hence ``+0.0``.  Otherwise the
+      operands are opposite-signed and the exact sum is zero, which §6.3 makes
+      ``+0.0`` in every mode *except* ``roundTowardNegative`` — and this
+      function does not know the mode.
+    - **difference**: ``a - b`` is ``a + (-b)``, so a zero result always comes
+      from opposite-signed addends — mode-dependent, including ``0 - 0``.
+    - **absolute value**: never negative, so a zero result is ``+0.0``.
+    - **negation**: a zero result means a zero operand, i.e. ``+0.0``, so the
+      result is ``-0.0``.  Never positive.
+    """
+    if op is abs:
+        return True
+    if op is operator.mul:
+        return all(v >= 0 for v in operands)
+    if op is operator.add:
+        return all(v == 0 for v in operands)
+    return False
+
+
 def _is_zero_set(f: 'FormatBound') -> bool:
-    """``f`` is the precise singleton ``{0}``."""
+    """``f`` is the precise singleton ``{0}`` — and therefore exactly ``+0.0``.
+
+    Callers use this to apply algebraic identities that hold for ``+0.0`` and
+    not for ``-0.0``, so reading the sign off the set is load-bearing.  It is
+    sound because of :func:`_zero_result_is_positive`: every operation that could produce
+    the other zero declines to produce a set, so a ``SetFormat`` containing
+    ``Fraction(0)`` can only have come from a value that really is ``+0.0``
+    (a literal, a range, or a join of those).
+    """
     return isinstance(f, SetFormat) and f.values == _ZERO_SET.values
 
 
@@ -518,7 +580,18 @@ def exact_binop(
     ):
         return None
     if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
-        result = frozenset(op(va, vb) for va in lhs.values for vb in rhs.values)
+        values: set[Fraction] = set()
+        for va in lhs.values:
+            for vb in rhs.values:
+                r = op(va, vb)
+                if r == 0 and not _zero_result_is_positive(op, va, vb):
+                    # May be a `-0.0`; see :func:`_zero_result_is_positive`.
+                    # Ahead of the cap, because collapsing to an AbstractFormat
+                    # would not rescue it — one bounded by zero on both sides
+                    # says the same unstatable thing a `{0}` set does.
+                    return None
+                values.add(r)
+        result = frozenset(values)
         if cap is not None and len(result) > cap:
             # collapse an over-large set to its covering AbstractFormat
             return _setformat_to_abstract(SetFormat(result))
@@ -526,17 +599,15 @@ def exact_binop(
     lhs_zero = _is_zero_set(lhs)
     rhs_zero = _is_zero_set(rhs)
     if op is operator.mul and (lhs_zero or rhs_zero):
-        # UNSOUND, and knowingly so: in IEEE-754 `0 * x` is NaN when *x* is an
-        # infinity or a NaN, and `-0.0` when *x* is negative.  Kept because a
-        # recomputed abstract product is degenerate and drives a later add/sub's
-        # `prec` to 0 (`test_exact_binop_mul_by_zero_set_stays_set`).
+        # `0 * x` is not `{0}`: IEEE-754 gives NaN for an infinite or NaN *x*
+        # and `-0.0` for a negative *x*.  The other operand is a `Format` here
+        # — the set/set case returned above — and a float format admits all
+        # three, so none of them can be ruled out.
         #
-        # A consumer must not read `{0}` as "an integer can hold this".  The C++
-        # backend currently does, so `0.0 * inf` compiles to
-        # `static_cast<uint8_t>(NaN)` and returns 0 -- see
-        # `docs/todos/reals-in-integer-storage.md` for why the fix has to be
-        # uniform rather than a guard here.
-        return _ZERO_SET
+        # Widen rather than falling through to the abstract path: `{0}` lifts to
+        # an AbstractFormat bounded by zero on both sides, whose product drives
+        # a later add/sub's `prec` to 0.
+        return None
     if op is operator.add:
         if lhs_zero:
             return rhs if isinstance(rhs, SetFormat) else _to_abstract(rhs)
@@ -563,7 +634,14 @@ def exact_unop(
     if not isinstance(arg, AbstractableFormatBound):
         return None
     if isinstance(arg, SetFormat):
-        return SetFormat(frozenset(op(v) for v in arg.values))
+        values: set[Fraction] = set()
+        for v in arg.values:
+            r = op(v)
+            if r == 0 and not _zero_result_is_positive(op, v):
+                # `neg(+0.0)` is `-0.0`, which a `Fraction` set cannot state.
+                return None
+            values.add(r)
+        return SetFormat(frozenset(values))
     af = _to_abstract(arg)
     if af is None:
         return None
@@ -680,6 +758,12 @@ def _literal_bound(e) -> FormatBound:
     instead — less precise, but true.  Every binary floating-point format has a
     signed zero, so ``FP32`` is a true bound for one; it is picked as a small
     widely-supported format, and nothing here depends on which.
+
+    This is the written-out case of the invariant :func:`_zero_result_is_positive`
+    maintains for computed values: a ``SetFormat`` never holds a negative zero,
+    so ``Fraction(0)`` in one always means ``+0.0``.  Here the bound must be
+    *some* format (a literal has no scope to fall back to), which is why this
+    names one rather than returning ``None``.
 
     The discriminator is the literal's **value**, not the type ``as_real``
     happens to return.  ``as_real`` returns a :class:`Float` only for a signed

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -864,6 +864,19 @@ def _literal_bound(e) -> FormatBound:
     return SetFormat.from_value(e.as_rational())
 
 
+def _has_list_depth(fmt: FormatBound, depth: int) -> bool:
+    """Can *fmt* be peeled *depth* times as a :class:`ListFormat`?
+
+    The precondition :func:`_list_set_widen` asserts.  Tested rather than
+    caught, so that a genuine shape bug still surfaces as the assertion it is.
+    """
+    for _ in range(depth):
+        if not isinstance(fmt, ListFormat):
+            return False
+        fmt = fmt.elt
+    return True
+
+
 def _list_set_widen(
     value_fmt: FormatBound,
     depth: int,
@@ -1153,13 +1166,11 @@ class _FormatInferInstance(Visitor):
     def _with_region_inserts(self, d: Definition, fmt: FormatBound) -> FormatBound:
         """*fmt*, widened by every store recorded against *d*'s alias region.
 
-        A store through one name mutates the list every name in the region
-        refers to, so each of their bounds has to admit the inserted value.
-        Replaying the record on *every* write rather than editing bounds in place
-        keeps this order-independent: a def computed after the store picks the
-        widening up when it is first set, and one computed before is re-widened
-        when the store is recorded (see :meth:`_visit_indexed_assign`).  Widening
-        only ever raises a bound, so a loop fixpoint still converges.
+        Replaying the record on each write, rather than editing bounds in place,
+        makes this order-independent: a def computed after the store picks the
+        widening up when it is first set, and one computed before is re-widened by
+        :meth:`_record_region_insert`.  Widening only raises a bound, so a loop
+        fixpoint still converges.
         """
         if not self._region_inserts:
             return fmt
@@ -1174,14 +1185,12 @@ class _FormatInferInstance(Visitor):
                 # keeps this flow-sensitive -- a read before the store still
                 # sees the narrow bound.
                 continue
-            try:
-                fmt = _list_set_widen(fmt, depth, insert_fmt, widen=self._widen)
-            except AssertionError:
-                # `_list_set_widen` asserts a `ListFormat` at each peeled level.
-                # A region can hold defs of differing nesting (a row and the
-                # matrix that holds it), and a store at one depth says nothing
-                # about a def shallower than that -- leave those alone.
-                pass
+            if not _has_list_depth(fmt, depth):
+                # A region can hold defs of differing nesting -- a row and the
+                # matrix that holds it -- and a store at one depth says nothing
+                # about a def shallower than that.
+                continue
+            fmt = _list_set_widen(fmt, depth, insert_fmt, widen=self._widen)
         return fmt
 
     def _bound_of_def(self, d: Definition) -> FormatBound:
@@ -1860,19 +1869,23 @@ class _FormatInferInstance(Visitor):
     ) -> None:
         """Note that a store put *insert_fmt* into *base*'s list at *depth*.
 
-        ``reaching_defs`` gives the store a fresh def of the name it was written
-        through, so that name's bound is widened directly.  But the list is one
-        object, and every other name in the same alias region now sees the
-        inserted value too -- ``ys = xs; ys[0] = y`` leaves ``xs[0]`` holding
-        ``y``.  Without this, ``xs``'s bound keeps its old element format and the
-        analysis reports a format the program exceeds; see
-        ``docs/todos/format-infer-aliasing.md``.
+        ``reaching_defs`` refreshes only the name written through, but the list is
+        one object: ``ys = xs; ys[0] = y`` leaves ``xs[0]`` holding ``y``.  Without
+        this, ``xs`` keeps its old element format and the analysis reports a bound
+        the program exceeds -- see ``docs/todos/format-infer-aliasing.md``.
         """
         region = self.alias.region_of(base)
         if region is None:
             return
         record = self._region_inserts.setdefault(region, [])
-        record.append((depth, insert_fmt, frozenset(already)))
+        entry = (depth, insert_fmt, frozenset(already))
+        if entry in record:
+            # A loop body is visited once per fixpoint iteration, so the same
+            # store arrives repeatedly.  Replaying a duplicate is harmless --
+            # widening is idempotent -- but the record would grow with the
+            # iteration count.
+            return
+        record.append(entry)
         # Defs already computed do not get another write on their own, so
         # re-widen them here.  Monotone, so this cannot cycle.
         for d in list(self.by_def):

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -136,6 +136,7 @@ from ...ast.fpyast import *
 from ...ast.visitor import Visitor
 from ...function import Function
 from ...number import INTEGER, REAL, Context, Float, RealFloat
+from ...number.context.mp_fixed import MPFixedFormat
 from ...number.format import REAL_FORMAT, Format
 from ...types import (
     BoolType,
@@ -350,14 +351,22 @@ Inferred format for an expression or variable definition.
 """
 
 
-_INTEGER_FORMAT: Format = INTEGER.format()
+_INTEGER_FORMAT: Format = MPFixedFormat(
+    INTEGER.format().nmin, enable_neg_zero=False,
+)
 """
-Cached format for the :data:`INTEGER` context — used as the result
-format of integer-producing operations (``Len``, ``Dim``, ``Size``,
-``Range1``/``Range2``/``Range3``, the integer projection of
-``Enumerate``).  These ops always produce integer values regardless of
-the active rounding context, so reporting the active context's format
-would be unnecessarily loose.
+The format of an integer-*valued* expression: the result of ``Len``, ``Dim``,
+``Size``, ``Range1``/``Range2``/``Range3``, and the integer projection of
+``Enumerate``.  These ops produce integers whatever the active rounding context
+is, so reporting the active context's format would be unnecessarily loose.
+
+Deliberately **not** ``INTEGER.format()``, though it describes the same value
+grid.  ``INTEGER`` is a rounding context, and FPy's has a signed zero; a *count*
+does not — a list length is an integer, and an integer has one zero.  Conflating
+the two is what made believing that signed zero unaffordable: every counter and
+length inherited it, and no C++ integer type holds one, so they all had to widen
+to ``float``.  Keeping the two apart lets a real rounded under ``INTEGER`` carry
+its ``-0.0`` (and reach a float storage) while a length stays an integer.
 """
 
 
@@ -598,8 +607,17 @@ _SET_BINOPS: dict[Any, Callable[[SetValue, SetValue], SetValue]] = {
     operator.mul: _set_mul,
 }
 """Exact binary arithmetic over :data:`SetValue`, keyed by the operator the
-caller passes.  An operator absent here has no set-level rule, so
-:func:`exact_binop` falls back to the abstract path rather than guessing."""
+caller passes.
+
+Why functions rather than operators on :class:`NegZero`: two of these rules must
+*produce* a negative zero from operands that are both plain
+:class:`Fraction`\\ s — ``-Fraction(0)`` and ``Fraction(-1) * Fraction(0)`` — and
+those go through ``Fraction``'s own dunders, which no method on the sentinel can
+intercept.  A reflected operator only fires when the sentinel is an *operand*,
+never when it must be the *result*.
+
+An operator absent here has no set-level rule, so :func:`exact_binop` falls back
+to the abstract path rather than guessing."""
 
 _SET_UNOPS: dict[Any, Callable[[SetValue], SetValue]] = {
     operator.neg: _set_neg,

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -149,6 +149,7 @@ from ...types import (
     VarType,
 )
 from ...utils import is_dyadic
+from ..alias import Alias, AliasAnalysis, Region
 from ..array_size import (
     ArraySizeAnalysis,
     ArraySizeInfer,
@@ -915,13 +916,14 @@ def _format_of_scope(scope: ContextScope) -> Format:
 
 @dataclass(frozen=True)
 class PreAnalyses:
-    """Bundle of the four structural pre-analyses a
-    :class:`FormatAnalysis` depends on.  Identical for every
-    instantiation of the same :class:`FuncDef`."""
+    """Bundle of the structural pre-analyses a :class:`FormatAnalysis`
+    depends on.  Identical for every instantiation of the same
+    :class:`FuncDef`."""
     def_use: DefineUseAnalysis
     type_info: TypeAnalysis
     ctx_use: ContextUseAnalysis
     array_size: ArraySizeAnalysis
+    alias: AliasAnalysis
 
 
 class PreAnalysisCache:
@@ -944,6 +946,7 @@ class PreAnalysisCache:
         type_info: TypeAnalysis | None = None,
         ctx_use: ContextUseAnalysis | None = None,
         array_size: ArraySizeAnalysis | None = None,
+        alias: AliasAnalysis | None = None,
     ) -> PreAnalyses:
         """Return the pre-analyses for *func*, computing them on the
         first request.  Pre-supplied analyses (via the keyword args)
@@ -963,7 +966,12 @@ class PreAnalysisCache:
             ctx_use = ContextUse.analyze(func, def_use=def_use)
         if array_size is None:
             array_size = ArraySizeInfer.analyze(func, type_info=type_info)
-        pre = PreAnalyses(def_use, type_info, ctx_use, array_size)
+        if alias is None:
+            # No escape summaries: `Alias` is then maximally conservative about
+            # what a call may retain, which over-approximates the aliasing --
+            # exactly the safe direction for the widening below.
+            alias = Alias.analyze(func, def_use=def_use, type_info=type_info)
+        pre = PreAnalyses(def_use, type_info, ctx_use, array_size, alias)
         self._table[key] = pre
         return pre
 
@@ -1090,7 +1098,11 @@ class _FormatInferInstance(Visitor):
         self.type_info = pre.type_info
         self.ctx_use = pre.ctx_use
         self.array_size = pre.array_size
+        self.alias = pre.alias
         self.by_def = {}
+        self._region_inserts: dict[
+            Region, list[tuple[int, FormatBound, frozenset[Definition]]]
+        ] = {}
         self.by_expr = {}
         self.by_call = {}
         self._pre_cache = pre_cache
@@ -1136,7 +1148,41 @@ class _FormatInferInstance(Visitor):
         return self.type_info.def_use
 
     def _set_def_bound(self, d: Definition, fmt: FormatBound):
-        self.by_def[d] = fmt
+        self.by_def[d] = self._with_region_inserts(d, fmt)
+
+    def _with_region_inserts(self, d: Definition, fmt: FormatBound) -> FormatBound:
+        """*fmt*, widened by every store recorded against *d*'s alias region.
+
+        A store through one name mutates the list every name in the region
+        refers to, so each of their bounds has to admit the inserted value.
+        Replaying the record on *every* write rather than editing bounds in place
+        keeps this order-independent: a def computed after the store picks the
+        widening up when it is first set, and one computed before is re-widened
+        when the store is recorded (see :meth:`_visit_indexed_assign`).  Widening
+        only ever raises a bound, so a loop fixpoint still converges.
+        """
+        if not self._region_inserts:
+            return fmt
+        region = self.alias.region_of(d)
+        if region is None:
+            return fmt
+        for depth, insert_fmt, already in self._region_inserts.get(region, ()):
+            if d in already:
+                # `reaching_defs` accounts for these two itself: the def the
+                # store reads is the list's state *before* it, and the def it
+                # creates already carries the widening.  Skipping them is what
+                # keeps this flow-sensitive -- a read before the store still
+                # sees the narrow bound.
+                continue
+            try:
+                fmt = _list_set_widen(fmt, depth, insert_fmt, widen=self._widen)
+            except AssertionError:
+                # `_list_set_widen` asserts a `ListFormat` at each peeled level.
+                # A region can hold defs of differing nesting (a row and the
+                # matrix that holds it), and a store at one depth says nothing
+                # about a def shallower than that -- leave those alone.
+                pass
+        return fmt
 
     def _bound_of_def(self, d: Definition) -> FormatBound:
         return self.by_def[d]
@@ -1804,6 +1850,34 @@ class _FormatInferInstance(Visitor):
         )
         d_def = self.def_use.find_def_from_site(stmt.var, stmt)
         self._set_def_bound(d_def, new_fmt)
+        self._record_region_insert(
+            d_use, len(stmt.indices), insert_fmt, already={d_use, d_def},
+        )
+
+    def _record_region_insert(
+        self, base: Definition, depth: int, insert_fmt: FormatBound,
+        *, already: set[Definition],
+    ) -> None:
+        """Note that a store put *insert_fmt* into *base*'s list at *depth*.
+
+        ``reaching_defs`` gives the store a fresh def of the name it was written
+        through, so that name's bound is widened directly.  But the list is one
+        object, and every other name in the same alias region now sees the
+        inserted value too -- ``ys = xs; ys[0] = y`` leaves ``xs[0]`` holding
+        ``y``.  Without this, ``xs``'s bound keeps its old element format and the
+        analysis reports a format the program exceeds; see
+        ``docs/todos/format-infer-aliasing.md``.
+        """
+        region = self.alias.region_of(base)
+        if region is None:
+            return
+        record = self._region_inserts.setdefault(region, [])
+        record.append((depth, insert_fmt, frozenset(already)))
+        # Defs already computed do not get another write on their own, so
+        # re-widen them here.  Monotone, so this cannot cycle.
+        for d in list(self.by_def):
+            if d not in already and self.alias.region_of(d) == region:
+                self.by_def[d] = self._with_region_inserts(d, self.by_def[d])
 
     def _visit_if1(self, stmt: If1Stmt, ctx: None):
         self._visit_expr(stmt.cond, ctx)

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -32,9 +32,9 @@ The analysis tracks a **format** that mirrors the basic-type structure::
 - :class:`SetFormat` describes an expression with a known, finite set of real
   values (e.g. a numeric literal or a join of numeric literals).  It is more
   precise than any :class:`Format` containing all of its values.  Its values are
-  :class:`Fraction`\\ s, which have no signed zero, so it carries the invariant
-  that ``Fraction(0)`` means exactly ``+0.0``; anything that could produce a
-  ``-0.0`` reports a :class:`Format` instead (see :func:`_zero_result_is_positive`).
+  :data:`SetValue` — an exact :class:`Fraction`, or :data:`NEG_ZERO` for the
+  negative zero a ``Fraction`` cannot represent — so a set says *which* zero it
+  holds rather than leaving it to an invariant.
 - A scalar :class:`Format` (e.g. ``IEEEFormat(es=8, nbits=32)``) describes a
   real-valued expression.  ``REAL_FORMAT`` is the **scalar top** — unrestricted
   real values (the format is unknown or unconstrained).
@@ -178,6 +178,40 @@ __all__ = [
 #####################################################################
 # Format lattice
 
+class NegZero:
+    """The value ``-0.0``, as a member of a :class:`SetFormat`.
+
+    A ``SetFormat`` holds a set of exact values, and ``-0.0`` is one — but a
+    :class:`Fraction` cannot represent it: ``Fraction(0)`` is *the* zero,
+    unsigned.  So the element domain is :data:`SetValue`, and this is its second
+    member.
+
+    Deliberately not a :class:`Float`: ``Float(-0.0) == Fraction(0)`` and the two
+    hash equally, so a ``frozenset`` would collapse them into one element.  A
+    distinct type keeps them distinct, which is the entire requirement.
+    """
+    __slots__ = ()
+
+    def __repr__(self):
+        return 'NEG_ZERO'
+
+    def __str__(self):
+        return '-0.0'
+
+    def __eq__(self, other):
+        return isinstance(other, NegZero)
+
+    def __hash__(self):
+        return hash(NegZero)
+
+
+NEG_ZERO = NegZero()
+"""The single :class:`NegZero` instance; compare with ``==`` or ``isinstance``."""
+
+SetValue: TypeAlias = Fraction | NegZero
+"""A member of a :class:`SetFormat`: an exact rational, or the negative zero."""
+
+
 @dataclass(frozen=True)
 class SetFormat:
     """
@@ -186,11 +220,16 @@ class SetFormat:
     Strictly more precise than any :class:`Format` that contains every value;
     when joined with such a format the format is returned (otherwise the join
     widens to ``REAL_FORMAT``).
+
+    Values are :data:`SetValue`, so the set says *which* zero it holds:
+    ``Fraction(0)`` is ``+0.0`` and :data:`NEG_ZERO` is ``-0.0``.  That is a
+    property of the representation rather than an invariant maintained by the
+    producers, which is what it replaced.
     """
-    values: frozenset[Fraction]
+    values: frozenset[SetValue]
 
     @staticmethod
-    def from_value(x: Fraction):
+    def from_value(x: SetValue):
         return SetFormat(frozenset((x,)))
 
 
@@ -212,11 +251,11 @@ def _free_var_format(val: object) -> 'FormatBound':
         case Fraction():
             return SetFormat.from_value(val)
         case Float():
-            # A negative zero is finite but not statable as a `Fraction`, so it
-            # gets no set bound either -- see :func:`_zero_result_is_positive` for the
-            # invariant, and :func:`_literal_bound` for the written-out case.
-            if not val.is_finite() or (val.is_zero() and val.s):
+            if not val.is_finite():
                 return None
+            # A captured `-0.0` is statable now: `NEG_ZERO` is a `SetValue`.
+            if val.is_zero() and val.s:
+                return SetFormat.from_value(NEG_ZERO)
             return SetFormat.from_value(val.as_rational())
         case RealFloat():
             return SetFormat.from_value(Fraction(val))
@@ -331,12 +370,14 @@ def _concrete_int(fmt: FormatBound) -> int | None:
     """
     if isinstance(fmt, SetFormat) and len(fmt.values) == 1:
         (v,) = fmt.values
-        if v.denominator == 1:
+        # `NEG_ZERO` is not an integer: it is a distinct value that no `range`
+        # bound may be, and it has no `denominator`.
+        if isinstance(v, Fraction) and v.denominator == 1:
             return v.numerator
     return None
 
 
-def _all_representable_in(values: frozenset[Fraction], fmt: Format) -> bool:
+def _all_representable_in(values: frozenset[SetValue], fmt: Format) -> bool:
     """
     Returns true iff every value in *values* is representable under *fmt*.
 
@@ -348,6 +389,12 @@ def _all_representable_in(values: frozenset[Fraction], fmt: Format) -> bool:
     if fmt == REAL_FORMAT:
         return True
     for v in values:
+        if isinstance(v, NegZero):
+            # Exact, thanks to `representable_in` knowing about signed zeros: a
+            # two's-complement format answers False and a float format True.
+            if not fmt.representable_in(RealFloat(s=True, exp=0, c=0)):
+                return False
+            continue
         if not is_dyadic(v):
             return False
         if not fmt.representable_in(RealFloat.from_rational(v)):
@@ -444,9 +491,16 @@ def _setformat_to_abstract(s: SetFormat) -> AbstractFormat | None:
     """
     if not s.values:
         return None
-    if not all(is_dyadic(v) for v in s.values):
+    if not all(isinstance(v, NegZero) or is_dyadic(v) for v in s.values):
         return None
-    rfs = [RealFloat.from_rational(v) for v in s.values]
+    # `NEG_ZERO` becomes a `RealFloat` that carries the sign, which the bounds
+    # below then read like any other value.  Its presence also sets
+    # `has_neg_zero` on the result -- see the end of this function.
+    rfs = [
+        RealFloat(s=True, exp=0, c=0) if isinstance(v, NegZero)
+        else RealFloat.from_rational(v)
+        for v in s.values
+    ]
     # Bounds: max non-negative value and min non-positive value, with
     # zero used when no value falls on the corresponding side.  This
     # matches AbstractFormat's convention of pos_bound >= 0 and
@@ -461,7 +515,10 @@ def _setformat_to_abstract(s: SetFormat) -> AbstractFormat | None:
     prec = max((rf.p for rf in rfs), default=1)
     prec = max(prec, 1)
     exp = min((rf.exp for rf in rfs), default=0)
-    return AbstractFormat(prec, exp, pos_bound, neg_bound=neg_bound)
+    return AbstractFormat(
+        prec, exp, pos_bound, neg_bound=neg_bound,
+        has_neg_zero=any(isinstance(v, NegZero) for v in s.values),
+    )
 
 
 def _to_abstract(f: AbstractableFormatBound | SetFormat) -> AbstractFormat | None:
@@ -478,102 +535,86 @@ def _to_abstract(f: AbstractableFormatBound | SetFormat) -> AbstractFormat | Non
 
 _ZERO_SET: 'SetFormat' = SetFormat.from_value(Fraction(0))
 
-_SIGNED_ZERO_FORMAT: Format = AbstractFormat(
-    1, 0, RealFloat(s=False, exp=0, c=0),
-    neg_bound=RealFloat(s=True, exp=0, c=0), has_neg_zero=True,
-).format()
-"""
-A format whose value set is exactly the two zeros, ``{+0.0, -0.0}``.
-
-The bound for a value that is known to be a zero but not known to be the
-*positive* one -- which :class:`SetFormat` cannot say, since it holds
-:class:`Fraction`\\ s.  It is tight: it admits neither ``1.0`` nor anything else,
-so it claims far less than naming a whole float format would.
-
-Its ``has_neg_zero`` is what keeps it off an integer storage.  ``uint8_t`` holds
-the integer 0 and neither sign, and the C++ ladder's rungs report
-``has_neg_zero=False`` for every integer type, so containment rejects them and
-the value lands on a float -- which is the whole point.
-"""
+def _set_as_fraction(v: SetValue) -> Fraction:
+    """*v*'s magnitude-and-sign as a rational: :data:`NEG_ZERO` becomes ``0``."""
+    return Fraction(0) if isinstance(v, NegZero) else v
 
 
-def _set_with_signed_zero(
-    values: frozenset[Fraction],
-) -> 'AbstractFormat | None':
-    """*values*, widened by the possibility that its zero is a negative one.
+def _set_is_negative(v: SetValue) -> bool:
+    """Does *v* carry a minus sign?  True for :data:`NEG_ZERO`."""
+    return True if isinstance(v, NegZero) else v < 0
 
-    The honest bound when an operation's exact result is a zero whose sign is
-    not provably positive: the values are known, and the only thing a
-    :class:`SetFormat` cannot carry is which zero it holds — so say the values
-    *and* set ``has_neg_zero``.
 
-    Strictly tighter than giving up.  Returning ``None`` sends the caller to the
-    active scope's whole format (:meth:`_bound_if_fits` → :meth:`_op_bound`);
-    this keeps the value range and gives up only the zero's sign.  ``None`` is
-    still the answer for a non-dyadic set, which no ``AbstractFormat`` can pin.
+def _set_neg(v: SetValue) -> SetValue:
+    """``-v``.  Negation exchanges the two zeros."""
+    if isinstance(v, NegZero):
+        return Fraction(0)
+    return NEG_ZERO if v == 0 else -v
+
+
+def _set_abs(v: SetValue) -> SetValue:
+    """``abs(v)``.  Never a negative zero."""
+    return Fraction(0) if isinstance(v, NegZero) else abs(v)
+
+
+def _set_add(a: SetValue, b: SetValue) -> SetValue:
+    """``a + b``.
+
+    IEEE-754 §6.3: a sum is ``-0.0`` only when both addends are.  Every other
+    zero sum — including ``1 + (-1)`` and ``(-0.0) + (+0.0)`` — is ``+0.0``.
     """
-    af = _setformat_to_abstract(SetFormat(values))
-    if af is None:
-        return None
-    af.has_neg_zero = True
-    return af
+    if isinstance(a, NegZero) and isinstance(b, NegZero):
+        return NEG_ZERO
+    return _set_as_fraction(a) + _set_as_fraction(b)
 
 
-def _zero_result_is_positive(
-    op: Callable[..., Any], *operands: Fraction,
-) -> bool:
-    """For an application of *op* over *operands* whose exact result is zero:
-    is that zero provably ``+0.0``?
+def _set_sub(a: SetValue, b: SetValue) -> SetValue:
+    """``a - b``, as ``a + (-b)``.
 
-    **The invariant this exists to maintain:** ``Fraction(0)`` in a
-    :class:`SetFormat` means exactly ``+0.0``.  A ``Fraction`` has no signed
-    zero, so a set cannot say which zero it holds — and consumers read it
-    literally.  The C++ backend picks the narrowest type containing ``{0}``,
-    which is ``uint8_t``, and an integer holds neither sign.  So an operation
-    that may have produced a ``-0.0`` reports a :class:`Format` instead of a
-    set: sound, and it costs only precision, because the caller then falls back
-    to the active scope's format (:meth:`_bound_if_fits` → :meth:`_op_bound`),
-    which contains the value whichever zero it is.
-
-    The verdict is per *application*, not per result value: the sign of a zero
-    is a property of the operands that produced it, not of the zero sitting in
-    the result set.
-
-    Every ``Fraction(0)`` *operand* is therefore a ``+0.0``, which leaves only
-    IEEE 754 §6.3 to read:
-
-    - **product**: the sign is the XOR of the operand signs, in every rounding
-      mode.  So a zero product is ``+0.0`` exactly when neither operand is
-      negative.
-    - **sum**: when the operands have the same sign, so does the result.  Both
-      operands zero means both are ``+0.0``, hence ``+0.0``.  Otherwise the
-      operands are opposite-signed and the exact sum is zero, which §6.3 makes
-      ``+0.0`` in every mode *except* ``roundTowardNegative`` — and this
-      function does not know the mode.
-    - **difference**: ``a - b`` is ``a + (-b)``, so a zero result always comes
-      from opposite-signed addends — mode-dependent, including ``0 - 0``.
-    - **absolute value**: never negative, so a zero result is ``+0.0``.
-    - **negation**: a zero result means a zero operand, i.e. ``+0.0``, so the
-      result is ``-0.0``.  Never positive.
+    Not special-cased: routing through :func:`_set_add` reproduces every
+    measured case, including ``(-0.0) - (+0.0) = -0.0`` and
+    ``(-0.0) - (-0.0) = +0.0``.
     """
-    if op is abs:
-        return True
-    if op is operator.mul:
-        return all(v >= 0 for v in operands)
-    if op is operator.add:
-        return all(v == 0 for v in operands)
-    return False
+    return _set_add(a, _set_neg(b))
+
+
+def _set_mul(a: SetValue, b: SetValue) -> SetValue:
+    """``a * b``.
+
+    IEEE-754 §6.3: a product's sign is the XOR of the operand signs, in every
+    rounding mode — so a zero product is ``-0.0`` exactly when the signs differ.
+    That is why a negative operand and a ``+0.0`` give ``-0.0`` even though
+    neither is a negative zero.
+    """
+    product = _set_as_fraction(a) * _set_as_fraction(b)
+    if product != 0:
+        return product
+    return NEG_ZERO if _set_is_negative(a) != _set_is_negative(b) else Fraction(0)
+
+
+_SET_BINOPS: dict[Any, Callable[[SetValue, SetValue], SetValue]] = {
+    operator.add: _set_add,
+    operator.sub: _set_sub,
+    operator.mul: _set_mul,
+}
+"""Exact binary arithmetic over :data:`SetValue`, keyed by the operator the
+caller passes.  An operator absent here has no set-level rule, so
+:func:`exact_binop` falls back to the abstract path rather than guessing."""
+
+_SET_UNOPS: dict[Any, Callable[[SetValue], SetValue]] = {
+    operator.neg: _set_neg,
+    abs: _set_abs,
+}
+"""Exact unary arithmetic over :data:`SetValue`; see :data:`_SET_BINOPS`."""
 
 
 def _is_zero_set(f: 'FormatBound') -> bool:
     """``f`` is the precise singleton ``{0}`` — and therefore exactly ``+0.0``.
 
     Callers use this to apply algebraic identities that hold for ``+0.0`` and
-    not for ``-0.0``, so reading the sign off the set is load-bearing.  It is
-    sound because of :func:`_zero_result_is_positive`: every operation that could produce
-    the other zero declines to produce a set, so a ``SetFormat`` containing
-    ``Fraction(0)`` can only have come from a value that really is ``+0.0``
-    (a literal, a range, or a join of those).
+    not for ``-0.0``, so reading the sign off the set is load-bearing — and it is
+    now structural: a negative zero is :data:`NEG_ZERO`, a different element, so
+    ``{Fraction(0)}`` cannot be holding one.  No invariant to maintain.
     """
     return isinstance(f, SetFormat) and f.values == _ZERO_SET.values
 
@@ -620,20 +661,14 @@ def exact_binop(
     ):
         return None
     if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
-        values: set[Fraction] = set()
-        signed_zero = False
-        for va in lhs.values:
-            for vb in rhs.values:
-                r = op(va, vb)
-                if r == 0 and not _zero_result_is_positive(op, va, vb):
-                    signed_zero = True
-                values.add(r)
-        result = frozenset(values)
-        if signed_zero:
-            # A set cannot say which zero this is, so report the same values as
-            # an AbstractFormat that can.  Supersedes the cap: this is already
-            # the collapsed form.
-            return _set_with_signed_zero(result)
+        # Exact arithmetic over `SetValue`, which carries the sign of a zero --
+        # so the result set says which zero it holds and nothing has to widen.
+        set_op = _SET_BINOPS.get(op)
+        if set_op is None:
+            return None
+        result = frozenset(
+            set_op(va, vb) for va in lhs.values for vb in rhs.values
+        )
         if cap is not None and len(result) > cap:
             # collapse an over-large set to its covering AbstractFormat
             return _setformat_to_abstract(SetFormat(result))
@@ -676,17 +711,12 @@ def exact_unop(
     if not isinstance(arg, AbstractableFormatBound):
         return None
     if isinstance(arg, SetFormat):
-        values: set[Fraction] = set()
-        signed_zero = False
-        for v in arg.values:
-            r = op(v)
-            if r == 0 and not _zero_result_is_positive(op, v):
-                # `neg(+0.0)` is `-0.0`, which a `Fraction` set cannot state.
-                signed_zero = True
-            values.add(r)
-        if signed_zero:
-            return _set_with_signed_zero(frozenset(values))
-        return SetFormat(frozenset(values))
+        # See :func:`exact_binop`: `SetValue` carries the sign of a zero, so
+        # `neg({+0.0})` is exactly `{-0.0}` rather than something widened.
+        set_op = _SET_UNOPS.get(op)
+        if set_op is None:
+            return None
+        return SetFormat(frozenset(set_op(v) for v in arg.values))
     af = _to_abstract(arg)
     if af is None:
         return None
@@ -791,38 +821,25 @@ def _join_bounds(
 def _literal_bound(e) -> FormatBound:
     """A numeric literal's bound: the singleton set of its exact value.
 
-    Except a **signed zero**.  ``SetFormat`` holds :class:`Fraction`s, and a
-    ``Fraction`` has no signed zero — so ``SetFormat({0})`` would assert that
-    ``-0.0`` and ``+0.0`` are the same value.  They are not: ``-0.0`` is a
-    distinct real that compares equal to ``+0.0`` but is distinguishable by
-    ``copysign``, and by division, where ``x / -0.0`` and ``x / +0.0`` have
-    opposite signs.
-
-    So the set cannot state this literal's value, and a bound that cannot state
-    a value must not pretend to.  Report a *format* that does contain it
-    instead: :data:`_SIGNED_ZERO_FORMAT`, whose value set is exactly the two
-    zeros.
-
-    This is the written-out case of the invariant :func:`_zero_result_is_positive`
-    maintains for computed values: a ``SetFormat`` never holds a negative zero,
-    so ``Fraction(0)`` in one always means ``+0.0``.  Here the bound must be
-    *some* format (a literal has no scope to fall back to), which is why this
-    names one rather than returning ``None``.
+    Including a **signed zero**.  ``-0.0`` is a distinct real -- it compares
+    equal to ``+0.0`` but is told apart by ``copysign``, and by division, where
+    ``x / -0.0`` and ``x / +0.0`` have opposite signs -- and a :class:`Fraction`
+    cannot represent it.  :data:`NEG_ZERO` can, so the set states this literal's
+    value exactly like any other.
 
     The discriminator is the literal's **value**, not the type ``as_real``
     happens to return.  ``as_real`` returns a :class:`Float` only for a signed
     zero today, but that invariant lives in :mod:`fpy2.ast.fpyast` and this
-    function cannot enforce it: a ``Float`` holding, say, ``1e-400`` is not a
-    zero, and answering the two-zeros format for it would be a false bound no
-    consumer could detect.  A non-zero ``Float`` *is* an exact rational, so it takes the
-    ``SetFormat`` path; anything else — an infinity or a NaN, which no literal
-    parses to — has no rational value at all, so the honest answer is the
-    scalar top.
+    function cannot enforce it: a ``Float`` holding ``1e-400`` is not a zero, and
+    answering ``NEG_ZERO`` for it would be a false bound no consumer could
+    detect.  A non-zero ``Float`` *is* an exact rational, so it takes the
+    ``as_rational`` path; an infinity or a NaN -- which no literal parses to --
+    has no rational value at all, so the honest answer is the scalar top.
     """
     v = e.as_real()
     if isinstance(v, Float):
         if v.is_zero():
-            return _SIGNED_ZERO_FORMAT
+            return SetFormat.from_value(NEG_ZERO if v.s else Fraction(0))
         if v.isinf or v.isnan:
             return REAL_FORMAT
     return SetFormat.from_value(e.as_rational())

--- a/fpy2/analysis/format_infer/analysis.py
+++ b/fpy2/analysis/format_infer/analysis.py
@@ -135,7 +135,7 @@ from typing import Any, TypeAlias
 from ...ast.fpyast import *
 from ...ast.visitor import Visitor
 from ...function import Function
-from ...number import FP32, INTEGER, REAL, Context, Float, RealFloat
+from ...number import INTEGER, REAL, Context, Float, RealFloat
 from ...number.format import REAL_FORMAT, Format
 from ...types import (
     BoolType,
@@ -478,6 +478,46 @@ def _to_abstract(f: AbstractableFormatBound | SetFormat) -> AbstractFormat | Non
 
 _ZERO_SET: 'SetFormat' = SetFormat.from_value(Fraction(0))
 
+_SIGNED_ZERO_FORMAT: Format = AbstractFormat(
+    1, 0, RealFloat(s=False, exp=0, c=0),
+    neg_bound=RealFloat(s=True, exp=0, c=0), has_neg_zero=True,
+).format()
+"""
+A format whose value set is exactly the two zeros, ``{+0.0, -0.0}``.
+
+The bound for a value that is known to be a zero but not known to be the
+*positive* one -- which :class:`SetFormat` cannot say, since it holds
+:class:`Fraction`\\ s.  It is tight: it admits neither ``1.0`` nor anything else,
+so it claims far less than naming a whole float format would.
+
+Its ``has_neg_zero`` is what keeps it off an integer storage.  ``uint8_t`` holds
+the integer 0 and neither sign, and the C++ ladder's rungs report
+``has_neg_zero=False`` for every integer type, so containment rejects them and
+the value lands on a float -- which is the whole point.
+"""
+
+
+def _set_with_signed_zero(
+    values: frozenset[Fraction],
+) -> 'AbstractFormat | None':
+    """*values*, widened by the possibility that its zero is a negative one.
+
+    The honest bound when an operation's exact result is a zero whose sign is
+    not provably positive: the values are known, and the only thing a
+    :class:`SetFormat` cannot carry is which zero it holds — so say the values
+    *and* set ``has_neg_zero``.
+
+    Strictly tighter than giving up.  Returning ``None`` sends the caller to the
+    active scope's whole format (:meth:`_bound_if_fits` → :meth:`_op_bound`);
+    this keeps the value range and gives up only the zero's sign.  ``None`` is
+    still the answer for a non-dyadic set, which no ``AbstractFormat`` can pin.
+    """
+    af = _setformat_to_abstract(SetFormat(values))
+    if af is None:
+        return None
+    af.has_neg_zero = True
+    return af
+
 
 def _zero_result_is_positive(
     op: Callable[..., Any], *operands: Fraction,
@@ -581,17 +621,19 @@ def exact_binop(
         return None
     if isinstance(lhs, SetFormat) and isinstance(rhs, SetFormat):
         values: set[Fraction] = set()
+        signed_zero = False
         for va in lhs.values:
             for vb in rhs.values:
                 r = op(va, vb)
                 if r == 0 and not _zero_result_is_positive(op, va, vb):
-                    # May be a `-0.0`; see :func:`_zero_result_is_positive`.
-                    # Ahead of the cap, because collapsing to an AbstractFormat
-                    # would not rescue it — one bounded by zero on both sides
-                    # says the same unstatable thing a `{0}` set does.
-                    return None
+                    signed_zero = True
                 values.add(r)
         result = frozenset(values)
+        if signed_zero:
+            # A set cannot say which zero this is, so report the same values as
+            # an AbstractFormat that can.  Supersedes the cap: this is already
+            # the collapsed form.
+            return _set_with_signed_zero(result)
         if cap is not None and len(result) > cap:
             # collapse an over-large set to its covering AbstractFormat
             return _setformat_to_abstract(SetFormat(result))
@@ -635,12 +677,15 @@ def exact_unop(
         return None
     if isinstance(arg, SetFormat):
         values: set[Fraction] = set()
+        signed_zero = False
         for v in arg.values:
             r = op(v)
             if r == 0 and not _zero_result_is_positive(op, v):
                 # `neg(+0.0)` is `-0.0`, which a `Fraction` set cannot state.
-                return None
+                signed_zero = True
             values.add(r)
+        if signed_zero:
+            return _set_with_signed_zero(frozenset(values))
         return SetFormat(frozenset(values))
     af = _to_abstract(arg)
     if af is None:
@@ -755,9 +800,8 @@ def _literal_bound(e) -> FormatBound:
 
     So the set cannot state this literal's value, and a bound that cannot state
     a value must not pretend to.  Report a *format* that does contain it
-    instead — less precise, but true.  Every binary floating-point format has a
-    signed zero, so ``FP32`` is a true bound for one; it is picked as a small
-    widely-supported format, and nothing here depends on which.
+    instead: :data:`_SIGNED_ZERO_FORMAT`, whose value set is exactly the two
+    zeros.
 
     This is the written-out case of the invariant :func:`_zero_result_is_positive`
     maintains for computed values: a ``SetFormat`` never holds a negative zero,
@@ -768,9 +812,9 @@ def _literal_bound(e) -> FormatBound:
     The discriminator is the literal's **value**, not the type ``as_real``
     happens to return.  ``as_real`` returns a :class:`Float` only for a signed
     zero today, but that invariant lives in :mod:`fpy2.ast.fpyast` and this
-    function cannot enforce it: a ``Float`` holding, say, ``1e-400`` is not in
-    ``FP32``, and answering ``FP32`` for it would be a false bound no consumer
-    could detect.  A non-zero ``Float`` *is* an exact rational, so it takes the
+    function cannot enforce it: a ``Float`` holding, say, ``1e-400`` is not a
+    zero, and answering the two-zeros format for it would be a false bound no
+    consumer could detect.  A non-zero ``Float`` *is* an exact rational, so it takes the
     ``SetFormat`` path; anything else — an infinity or a NaN, which no literal
     parses to — has no rational value at all, so the honest answer is the
     scalar top.
@@ -778,7 +822,7 @@ def _literal_bound(e) -> FormatBound:
     v = e.as_real()
     if isinstance(v, Float):
         if v.is_zero():
-            return FP32.format()
+            return _SIGNED_ZERO_FORMAT
         if v.isinf or v.isnan:
             return REAL_FORMAT
     return SetFormat.from_value(e.as_rational())

--- a/fpy2/analysis/format_infer/format.py
+++ b/fpy2/analysis/format_infer/format.py
@@ -439,34 +439,19 @@ class AbstractFormat:
         af.has_nan = fmt.representable_in(Float.nan())
         # `MPFixedFormat` is taken as having no negative zero, whatever it says.
         #
-        # TODO: this is a lie and it needs fixing.  `MPFixedFormat` backs FPy's
-        # `INTEGER`, which really does hold a negative zero, deliberately -- but
-        # no C++ integer type does.
+        # TODO: a lie, and the last one here.  `MPFixedFormat` backs FPy's
+        # `INTEGER`, which does hold a negative zero -- but no C++ integer type
+        # does, and believing it diverges the loop fixpoint in
+        # `test_while{5,6,7}_rounded` to `REAL_FORMAT`, which nothing can store.
+        # It costs one divergence: `-x` for an `INTEGER` parameter `x == 0` gives
+        # `-0.0` from the interpreter and `0` from compiled code.  A *literal*
+        # zero is fine -- its bound is a `SetFormat`, which states the sign.
+        # `docs/todos/reals-in-integer-storage.md` has the diagnosis and the two
+        # candidate fixes.
         #
-        # The scope is now as narrow as it can be made from this side.  Integer
-        # *counts* no longer need the lie: `format_infer._INTEGER_FORMAT` is its
-        # own `MPFixedFormat` with `enable_neg_zero=False`, because a list length
-        # is an integer and an integer has one zero.  What remains is a real
-        # rounded under an ``INTEGER`` *scope*, whose bound is `INTEGER.format()`
-        # itself.
-        #
-        # Believing *that* is what is still unaffordable, and the obstacle is no
-        # longer storage selection -- it is the loop fixpoint.  For `x += 1`
-        # inside `with fp.INTEGER:`, the scope admits a `-0.0` while the sum
-        # provably cannot be one (a sum is `-0.0` only when both addends are), so
-        # `scope_af <= exact` correctly fails, `_bound_if_fits` takes its
-        # mixed-overlap branch, and `test_while{5,6,7}_rounded` widen to
-        # `REAL_FORMAT` -- which no C++ type can hold.  Intersecting the
-        # membership flags in that branch was tried and does not converge either.
-        #
-        # So the fix is either to stop `MPFixedContext` preserving signed zeros
-        # (contradicting `TestMPFixedKeepsNegativeZero`), or to make that
-        # fixpoint stable when a bound and its scope disagree about a membership
-        # flag.  Until then this leaves one divergence: negating an integer whose
-        # zero is not statically known -- `-x` for an `INTEGER` parameter `x == 0`
-        # gives `-0.0` from the interpreter and `0` from compiled code.  A
-        # *literal* zero is fine; its bound is a `SetFormat`, which states the
-        # sign via `NEG_ZERO`.  See `docs/todos/reals-in-integer-storage.md`.
+        # Not extended to `MPBFixedFormat`: its `enable_neg_zero` is what lets a
+        # bound say "this really can be a negative zero" and so reach a float
+        # storage, which is the whole point of the flag.
         af.has_neg_zero = (
             not isinstance(fmt, MPFixedFormat)
             and fmt.representable_in(Float(s=True, exp=0, c=0))
@@ -521,16 +506,15 @@ class AbstractFormat:
                         enable_nan=enable_nan, enable_inf=enable_inf,
                         enable_neg_zero=self.has_neg_zero,
                     )
-                else:
-                    neg_maxval = self.neg_bound
-                    if not neg_maxval.s:
-                        # MPBFloatFormat requires a strictly-negative neg_maxval;
-                        # widen symmetrically (sound over-approximation).
-                        neg_maxval = RealFloat(s=True, x=self.pos_bound)
-                    return MPBFloatFormat(
-                        self.prec, emin, self.pos_bound, neg_maxval,
-                        enable_nan=enable_nan, enable_inf=enable_inf,
-                    )
+                neg_maxval = self.neg_bound
+                if not neg_maxval.s:
+                    # MPBFloatFormat requires a strictly-negative neg_maxval;
+                    # widen symmetrically (sound over-approximation).
+                    neg_maxval = RealFloat(s=True, x=self.pos_bound)
+                return MPBFloatFormat(
+                    self.prec, emin, self.pos_bound, neg_maxval,
+                    enable_nan=enable_nan, enable_inf=enable_inf,
+                )
             if bounds_unbounded:
                 return MPSFloatFormat(
                     self.prec, emin, enable_nan=enable_nan, enable_inf=enable_inf,
@@ -637,11 +621,11 @@ class AbstractFormat:
              ``RealFloat`` bounds by magnitude, so the two zeros are
              indistinguishable there.
 
-        Adding a membership implication only ever *removes* containments, so a
-        flag that under-reports costs precision rather than soundness.  The
-        arithmetic operators do not yet derive ``has_neg_zero`` for their
-        results, which is exactly such an under-report; see the note on
-        :meth:`__neg__`.
+        Under-reporting a flag is not merely imprecise.  It accepts containments
+        that should fail, and storage selection reads that as permission -- a
+        bound that can hold a ``-0.0`` reaching an integer type is a wrong
+        answer, not a loose one.  Every operator derives ``has_neg_zero`` for
+        this reason.
         """
 
         # 4. special values

--- a/fpy2/analysis/format_infer/format.py
+++ b/fpy2/analysis/format_infer/format.py
@@ -55,6 +55,7 @@ class AbstractFormat:
     - `has_pos_inf`: whether `+inf` is a representable value
     - `has_neg_inf`: whether `-inf` is a representable value
     - `has_nan`: whether `NaN` is a representable value
+    - `has_neg_zero`: whether `-0.0` is a representable value
 
     A special-value flag is independent of the corresponding bound: e.g.
     `pos_bound = inf` means the finite grid is unbounded, not that `+inf` is a
@@ -68,6 +69,7 @@ class AbstractFormat:
     has_pos_inf: bool
     has_neg_inf: bool
     has_nan: bool
+    has_neg_zero: bool
 
     def __init__(
         self,
@@ -79,6 +81,7 @@ class AbstractFormat:
         has_pos_inf: bool = False,
         has_neg_inf: bool = False,
         has_nan: bool = False,
+        has_neg_zero: bool = False,
     ):
         if prec <= 0:
             raise ValueError("`prec` must be positive.")
@@ -90,11 +93,12 @@ class AbstractFormat:
         self.has_pos_inf = has_pos_inf
         self.has_neg_inf = has_neg_inf
         self.has_nan = has_nan
+        self.has_neg_zero = has_neg_zero
 
     def __hash__(self):
         return hash((
             self.prec, self.exp, self.pos_bound, self.neg_bound,
-            self.has_pos_inf, self.has_neg_inf, self.has_nan,
+            self.has_pos_inf, self.has_neg_inf, self.has_nan, self.has_neg_zero,
         ))
 
     def __eq__(self, other):
@@ -107,6 +111,7 @@ class AbstractFormat:
             and self.has_pos_inf == other.has_pos_inf
             and self.has_neg_inf == other.has_neg_inf
             and self.has_nan == other.has_nan
+            and self.has_neg_zero == other.has_neg_zero
         )
 
     def __str__(self) -> str:
@@ -115,6 +120,7 @@ class AbstractFormat:
                 (self.has_pos_inf, '+inf'),
                 (self.has_neg_inf, '-inf'),
                 (self.has_nan, 'nan'),
+                (self.has_neg_zero, '-0'),
             ) if flag
         )
         base = f'A({self.prec}, {self.exp}, +{self.pos_bound}, {self.neg_bound}'
@@ -125,10 +131,27 @@ class AbstractFormat:
         return AbstractFormat(
             self.prec, self.exp, self.pos_bound, neg_bound=self.neg_bound,
             has_pos_inf=self.has_pos_inf, has_neg_inf=self.has_neg_inf, has_nan=self.has_nan,
+            has_neg_zero=self.has_neg_zero,
         )
 
     def __neg__(self) -> 'AbstractFormat':
-        """Negation of the format (swaps positive and negative bounds)."""
+        """Negation of the format (swaps positive and negative bounds).
+
+        ``has_neg_zero`` is deliberately **not** derived here yet, and the same
+        goes for :meth:`__add__`, :meth:`__sub__` and :meth:`__mul__`.  The
+        correct rule is not a flag swap: negation yields a ``-0.0`` exactly when
+        the operand contains a ``+0.0``, and since ``pos_bound >= 0 >=
+        neg_bound`` holds by convention, every operand does.  A conservative
+        ``True`` here would therefore mark every arithmetic result as holding a
+        negative zero and collapse integer storage wholesale, so the rule needs
+        to be derived per operator against real measurement rather than assumed.
+
+        Leaving it ``False`` reproduces today's behaviour exactly: the flag is an
+        extra containment *requirement*, so under-reporting it accepts the same
+        storages as before rather than a narrower one.  Concretely, ``-z`` on an
+        integer-bounded ``z`` still selects an integer and still drops the sign;
+        that case is unfixed, not newly broken.
+        """
         # negation maps +inf <-> -inf; NaN is unsigned so it is preserved
         return AbstractFormat(
             self.prec, self.exp, -self.neg_bound, neg_bound=-self.pos_bound,
@@ -338,10 +361,32 @@ class AbstractFormat:
         Callers should gate with ``isinstance(fmt, AbstractableFormat)``.
 
         Special-value membership is derived by probing *fmt*'s
-        :meth:`representable_in` with each signed infinity and NaN.  Probing
-        ``+inf``/``-inf`` separately captures per-sign asymmetry a single
-        ``enable_inf`` flag cannot (e.g. a positive-only format has no -inf).
-        This round-trips with :meth:`format`, which sets the ``enable_*`` flags.
+        :meth:`representable_in` with each signed infinity, NaN, and a negative
+        zero.  Probing ``+inf``/``-inf`` separately captures per-sign asymmetry a
+        single ``enable_inf`` flag cannot (e.g. a positive-only format has no
+        -inf).  This round-trips with :meth:`format`, which sets the
+        ``enable_*`` flags.
+
+        **Carve-out: a fixed-point format reports no negative zero**, whatever
+        its ``representable_in`` says.  ``MPFixedFormat`` (which backs FPy's
+        ``INTEGER``) does hold one, but taking it at face value marks every
+        integer-valued bound as needing a signed zero — and since no ``Format``
+        has an ``enable_neg_zero``, :meth:`format` cannot materialize a
+        fixed-point format *without* one either, so an integer bound that
+        round-trips through it acquires the flag as well.  Between them, loop
+        counters and integer arithmetic all retype to ``float``.
+
+        TODO: drop the carve-out once ``MPFixedFormat`` / ``MPBFixedFormat``
+        grow an option to disable ``-0.0``.  Then integer contexts can say so
+        directly, ``format()`` becomes lossless, and the real bug behind the
+        carve-out is fixable: FPy's ``INTEGER`` genuinely has a negative zero
+        while C++ ``int64_t`` does not, so ``-z`` on an integer ``z`` returns
+        ``-0.0`` from the interpreter and ``0`` from compiled code.  Under this
+        carve-out that divergence stays as it is today.
+
+        Because a membership flag is a containment *requirement*, under-reporting
+        it only ever accepts the storages it accepted before — so the carve-out
+        costs nothing in soundness relative to today and defers precision.
         """
         # finite grid: quantum, precision, and bounds
         match fmt:
@@ -387,9 +432,14 @@ class AbstractFormat:
                 raise ValueError(f'format is not abstractable: {fmt!r}')
 
         # special values: probe the format's representable set directly.
+        # TODO: drop the carve-out once MPFixedFormat / MPBFixedFormat gain an option to disable -0.0.
         af.has_pos_inf = fmt.representable_in(Float.inf(s=False))
         af.has_neg_inf = fmt.representable_in(Float.inf(s=True))
         af.has_nan = fmt.representable_in(Float.nan())
+        af.has_neg_zero = (
+            not isinstance(fmt, MPFixedFormat | MPBFixedFormat)
+            and fmt.representable_in(Float(s=True, exp=0, c=0))
+        )
         return af
 
     def format(self) -> Format:
@@ -490,7 +540,16 @@ class AbstractFormat:
              other's subnormal region (pos_bound <= 2^(other.exp + other.prec)), in which case
              the floating-point precision of other is irrelevant — all values fit exactly.
           4. Special values: every special value in self must also be in other
-             (a member of self that other lacks breaks containment).
+             (a member of self that other lacks breaks containment).  This
+             includes ``-0.0``, which conditions 1-3 cannot see: they compare
+             ``RealFloat`` bounds by magnitude, so the two zeros are
+             indistinguishable there.
+
+        Adding a membership implication only ever *removes* containments, so a
+        flag that under-reports costs precision rather than soundness.  The
+        arithmetic operators do not yet derive ``has_neg_zero`` for their
+        results, which is exactly such an under-report; see the note on
+        :meth:`__neg__`.
         """
 
         # 4. special values — each is a cheap membership implication
@@ -499,6 +558,8 @@ class AbstractFormat:
         if self.has_neg_inf and not other.has_neg_inf:
             return False
         if self.has_nan and not other.has_nan:
+            return False
+        if self.has_neg_zero and not other.has_neg_zero:
             return False
 
         # 1. quantum

--- a/fpy2/analysis/format_infer/format.py
+++ b/fpy2/analysis/format_infer/format.py
@@ -439,23 +439,34 @@ class AbstractFormat:
         af.has_nan = fmt.representable_in(Float.nan())
         # `MPFixedFormat` is taken as having no negative zero, whatever it says.
         #
-        # TODO: this is a lie and it needs fixing.  `MPFixedFormat` -- which backs
-        # FPy's `INTEGER` -- really does hold a negative zero, deliberately so.
-        # But C++ has no integer type that does, and believing the format costs
-        # integer storage everywhere: measured, it retypes every `range` counter
-        # as `float`, and it diverges the loop fixpoint in
-        # `test_while{5,6,7}_rounded` all the way to `REAL_FORMAT`, which no C++
-        # type can hold.  The honest fix is either for `MPFixedContext` to flatten
-        # signed zeros the way `FixedContext` already does, or for the backend to
-        # stop storing `INTEGER`-bounded reals in `int64_t`.  Until then this
-        # leaves one known divergence unfixed: `-z` on an integer `z` returns
-        # `-0.0` from the interpreter and `0` from compiled code (see
-        # `docs/todos/reals-in-integer-storage.md`).
+        # TODO: this is a lie and it needs fixing.  `MPFixedFormat` backs FPy's
+        # `INTEGER`, which really does hold a negative zero, deliberately -- but
+        # no C++ integer type does.
         #
-        # Deliberately *not* extended to `MPBFixedFormat`: its `enable_neg_zero`
-        # is the one thing that lets a bound say "this really can be a negative
-        # zero" and so reach a float storage, which is the whole point of the
-        # flag.  Only the unbounded fixed-point case is distrusted here.
+        # The scope is now as narrow as it can be made from this side.  Integer
+        # *counts* no longer need the lie: `format_infer._INTEGER_FORMAT` is its
+        # own `MPFixedFormat` with `enable_neg_zero=False`, because a list length
+        # is an integer and an integer has one zero.  What remains is a real
+        # rounded under an ``INTEGER`` *scope*, whose bound is `INTEGER.format()`
+        # itself.
+        #
+        # Believing *that* is what is still unaffordable, and the obstacle is no
+        # longer storage selection -- it is the loop fixpoint.  For `x += 1`
+        # inside `with fp.INTEGER:`, the scope admits a `-0.0` while the sum
+        # provably cannot be one (a sum is `-0.0` only when both addends are), so
+        # `scope_af <= exact` correctly fails, `_bound_if_fits` takes its
+        # mixed-overlap branch, and `test_while{5,6,7}_rounded` widen to
+        # `REAL_FORMAT` -- which no C++ type can hold.  Intersecting the
+        # membership flags in that branch was tried and does not converge either.
+        #
+        # So the fix is either to stop `MPFixedContext` preserving signed zeros
+        # (contradicting `TestMPFixedKeepsNegativeZero`), or to make that
+        # fixpoint stable when a bound and its scope disagree about a membership
+        # flag.  Until then this leaves one divergence: negating an integer whose
+        # zero is not statically known -- `-x` for an `INTEGER` parameter `x == 0`
+        # gives `-0.0` from the interpreter and `0` from compiled code.  A
+        # *literal* zero is fine; its bound is a `SetFormat`, which states the
+        # sign via `NEG_ZERO`.  See `docs/todos/reals-in-integer-storage.md`.
         af.has_neg_zero = (
             not isinstance(fmt, MPFixedFormat)
             and fmt.representable_in(Float(s=True, exp=0, c=0))
@@ -594,6 +605,23 @@ class AbstractFormat:
         # everything else
         return self.prec
 
+    def specials_contained_in(self, other: 'AbstractFormat') -> bool:
+        """Is every special value of ``self`` also one of ``other``?
+
+        Condition 4 of :meth:`_is_contained_in`, factored out because storage
+        selection needs it *without* the magnitude conditions: its fallback for an
+        unbounded integer deliberately ignores the bounds, but must not ignore
+        these.  Keeping one implementation is the point -- ``has_neg_zero`` was
+        added to the containment check and missed in that fallback, which let a
+        bound carrying a ``-0.0`` reach an integer storage.
+        """
+        return not (
+            (self.has_pos_inf and not other.has_pos_inf)
+            or (self.has_neg_inf and not other.has_neg_inf)
+            or (self.has_nan and not other.has_nan)
+            or (self.has_neg_zero and not other.has_neg_zero)
+        )
+
     def _is_contained_in(self, other: 'AbstractFormat') -> bool:
         """Return True iff every value representable by `self` is also representable by `other`.
 
@@ -616,14 +644,8 @@ class AbstractFormat:
         :meth:`__neg__`.
         """
 
-        # 4. special values — each is a cheap membership implication
-        if self.has_pos_inf and not other.has_pos_inf:
-            return False
-        if self.has_neg_inf and not other.has_neg_inf:
-            return False
-        if self.has_nan and not other.has_nan:
-            return False
-        if self.has_neg_zero and not other.has_neg_zero:
+        # 4. special values
+        if not self.specials_contained_in(other):
             return False
 
         # 1. quantum

--- a/fpy2/analysis/format_infer/format.py
+++ b/fpy2/analysis/format_infer/format.py
@@ -137,30 +137,25 @@ class AbstractFormat:
     def __neg__(self) -> 'AbstractFormat':
         """Negation of the format (swaps positive and negative bounds).
 
-        ``has_neg_zero`` is deliberately **not** derived here yet, and the same
-        goes for :meth:`__add__`, :meth:`__sub__` and :meth:`__mul__`.  The
-        correct rule is not a flag swap: negation yields a ``-0.0`` exactly when
-        the operand contains a ``+0.0``, and since ``pos_bound >= 0 >=
-        neg_bound`` holds by convention, every operand does.  A conservative
-        ``True`` here would therefore mark every arithmetic result as holding a
-        negative zero and collapse integer storage wholesale, so the rule needs
-        to be derived per operator against real measurement rather than assumed.
-
-        Leaving it ``False`` reproduces today's behaviour exactly: the flag is an
-        extra containment *requirement*, so under-reporting it accepts the same
-        storages as before rather than a narrower one.  Concretely, ``-z`` on an
-        integer-bounded ``z`` still selects an integer and still drops the sign;
-        that case is unfixed, not newly broken.
+        ``has_neg_zero`` carries over unchanged.  Negation maps ``+0.0`` to
+        ``-0.0``, and every grid contains a ``+0.0`` -- ``pos_bound >= 0 >=
+        neg_bound`` holds by convention and nothing excludes zero -- so the image
+        holds a ``-0.0`` exactly when this number system has one at all.  A
+        system without: ``-(0)`` under ``SINT8`` is ``+0.0``, since
+        two's-complement has a single zero.
         """
         # negation maps +inf <-> -inf; NaN is unsigned so it is preserved
         return AbstractFormat(
             self.prec, self.exp, -self.neg_bound, neg_bound=-self.pos_bound,
             has_pos_inf=self.has_neg_inf, has_neg_inf=self.has_pos_inf, has_nan=self.has_nan,
+            has_neg_zero=self.has_neg_zero,
         )
 
     def __abs__(self) -> 'AbstractFormat':
         """Absolute value of the format (clamps the negative bound to zero)."""
-        # abs maps -inf to +inf, so +inf is present if either infinity was
+        # abs maps -inf to +inf, so +inf is present if either infinity was.
+        # `has_neg_zero` is left at its default: `abs` never yields a negative
+        # zero, so false is the derived answer here, not an omission.
         return AbstractFormat(
             self.prec, self.exp, self.pos_bound, neg_bound=RealFloat.from_int(0),
             has_pos_inf=self.has_pos_inf or self.has_neg_inf, has_neg_inf=False, has_nan=self.has_nan,
@@ -211,10 +206,14 @@ class AbstractFormat:
             or (self.has_pos_inf and other.has_neg_inf)
             or (self.has_neg_inf and other.has_pos_inf)
         )
+        # A sum is `-0.0` only when *both* addends are: IEEE-754 gives a
+        # like-signed sum that sign, and every other zero sum is `+0.0`.
+        has_neg_zero = self.has_neg_zero and other.has_neg_zero
 
         return AbstractFormat(
             prec, exp, pos_bound, neg_bound=neg_bound,
             has_pos_inf=has_pos_inf, has_neg_inf=has_neg_inf, has_nan=has_nan,
+            has_neg_zero=has_neg_zero,
         )
 
     def __sub__(self, other: 'AbstractFormat') -> 'AbstractFormat':
@@ -264,10 +263,16 @@ class AbstractFormat:
             or (self.has_pos_inf and other.has_pos_inf)
             or (self.has_neg_inf and other.has_neg_inf)
         )
+        # `a - b` is `a + (-b)`, so by the sum rule both addends must be able to
+        # be `-0.0`: `a` directly, and `-b` when *b* can be `+0.0`.  Every grid
+        # contains a `+0.0` -- `pos_bound >= 0 >= neg_bound` holds by convention
+        # and nothing excludes zero -- so only `a` is in question.
+        has_neg_zero = self.has_neg_zero
 
         return AbstractFormat(
             prec, exp, pos_bound, neg_bound=neg_bound,
             has_pos_inf=has_pos_inf, has_neg_inf=has_neg_inf, has_nan=has_nan,
+            has_neg_zero=has_neg_zero,
         )
 
 
@@ -298,9 +303,18 @@ class AbstractFormat:
         other_inf = other.has_pos_inf or other.has_neg_inf
         inf_out = self_inf or other_inf
         has_nan = self.has_nan or other.has_nan or inf_out
+        # A zero product takes the XOR of the operand signs (IEEE-754 §6.3, in
+        # every rounding mode), so a `-0.0` needs a sign disagreement -- and one
+        # is always available once *either* number system has a signed zero:
+        # every grid contains a `+0.0`, and a negative times that zero is
+        # `-0.0`.  When neither system has one, no product can be one:
+        # two's-complement has a single zero, and `(-2) * 0` under `SINT8` is
+        # `+0.0`.
+        has_neg_zero = self.has_neg_zero or other.has_neg_zero
         return AbstractFormat(
             prec, exp, pos_bound, neg_bound=neg_bound,
             has_pos_inf=inf_out, has_neg_inf=inf_out, has_nan=has_nan,
+            has_neg_zero=has_neg_zero,
         )
 
     def __and__(self, other: 'AbstractFormat') -> 'AbstractFormat':
@@ -367,26 +381,13 @@ class AbstractFormat:
         -inf).  This round-trips with :meth:`format`, which sets the
         ``enable_*`` flags.
 
-        **Carve-out: a fixed-point format reports no negative zero**, whatever
-        its ``representable_in`` says.  ``MPFixedFormat`` (which backs FPy's
-        ``INTEGER``) does hold one, but taking it at face value marks every
-        integer-valued bound as needing a signed zero — and since no ``Format``
-        has an ``enable_neg_zero``, :meth:`format` cannot materialize a
-        fixed-point format *without* one either, so an integer bound that
-        round-trips through it acquires the flag as well.  Between them, loop
-        counters and integer arithmetic all retype to ``float``.
-
-        TODO: drop the carve-out once ``MPFixedFormat`` / ``MPBFixedFormat``
-        grow an option to disable ``-0.0``.  Then integer contexts can say so
-        directly, ``format()`` becomes lossless, and the real bug behind the
-        carve-out is fixable: FPy's ``INTEGER`` genuinely has a negative zero
-        while C++ ``int64_t`` does not, so ``-z`` on an integer ``z`` returns
-        ``-0.0`` from the interpreter and ``0`` from compiled code.  Under this
-        carve-out that divergence stays as it is today.
-
-        Because a membership flag is a containment *requirement*, under-reporting
-        it only ever accepts the storages it accepted before — so the carve-out
-        costs nothing in soundness relative to today and defers precision.
+        ``has_neg_zero`` round-trips like the others, via each format's
+        ``enable_neg_zero``.  That flag exists for this: without it
+        :meth:`format` could not express "no negative zero", so every
+        integer-valued bound materialized on the way to storage selection would
+        acquire one and lose its integer storage — ``int8 + int8`` lands on a
+        *float*-shaped ``MPBFloatFormat``, whose value set legitimately includes
+        a ``-0.0`` unless told otherwise.
         """
         # finite grid: quantum, precision, and bounds
         match fmt:
@@ -436,8 +437,27 @@ class AbstractFormat:
         af.has_pos_inf = fmt.representable_in(Float.inf(s=False))
         af.has_neg_inf = fmt.representable_in(Float.inf(s=True))
         af.has_nan = fmt.representable_in(Float.nan())
+        # `MPFixedFormat` is taken as having no negative zero, whatever it says.
+        #
+        # TODO: this is a lie and it needs fixing.  `MPFixedFormat` -- which backs
+        # FPy's `INTEGER` -- really does hold a negative zero, deliberately so.
+        # But C++ has no integer type that does, and believing the format costs
+        # integer storage everywhere: measured, it retypes every `range` counter
+        # as `float`, and it diverges the loop fixpoint in
+        # `test_while{5,6,7}_rounded` all the way to `REAL_FORMAT`, which no C++
+        # type can hold.  The honest fix is either for `MPFixedContext` to flatten
+        # signed zeros the way `FixedContext` already does, or for the backend to
+        # stop storing `INTEGER`-bounded reals in `int64_t`.  Until then this
+        # leaves one known divergence unfixed: `-z` on an integer `z` returns
+        # `-0.0` from the interpreter and `0` from compiled code (see
+        # `docs/todos/reals-in-integer-storage.md`).
+        #
+        # Deliberately *not* extended to `MPBFixedFormat`: its `enable_neg_zero`
+        # is the one thing that lets a bound say "this really can be a negative
+        # zero" and so reach a float storage, which is the whole point of the
+        # flag.  Only the unbounded fixed-point case is distrusted here.
         af.has_neg_zero = (
-            not isinstance(fmt, MPFixedFormat | MPBFixedFormat)
+            not isinstance(fmt, MPFixedFormat)
             and fmt.representable_in(Float(s=True, exp=0, c=0))
         )
         return af
@@ -479,15 +499,27 @@ class AbstractFormat:
             if bounds_bounded:
                 assert isinstance(self.pos_bound, RealFloat)
                 assert isinstance(self.neg_bound, RealFloat)
-                neg_maxval = self.neg_bound
-                if not neg_maxval.s:
-                    # MPBFloatFormat requires a strictly-negative neg_maxval;
-                    # widen symmetrically (sound over-approximation).
-                    neg_maxval = RealFloat(s=True, x=self.pos_bound)
-                return MPBFloatFormat(
-                    self.prec, emin, self.pos_bound, neg_maxval,
-                    enable_nan=enable_nan, enable_inf=enable_inf,
-                )
+                if not self._prec_constrains():
+                    # An integer grid: describe it as fixed-point.  Materializing
+                    # as a float would be correct but perverse — every value would
+                    # be subnormal — and, more to the point, a float format has a
+                    # signed zero.  `int8 + int8` lands here, and describing it as a
+                    # float is what cost it its `int16_t` storage.
+                    return MPBFixedFormat(
+                        self.exp - 1, self.pos_bound, self.neg_bound,
+                        enable_nan=enable_nan, enable_inf=enable_inf,
+                        enable_neg_zero=self.has_neg_zero,
+                    )
+                else:
+                    neg_maxval = self.neg_bound
+                    if not neg_maxval.s:
+                        # MPBFloatFormat requires a strictly-negative neg_maxval;
+                        # widen symmetrically (sound over-approximation).
+                        neg_maxval = RealFloat(s=True, x=self.pos_bound)
+                    return MPBFloatFormat(
+                        self.prec, emin, self.pos_bound, neg_maxval,
+                        enable_nan=enable_nan, enable_inf=enable_inf,
+                    )
             if bounds_unbounded:
                 return MPSFloatFormat(
                     self.prec, emin, enable_nan=enable_nan, enable_inf=enable_inf,
@@ -506,11 +538,43 @@ class AbstractFormat:
                 return MPBFixedFormat(
                     nmin, self.pos_bound, self.neg_bound,
                     enable_nan=enable_nan, enable_inf=enable_inf,
+                    enable_neg_zero=self.has_neg_zero,
                 )
             if bounds_unbounded:
-                return MPFixedFormat(nmin, enable_nan=enable_nan, enable_inf=enable_inf)
+                return MPFixedFormat(nmin, enable_nan=enable_nan, enable_inf=enable_inf,
+                    enable_neg_zero=self.has_neg_zero)
 
         return REAL_FORMAT
+
+    def _prec_constrains(self) -> bool:
+        """Does ``prec`` actually thin the grid inside the bounds?
+
+        The grid has spacing ``2**exp``; spanning the bounds at that spacing
+        needs some number of significand bits.  If ``prec`` supplies at least
+        that many it removes nothing, and the value set is the *whole* grid —
+        which is exactly what a fixed-point format describes.  If ``prec`` is
+        smaller, values thin out as the magnitude grows, and only a floating-point
+        format can say that.
+
+        So this is the float/fixed discriminator, and it is about the precision
+        constraint alone — not about whether the values happen to be integers.
+        ``A(24, -149, ±3.4e38)`` (FP32's own shape) needs 278 bits to span its
+        range at quantum ``2**-149`` and has 24, so it is genuinely floating.
+        ``A(9, 0, +254, -256)`` — the sum of two ``int8`` formats — needs 9 and
+        has 9, so it is genuinely fixed.
+
+        Only meaningful with a finite ``prec``/``exp`` and finite bounds; callers
+        check that first.
+        """
+        if not isinstance(self.prec, int) or not isinstance(self.exp, int):
+            return True
+        if isinstance(self.pos_bound, float) or isinstance(self.neg_bound, float):
+            return True
+        needed = max(
+            _maxval_precision(self.pos_bound, self.exp),
+            _maxval_precision(RealFloat(s=False, x=self.neg_bound), self.exp),
+        )
+        return self.prec < needed
 
     def effective_prec(self):
         """Effective maximum precision."""

--- a/fpy2/backend/cpp/emitter.py
+++ b/fpy2/backend/cpp/emitter.py
@@ -2971,7 +2971,9 @@ class CppEmitter(Visitor):
         fmt = self.format_info.by_expr.get(e)
         if isinstance(fmt, SetFormat) and len(fmt.values) == 1:
             (v,) = fmt.values
-            if v.denominator == 1:
+            # A `SetFormat` value may be `NEG_ZERO`, which is not an integer --
+            # no `range` bound may be one, and it has no `denominator`.
+            if isinstance(v, Fraction) and v.denominator == 1:
                 return v.numerator
         return None
 

--- a/fpy2/backend/cpp/storage.py
+++ b/fpy2/backend/cpp/storage.py
@@ -131,7 +131,13 @@ def choose_storage_scalar(bound: FormatBound) -> CppScalar:
     for cpp_ty, ladder_af in _LADDER:
         if af <= ladder_af:
             return cpp_ty
-    if isinstance(bound, MPFixedFormat) and bound.expmin >= 0:
+    if (isinstance(bound, MPFixedFormat) and bound.expmin >= 0
+            and af.specials_contained_in(_LADDER_LOOKUP[CppScalar.S64])):
+        # Deliberately ignores the *magnitude* bound -- an unbounded integer has
+        # none, and overflow is the user's problem (see the docstring above).  It
+        # must not ignore the membership flags too: `int64_t` holds no NaN, no
+        # infinity and no signed zero, so a bound carrying one of those has no
+        # business here even though the ladder search already rejected it.
         return CppScalar.S64
     raise StorageSelectionError(
         f'no storage type on the ladder contains {bound!r}'

--- a/fpy2/number/context/mp_fixed.py
+++ b/fpy2/number/context/mp_fixed.py
@@ -32,7 +32,8 @@ class MPFixedFormat(OrdinalFormat):
     enable_inf: bool
     """is infinity representable?"""
 
-    def __init__(self, nmin: int, enable_nan: bool = False, enable_inf: bool = False):
+    def __init__(self, nmin: int, enable_nan: bool = False, enable_inf: bool = False,
+                 enable_neg_zero: bool = True):
         if not isinstance(nmin, int):
             raise TypeError(f'Expected \'int\' for nmin={nmin}, got {type(nmin)}')
         if not isinstance(enable_nan, bool):
@@ -42,6 +43,7 @@ class MPFixedFormat(OrdinalFormat):
         self.nmin = nmin
         self.enable_nan = enable_nan
         self.enable_inf = enable_inf
+        self.enable_neg_zero = enable_neg_zero
 
     def __eq__(self, other):
         return (
@@ -49,10 +51,12 @@ class MPFixedFormat(OrdinalFormat):
             and self.nmin == other.nmin
             and self.enable_nan == other.enable_nan
             and self.enable_inf == other.enable_inf
+            and self.enable_neg_zero == other.enable_neg_zero
         )
 
     def __hash__(self):
-        return hash((self.__class__, self.nmin, self.enable_nan, self.enable_inf))
+        return hash((self.__class__, self.nmin, self.enable_nan, self.enable_inf,
+                     self.enable_neg_zero))
 
     @property
     def expmin(self) -> int:
@@ -60,6 +64,8 @@ class MPFixedFormat(OrdinalFormat):
         return self.nmin + 1
 
     def representable_in(self, x: RealFloat | Float) -> bool:
+        if isinstance(x, Float | RealFloat) and x.is_zero() and x.s and not self.enable_neg_zero:
+            return False
         match x:
             case Float():
                 if x.isnan:

--- a/fpy2/number/context/mpb_fixed.py
+++ b/fpy2/number/context/mpb_fixed.py
@@ -53,6 +53,7 @@ class MPBFixedFormat(SizedFormat):
         neg_maxval: RealFloat | None = None,
         enable_nan: bool = False,
         enable_inf: bool = False,
+        enable_neg_zero: bool = True,
     ):
         if not isinstance(nmin, int):
             raise TypeError(f'Expected \'int\' for nmin={nmin}, got {type(nmin)}')
@@ -82,8 +83,9 @@ class MPBFixedFormat(SizedFormat):
         self.neg_maxval = neg_maxval
         self.enable_nan = enable_nan
         self.enable_inf = enable_inf
+        self.enable_neg_zero = enable_neg_zero
 
-        self._mp_fmt = MPFixedFormat(nmin, enable_nan, enable_inf)
+        self._mp_fmt = MPFixedFormat(nmin, enable_nan, enable_inf, enable_neg_zero)
         self._pos_maxval_ord = self._mp_fmt._to_ordinal(pos_maxval)
         self._neg_maxval_ord = self._mp_fmt._to_ordinal(neg_maxval)
 
@@ -95,6 +97,7 @@ class MPBFixedFormat(SizedFormat):
             and self.neg_maxval == other.neg_maxval
             and self.enable_nan == other.enable_nan
             and self.enable_inf == other.enable_inf
+            and self.enable_neg_zero == other.enable_neg_zero
         )
 
     def __hash__(self):
@@ -105,6 +108,7 @@ class MPBFixedFormat(SizedFormat):
             self.neg_maxval,
             self.enable_nan,
             self.enable_inf,
+            self.enable_neg_zero,
         ))
 
     @property
@@ -113,6 +117,8 @@ class MPBFixedFormat(SizedFormat):
         return self.nmin + 1
 
     def representable_in(self, x: RealFloat | Float) -> bool:
+        if isinstance(x, Float | RealFloat) and x.is_zero() and x.s and not self.enable_neg_zero:
+            return False
         if not self._mp_fmt.representable_in(x):
             return False
         if not x.is_nonzero():

--- a/tests/infra/backend/cpp.py
+++ b/tests/infra/backend/cpp.py
@@ -1603,9 +1603,49 @@ def _regression_replaced_slot(
         return xss[0][0] + ys[0]
 
 
+@fp.fpy
+def _regression_signed_zero_from_neg() -> fp.Real:
+    """A *statically-known* zero turned negative.
+
+    `format_infer` bounds a literal by the exact set of its values, and a
+    `Fraction` has no signed zero -- so `{0}` used to survive a negation, the
+    C++ backend stored it as `uint8_t`, and this returned `+0.0` where the
+    interpreter returns `-0.0`.
+
+    The whole family survived on coverage: `_float_bit_eq` has always
+    distinguished +0 from -0, but no program made a known zero go negative.
+    `x` is unused on purpose -- the point is that the zero is a compile-time
+    constant, which is what produces the set bound.
+    """
+    with fp.FP64:
+        z = 0.0
+        return -z
+
+
+@fp.fpy
+def _regression_signed_zero_from_mul() -> fp.Real:
+    """The same via multiplication: IEEE makes a product's zero sign the XOR of
+    the operand signs, so `0.0 * -1.0` is `-0.0`."""
+    with fp.FP64:
+        z = 0.0
+        return z * -1.0
+
+
+@fp.fpy
+def _regression_positive_zero_still_narrows() -> fp.Real:
+    """The other direction, so the fix above cannot be "widen everything":
+    `+0.0` really is the integer 0 and keeps its precise bound."""
+    with fp.FP64:
+        z = 0.0
+        return abs(z) + 0.0
+
+
 _regression_funcs: list[fp.Function] = [
     _regression_quant_dot_real_widen,
     _regression_empty_range,
+    _regression_signed_zero_from_neg,
+    _regression_signed_zero_from_mul,
+    _regression_positive_zero_still_narrows,
     _regression_calls_user_fn,
     _regression_any_bool_list,
     _regression_all_bool_list,

--- a/tests/unit/analysis/test_format.py
+++ b/tests/unit/analysis/test_format.py
@@ -92,6 +92,91 @@ class TestAbstractFormat():
         print(list(generate(A1.prec, Fraction(2) ** A1.exp, A1.bound)))
         print(list(generate(A2.prec, Fraction(2) ** A2.exp, A2.bound)))
 
+    # `has_neg_zero`: the one special-value flag whose value sits *inside* the
+    # finite grid.  `pos_bound >= 0 >= neg_bound` holds by convention and the
+    # bounds are compared by magnitude, so conditions 1-3 of containment cannot
+    # tell `+0.0` from `-0.0`; only this flag can.
+
+    _PZ = fp.RealFloat(s=False, exp=0, c=0)
+    _NZ = fp.RealFloat(s=True, exp=0, c=0)
+
+    def test_neg_zero_is_probed_from_the_format(self):
+        """A float format has a signed zero; a fixed one does not.
+
+        Regression target: reading it off the *bounds* instead would report
+        `True` for every format, since a bound of `-0.0` is magnitude-equal to
+        `+0.0`.
+        """
+        for ctx in (fp.FP32, fp.FP64):
+            assert AbstractFormat.from_format(ctx.format()).has_neg_zero, ctx
+        for ctx in (fp.UINT8, fp.SINT8, fp.SINT64):
+            assert not AbstractFormat.from_format(ctx.format()).has_neg_zero, ctx
+
+    def test_neg_zero_distinguishes_two_otherwise_equal_formats(self):
+        """The whole point: these differ only in the sign of their zero, and
+        every other field — including the magnitude of `neg_bound` — is equal."""
+        pos = AbstractFormat(1, 0, self._PZ, neg_bound=self._PZ)
+        neg = AbstractFormat(1, 0, self._PZ, neg_bound=self._NZ, has_neg_zero=True)
+        assert pos != neg
+        assert hash(pos) != hash(neg)
+        assert '-0' in str(neg) and '-0' not in str(pos)
+
+    def test_a_neg_zero_bound_is_not_contained_in_an_integer_format(self):
+        """Containment gains a fourth membership implication.
+
+        `uint8_t` holds the integer 0 but not a negative zero, so a bound
+        carrying one must not fit in it — this is what stops the C++ backend
+        selecting an integer storage and dropping the sign.
+        """
+        neg = AbstractFormat(1, 0, self._PZ, neg_bound=self._NZ, has_neg_zero=True)
+        for ctx in (fp.UINT8, fp.SINT8, fp.SINT64):
+            assert not (neg <= AbstractFormat.from_format(ctx.format())), ctx
+        # ...but it does fit a float, which has both zeros.
+        for ctx in (fp.FP32, fp.FP64):
+            assert neg <= AbstractFormat.from_format(ctx.format()), ctx
+
+    def test_a_positive_zero_bound_still_fits_an_integer(self):
+        """The other direction, so the implication cannot be "reject all zeros":
+        `+0.0` really is the integer 0 and keeps the narrow storage."""
+        pos = AbstractFormat(1, 0, self._PZ, neg_bound=self._PZ)
+        assert pos <= AbstractFormat.from_format(fp.UINT8.format())
+
+    def test_fixed_point_formats_are_carved_out(self):
+        """A fixed-point format reports no negative zero, whatever it says.
+
+        `MPFixedFormat` (FPy's `INTEGER`) genuinely holds one, but taking that at
+        face value marks every integer-valued bound as needing a signed zero —
+        and since no `Format` has an `enable_neg_zero`, `format()` cannot
+        materialize a fixed-point format without one either.  Between them, loop
+        counters and integer arithmetic all retype to `float`.
+
+        This test should **fail** once `MPFixedFormat`/`MPBFixedFormat` gain an
+        option to disable `-0.0`; that is the point, since the carve-out and the
+        `INTEGER`-vs-`int64_t` divergence it defers both go away together.
+        """
+        nz = fp.RealFloat(s=True, exp=0, c=0)
+        # the format itself says yes...
+        assert fp.INTEGER.format().representable_in(nz)
+        # ...but the abstraction deliberately says no.
+        assert not AbstractFormat.from_format(fp.INTEGER.format()).has_neg_zero
+        # A *float* format is unaffected by the carve-out.
+        assert AbstractFormat.from_format(fp.FP64.format()).has_neg_zero
+
+    def test_neg_zero_does_not_round_trip_through_format(self):
+        """Pins the documented asymmetry rather than leaving it to rot.
+
+        No `Format` has an `enable_neg_zero`, and every format `format()` can
+        produce admits a negative zero — so re-abstracting reports `True` even
+        where the original said `False`.  That is a sound over-approximation
+        (containment only ever gets stricter), and it does not reach the C++
+        storage ladder, which abstracts each type's own `Format` directly.
+        """
+        pos = AbstractFormat(1, 0, self._PZ, neg_bound=self._PZ)
+        assert not pos.has_neg_zero
+        assert AbstractFormat.from_format(pos.format()).has_neg_zero
+        # The ladder is unaffected: it abstracts `SINT8.format()` itself.
+        assert not AbstractFormat.from_format(fp.SINT8.format()).has_neg_zero
+
     def test_contains_examples(self):
         """Testing containment check."""
         # FP32 \subseteq FP64

--- a/tests/unit/analysis/test_format.py
+++ b/tests/unit/analysis/test_format.py
@@ -165,7 +165,8 @@ class TestAbstractFormat():
         This test should **fail** once that is fixed properly (either
         `MPFixedContext` flattens signed zeros, or the backend stops storing
         `INTEGER`-bounded reals in `int64_t`).  That is the point: the carve-out
-        and the `-z`-on-an-integer divergence it defers go away together.
+        and the divergence it defers -- negating an integer whose zero is not
+        statically known -- go away together.
         """
         nz = fp.RealFloat(s=True, exp=0, c=0)
         assert fp.INTEGER.format().representable_in(nz)          # the format says yes

--- a/tests/unit/analysis/test_format.py
+++ b/tests/unit/analysis/test_format.py
@@ -141,41 +141,146 @@ class TestAbstractFormat():
         pos = AbstractFormat(1, 0, self._PZ, neg_bound=self._PZ)
         assert pos <= AbstractFormat.from_format(fp.UINT8.format())
 
-    def test_fixed_point_formats_are_carved_out(self):
-        """A fixed-point format reports no negative zero, whatever it says.
+    def test_neg_zero_round_trips_through_format(self):
+        """`has_neg_zero` survives materialize-and-re-abstract, both ways.
 
-        `MPFixedFormat` (FPy's `INTEGER`) genuinely holds one, but taking that at
-        face value marks every integer-valued bound as needing a signed zero —
-        and since no `Format` has an `enable_neg_zero`, `format()` cannot
-        materialize a fixed-point format without one either.  Between them, loop
-        counters and integer arithmetic all retype to `float`.
+        This is what each format's `enable_neg_zero` is for.  Without it the flag
+        decays to `True`, because the shapes `format()` produces admit a negative
+        zero by default — and then every integer-valued bound materialized on the
+        way to storage selection loses its integer storage.
+        """
+        for hnz in (False, True):
+            af = AbstractFormat(1, 0, self._PZ, neg_bound=self._NZ, has_neg_zero=hnz)
+            assert af.format().representable_in(self._NZ) is hnz
+            assert AbstractFormat.from_format(af.format()).has_neg_zero is hnz
 
-        This test should **fail** once `MPFixedFormat`/`MPBFixedFormat` gain an
-        option to disable `-0.0`; that is the point, since the carve-out and the
-        `INTEGER`-vs-`int64_t` divergence it defers both go away together.
+    def test_unbounded_fixed_point_is_not_believed_about_neg_zero(self):
+        """`MPFixedFormat` is taken as having no negative zero, whatever it says.
+
+        FPy's `INTEGER` really does hold one, deliberately.  But C++ has no
+        integer type that does, and believing the format costs integer storage
+        everywhere -- it retypes `range` counters as `float` and diverges the
+        loop fixpoint in `test_while{5,6,7}_rounded` to `REAL_FORMAT`.
+
+        This test should **fail** once that is fixed properly (either
+        `MPFixedContext` flattens signed zeros, or the backend stops storing
+        `INTEGER`-bounded reals in `int64_t`).  That is the point: the carve-out
+        and the `-z`-on-an-integer divergence it defers go away together.
         """
         nz = fp.RealFloat(s=True, exp=0, c=0)
-        # the format itself says yes...
-        assert fp.INTEGER.format().representable_in(nz)
-        # ...but the abstraction deliberately says no.
+        assert fp.INTEGER.format().representable_in(nz)          # the format says yes
         assert not AbstractFormat.from_format(fp.INTEGER.format()).has_neg_zero
-        # A *float* format is unaffected by the carve-out.
-        assert AbstractFormat.from_format(fp.FP64.format()).has_neg_zero
 
-    def test_neg_zero_does_not_round_trip_through_format(self):
-        """Pins the documented asymmetry rather than leaving it to rot.
+    def test_bounded_fixed_point_is_still_believed(self):
+        """The carve-out stops at the *unbounded* case.
 
-        No `Format` has an `enable_neg_zero`, and every format `format()` can
-        produce admits a negative zero — so re-abstracting reports `True` even
-        where the original said `False`.  That is a sound over-approximation
-        (containment only ever gets stricter), and it does not reach the C++
-        storage ladder, which abstracts each type's own `Format` directly.
+        `MPBFixedFormat.enable_neg_zero` is what lets a bound say "this really
+        can be a negative zero" and so reach a float storage — the whole reason
+        the flag exists.  Extending the carve-out to it would silently undo that.
         """
-        pos = AbstractFormat(1, 0, self._PZ, neg_bound=self._PZ)
-        assert not pos.has_neg_zero
-        assert AbstractFormat.from_format(pos.format()).has_neg_zero
-        # The ladder is unaffected: it abstracts `SINT8.format()` itself.
-        assert not AbstractFormat.from_format(fp.SINT8.format()).has_neg_zero
+        pz = fp.RealFloat(s=False, exp=0, c=0)
+        nz = fp.RealFloat(s=True, exp=0, c=0)
+        af = AbstractFormat(1, 0, pz, neg_bound=nz, has_neg_zero=True)
+        assert AbstractFormat.from_format(af.format()).has_neg_zero
+
+    def test_add_derives_neg_zero_as_a_conjunction(self):
+        """A sum is `-0.0` only when *both* addends are.
+
+        IEEE-754 gives a like-signed sum that sign, and every other zero sum is
+        `+0.0` — checked against the interpreter: `(-0)+(-0)` is `-0.0` while
+        `(-0)+(+0)`, `(+0)+(+0)` and `1+(-1)` are all `+0.0`.
+
+        This is not cosmetic.  `_bound_if_fits` asks `scope_af <= exact`, so an
+        `exact` that under-reports the flag *fails* a containment that really
+        holds, and `x + y` under FP32 degrades from `FP32.format()` to a
+        materialized approximation.
+        """
+        f32 = AbstractFormat.from_format(fp.FP32.format())   # has a signed zero
+        i8 = AbstractFormat.from_format(fp.SINT8.format())   # does not
+        assert f32.has_neg_zero and not i8.has_neg_zero
+        assert (f32 + f32).has_neg_zero
+        assert not (i8 + i8).has_neg_zero
+        assert not (f32 + i8).has_neg_zero
+        assert not (i8 + f32).has_neg_zero
+
+    def test_sub_derives_neg_zero_from_the_left_operand(self):
+        """`a - b` is `a + (-b)`, so by the sum rule both addends must be able to
+        be `-0.0`: `a` directly, and `-b` whenever `b` can be `+0.0` — which
+        every grid can.  So only `a` matters.  Confirmed against the
+        interpreter: `(-0)-(+0)` is `-0.0`, while `(+0)-(+0)`, `(-0)-(-0)` and
+        `1-1` are `+0.0`."""
+        f32 = AbstractFormat.from_format(fp.FP32.format())
+        i8 = AbstractFormat.from_format(fp.SINT8.format())
+        assert (f32 - i8).has_neg_zero
+        assert (f32 - f32).has_neg_zero
+        assert not (i8 - f32).has_neg_zero
+        assert not (i8 - i8).has_neg_zero
+
+    def test_neg_carries_neg_zero_over(self):
+        """Negation maps `+0.0` to `-0.0`, and every grid contains a `+0.0` — so
+        the image holds one exactly when the number system does.
+
+        Checked against the interpreter: `-(+0)` is `-0.0` under FP64, while
+        `-(0)` under `SINT8` is `+0.0`, two's-complement having a single zero.
+        """
+        f64 = AbstractFormat.from_format(fp.FP64.format())
+        i8 = AbstractFormat.from_format(fp.SINT8.format())
+        assert (-f64).has_neg_zero
+        assert not (-i8).has_neg_zero
+
+    def test_mul_derives_neg_zero_as_a_disjunction(self):
+        """A zero product takes the XOR of the operand signs, so a `-0.0` needs a
+        sign disagreement — and one is always available once *either* system has
+        a signed zero, since every grid contains a `+0.0` and negative times
+        that zero is `-0.0`.
+
+        Checked against the interpreter: `(-1)*(+0)`, `(+0)*(-1)` and `(-0)*(+2)`
+        are all `-0.0` under FP64, while `(-2)*0` under `SINT8` is `+0.0`.
+
+        Note this is a *disjunction* where addition takes a conjunction — the
+        asymmetry is real, and assuming one rule for both is what makes
+        `no -0 * no -0 = no -0` look plausible while `(-1) * 0 = -0.0`.
+        """
+        f64 = AbstractFormat.from_format(fp.FP64.format())
+        i8 = AbstractFormat.from_format(fp.SINT8.format())
+        assert (f64 * f64).has_neg_zero
+        assert (f64 * i8).has_neg_zero
+        assert (i8 * f64).has_neg_zero
+        assert not (i8 * i8).has_neg_zero
+
+    def test_integer_ops_keep_an_integer_storage(self):
+        """The payoff: deriving the flag must not cost integer code its storage.
+
+        Both rules answer "does this number system have a signed zero", and an
+        integer one does not — so negation and multiplication of integer-bounded
+        values stay integers rather than widening to `float`.
+        """
+        from fpy2.backend.cpp.storage import choose_storage_scalar
+        from fpy2.backend.cpp.types import CppScalar
+        i8 = AbstractFormat.from_format(fp.SINT8.format())
+        assert choose_storage_scalar((-i8).format()) != CppScalar.F32
+        assert choose_storage_scalar((i8 * i8).format()) != CppScalar.F32
+
+    def test_abs_never_has_a_negative_zero(self):
+        """`abs` cannot produce one, so `False` here is the derived answer."""
+        f32 = AbstractFormat.from_format(fp.FP32.format())
+        assert f32.has_neg_zero
+        assert not abs(f32).has_neg_zero
+
+    def test_integer_arithmetic_keeps_no_negative_zero(self):
+        """The case that forced `enable_neg_zero` to exist.
+
+        `SINT8` has `prec=inf`, but the *sum* has a finite precision, so
+        `format()` materializes it as a float-shaped `MPBFloatFormat` — whose
+        value set includes a `-0.0` unless the flag says otherwise.  Left to
+        decay, `int8 + int8` stopped fitting `int16_t` and became `float`.
+        """
+        a = AbstractFormat.from_format(fp.SINT8.format())
+        assert not a.has_neg_zero
+        s = a + a
+        assert not s.has_neg_zero
+        assert not s.format().representable_in(self._NZ)
+        assert not AbstractFormat.from_format(s.format()).has_neg_zero
 
     def test_contains_examples(self):
         """Testing containment check."""

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -15,7 +15,11 @@ from hypothesis import given, settings, strategies as st
 
 from fpy2.analysis import ContextUseAnalysis, FormatInfer, TypeAnalysis, TypeInfer
 from fpy2.analysis.format_infer import AbstractFormat, ListFormat, SetFormat, TupleFormat
-from fpy2.analysis.format_infer.analysis import _join_bounds, _list_set_widen
+from fpy2.analysis.format_infer.analysis import (
+    _INTEGER_FORMAT,
+    _join_bounds,
+    _list_set_widen,
+)
 from fpy2.analysis.reaching_defs import AssignDef
 from fpy2.ast.fpyast import FuncDef, IndexedAssign
 from fpy2.number.context.format import Format
@@ -1012,7 +1016,7 @@ class TestFormatInfer:
         len_bounds = [
             b for e, b in info.by_expr.items() if type(e).__name__ == 'Len'
         ]
-        integer_fmt = fp.INTEGER.format()
+        integer_fmt = _INTEGER_FORMAT
         assert len_bounds and len_bounds[0] == integer_fmt, (
             f'expected Len to report INTEGER format, got {len_bounds}'
         )
@@ -1033,7 +1037,7 @@ class TestFormatInfer:
         range_bounds = [
             b for e, b in info.by_expr.items() if type(e).__name__ == 'Range1'
         ]
-        integer_fmt = fp.INTEGER.format()
+        integer_fmt = _INTEGER_FORMAT
         assert range_bounds, 'expected a Range1 expression'
         assert range_bounds[0] == ListFormat(integer_fmt), (
             f'expected ListFormat(INTEGER) for Range1, got {range_bounds}'
@@ -1153,7 +1157,7 @@ class TestFormatInfer:
 
         info = self._run(f)
         lens = [b for e, b in info.by_expr.items() if type(e).__name__ == 'Len']
-        assert lens and lens[0] == fp.INTEGER.format()
+        assert lens and lens[0] == _INTEGER_FORMAT
 
     def test_dim_pins_nesting_depth(self):
         """``dim(xs)`` always pins the (static) nesting depth."""
@@ -1212,7 +1216,7 @@ class TestFormatInfer:
         assert enum_bounds, 'expected an Enumerate expression'
         bound = enum_bounds[0]
         # Outer: ListFormat. Element: TupleFormat((INTEGER, FP32)).
-        integer_fmt = fp.INTEGER.format()
+        integer_fmt = _INTEGER_FORMAT
         fp32_fmt = fp.FP32.format()
         assert isinstance(bound, ListFormat)
         assert isinstance(bound.elt, TupleFormat)
@@ -1391,6 +1395,27 @@ class TestFormatInfer:
         assert REAL_FORMAT in s_bounds, (
             f'expected REAL_FORMAT among s bounds with widening, got {s_bounds}'
         )
+
+    def test_integer_valued_ops_do_not_inherit_integers_signed_zero(self):
+        """`_INTEGER_FORMAT` is not `INTEGER.format()`, though the grids match.
+
+        `INTEGER` is a rounding *context* and FPy's has a signed zero; a *count*
+        does not -- a list length is an integer, and an integer has one zero.
+        Conflating them made believing that signed zero unaffordable: every
+        counter and length inherited it, no C++ integer type holds one, so they
+        all widened to `float`.
+        """
+        from fpy2.analysis.format_infer.format import AbstractFormat
+        assert _INTEGER_FORMAT != fp.INTEGER.format()
+        assert not AbstractFormat.from_format(_INTEGER_FORMAT).has_neg_zero
+        # ...but they describe the same value grid.
+        assert _INTEGER_FORMAT.nmin == fp.INTEGER.format().nmin
+
+    def test_an_integer_count_keeps_an_integer_storage(self):
+        """The consequence at the backend: `len(xs)` stays an integer."""
+        from fpy2.backend.cpp.storage import choose_storage_scalar
+        from fpy2.backend.cpp.types import CppScalar
+        assert choose_storage_scalar(_INTEGER_FORMAT) != CppScalar.F32
 
     def test_literal_bound_states_a_signed_zero_exactly(self):
         """A ``-0.0`` literal gets ``SetFormat({NEG_ZERO})`` -- an exact bound.
@@ -1613,7 +1638,7 @@ class TestFormatInfer:
 
         info = FormatInfer.analyze(f.ast, loop_iter_limit=2)
         x_bounds = {b for d, b in info.by_def.items() if d.name.base == 'x'}
-        int_fmt = fp.INTEGER.format()
+        int_fmt = _INTEGER_FORMAT
         assert int_fmt in x_bounds, (
             f'expected INTEGER MPFixedFormat among x bounds, got {x_bounds}'
         )

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1419,14 +1419,14 @@ class TestFormatInfer:
             def as_rational(self):
                 return self._rational
 
+        from fpy2.analysis.format_infer.analysis import _SIGNED_ZERO_FORMAT
         neg_zero = _FakeLiteral(Float(s=True, exp=0, c=0), Fraction(0))
-        assert _literal_bound(neg_zero) == fp.FP32.format()
+        assert _literal_bound(neg_zero) == _SIGNED_ZERO_FORMAT
 
-        # Not a zero, so `FP32` is not known to contain it -- and it does not:
-        # `2**-400` is far below `FP32`'s smallest subnormal.  A `Float` is an
-        # exact rational whenever it is finite, so the set states it exactly.
+        # Not a zero, so the two-zeros format does not contain it.  A `Float` is
+        # an exact rational whenever it is finite, so the set states it exactly.
         tiny = Float(s=False, exp=-400, c=1)
-        assert _literal_bound(_FakeLiteral(tiny, tiny.as_rational())) != fp.FP32.format()
+        assert _literal_bound(_FakeLiteral(tiny, tiny.as_rational())) != _SIGNED_ZERO_FORMAT
         assert _literal_bound(_FakeLiteral(tiny, tiny.as_rational())) == \
             SetFormat.from_value(tiny.as_rational())
 
@@ -1455,7 +1455,8 @@ class TestFormatInfer:
         pos_info = FormatInfer.analyze(pos.ast)
         # `-0.0` reports a format; `+0.0` is exactly the integer 0, so it keeps
         # the precise singleton set and nothing about it regresses.
-        assert neg_info.fn_fmt.ret_fmt == fp.FP32.format(), neg_info.fn_fmt.ret_fmt
+        from fpy2.analysis.format_infer.analysis import _SIGNED_ZERO_FORMAT
+        assert neg_info.fn_fmt.ret_fmt == _SIGNED_ZERO_FORMAT, neg_info.fn_fmt.ret_fmt
         assert pos_info.fn_fmt.ret_fmt == SetFormat.from_value(Fraction(0)), \
             pos_info.fn_fmt.ret_fmt
 
@@ -1475,7 +1476,11 @@ class TestFormatInfer:
         from fpy2.analysis.format_infer.analysis import exact_unop
         import operator
         zero = SetFormat(frozenset((Fraction(0),)))
-        assert exact_unop(zero, operator.neg) is None
+        # Not a set -- and, since Phase 4, a *tight* bound rather than a
+        # give-up: the values are kept and only the zero's sign is surrendered.
+        got = exact_unop(zero, operator.neg)
+        assert not isinstance(got, SetFormat)
+        assert got is not None and got.has_neg_zero
         # A set with no zero in it negates exactly, as before.
         assert exact_unop(SetFormat(frozenset((Fraction(2),))), operator.neg) \
             == SetFormat(frozenset((Fraction(-2),)))
@@ -1497,8 +1502,10 @@ class TestFormatInfer:
         pos = SetFormat(frozenset((Fraction(2),)))
         neg = SetFormat(frozenset((Fraction(-2),)))
         assert exact_binop(zero, pos, operator.mul) == zero
-        assert exact_binop(zero, neg, operator.mul) is None   # -0.0
-        assert exact_binop(neg, zero, operator.mul) is None   # -0.0
+        for got in (exact_binop(zero, neg, operator.mul),
+                    exact_binop(neg, zero, operator.mul)):
+            assert not isinstance(got, SetFormat)      # may be -0.0
+            assert got is not None and got.has_neg_zero
 
     def test_add_and_sub_to_zero_follow_the_ieee_sign_rule(self):
         """An exactly-zero sum of *opposite-signed* operands is ``+0.0`` in
@@ -1513,9 +1520,11 @@ class TestFormatInfer:
         one = SetFormat(frozenset((Fraction(1),)))
         neg_one = SetFormat(frozenset((Fraction(-1),)))
         assert exact_binop(zero, zero, operator.add) == zero
-        assert exact_binop(one, neg_one, operator.add) is None
-        assert exact_binop(one, one, operator.sub) is None
-        assert exact_binop(zero, zero, operator.sub) is None
+        for got in (exact_binop(one, neg_one, operator.add),
+                    exact_binop(one, one, operator.sub),
+                    exact_binop(zero, zero, operator.sub)):
+            assert not isinstance(got, SetFormat)
+            assert got is not None and got.has_neg_zero
         # A non-zero result is unaffected either way.
         assert exact_binop(one, one, operator.add) \
             == SetFormat(frozenset((Fraction(2),)))

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1663,6 +1663,90 @@ class TestFormatInfer:
     # ------------------------------------------------------------------
     # Functional-update (``IndexedAssign``) semantics
 
+    # A store mutates the list *every* name in its alias region refers to, so
+    # each of their bounds has to admit the inserted value.  `reaching_defs`
+    # only refreshes the name written through, which is why `format_infer`
+    # consults `Alias`; see `docs/todos/format-infer-aliasing.md`.
+
+    _NARROW = SetFormat(frozenset((Fraction(1), Fraction(2))))
+
+    def test_a_store_through_an_alias_widens_the_original(self):
+        """`ys = xs; ys[0] = y` leaves `xs[0]` holding `y`.
+
+        The bug this fixes: only `ys` was widened, so `xs` kept the literal
+        element set and the analysis reported a bound the program exceeds.
+        Every consumer inherited that, not just the C++ backend.
+        """
+        @fp.fpy
+        def f(y: fp.Real) -> fp.Real:
+            xs = [1.0, 2.0]
+            ys = xs
+            ys[0] = y
+            return xs[0]
+
+        info = FormatInfer.analyze(f.ast)
+        assert info.fn_fmt.ret_fmt == REAL_FORMAT, info.fn_fmt.ret_fmt
+
+    def test_a_read_only_alias_does_not_widen(self):
+        """The precision side: aliasing alone changes nothing.
+
+        Only a *store* widens, so a name that merely shares a list keeps the
+        exact element set.  A blanket "aliased names share one bound" rule would
+        lose this for every consumer even where nothing is ever written.
+        """
+        @fp.fpy
+        def f(y: fp.Real) -> fp.Real:
+            xs = [1.0, 2.0]
+            ys = xs
+            return ys[0]
+
+        info = FormatInfer.analyze(f.ast)
+        assert info.fn_fmt.ret_fmt == self._NARROW, info.fn_fmt.ret_fmt
+
+    def test_a_read_before_the_store_keeps_its_narrow_bound(self):
+        """Flow-sensitivity: `a` is read before the store, so it really is
+        narrow -- it holds the element the list had at that point.
+
+        This is what excluding the two defs `reaching_defs` already refreshes
+        buys.  Widening them instead marks the list's *pre-store* state with the
+        inserted format, which over-widens even a direct `xs[0] = x`.
+        """
+        @fp.fpy
+        def f(y: fp.Real) -> fp.Real:
+            xs = [1.0, 2.0]
+            ys = xs
+            a = xs[0]
+            ys[0] = y
+            return a
+
+        info = FormatInfer.analyze(f.ast)
+        assert info.fn_fmt.ret_fmt == self._NARROW, info.fn_fmt.ret_fmt
+        # ...while `xs` itself is widened, since after the store it does hold `y`.
+        xs_bounds = [b for d, b in info.by_def.items()
+                     if getattr(d.name, 'base', None) == 'xs']
+        assert xs_bounds == [ListFormat(REAL_FORMAT)], xs_bounds
+
+    def test_a_read_after_a_store_across_a_back_edge_is_widened(self):
+        """The case that would be a *wrong answer* rather than a refusal.
+
+        Iteration 2's read sees what iteration 1 stored, so `a` must admit the
+        inserted format.  It only does if the widening survives the loop
+        fixpoint -- which is why the region record is replayed on every bound
+        write instead of editing bounds in place.
+        """
+        @fp.fpy
+        def f(y: fp.Real) -> fp.Real:
+            xs = [1.0, 2.0]
+            ys = xs
+            a = 0.0
+            for _ in range(2):
+                a = xs[0]
+                ys[0] = y
+            return a
+
+        info = FormatInfer.analyze(f.ast)
+        assert info.fn_fmt.ret_fmt == REAL_FORMAT, info.fn_fmt.ret_fmt
+
     def test_indexed_assign_widens_format_at_fresh_def(self):
         """
         ``xs[i] = x`` creates a *fresh* SSA def of ``xs`` (per

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1459,18 +1459,119 @@ class TestFormatInfer:
         assert pos_info.fn_fmt.ret_fmt == SetFormat.from_value(Fraction(0)), \
             pos_info.fn_fmt.ret_fmt
 
-    def test_exact_binop_mul_by_zero_set_stays_set(self):
-        """``Mul(loose_format, SetFormat({0}))`` short-circuits to
-        ``SetFormat({0})`` rather than producing a degenerate
-        zero-bounded ``AbstractFormat`` whose subsequent ``add``/``sub``
-        drives ``prec`` to 0.
+    # ``Fraction(0)`` in a ``SetFormat`` means exactly ``+0.0`` -- a ``Fraction``
+    # has no signed zero, and consumers read the set literally (the C++ backend
+    # picks ``uint8_t`` for ``{0}``, which holds neither sign).  So every
+    # operation that may have produced a ``-0.0`` must answer with a format
+    # instead.  See ``format_infer._zero_result_is_positive``.
+
+    def test_neg_of_a_zero_set_does_not_stay_a_set(self):
+        """``-(+0.0)`` is ``-0.0``, but ``-Fraction(0) == Fraction(0)``.
+
+        This was a live wrong answer: `z = 0.0; return -z` inferred ``{0}``,
+        stored as ``uint8_t``, and the emitted C++ returned ``+0.0`` where the
+        interpreter returns ``-0.0``.
+        """
+        from fpy2.analysis.format_infer.analysis import exact_unop
+        import operator
+        zero = SetFormat(frozenset((Fraction(0),)))
+        assert exact_unop(zero, operator.neg) is None
+        # A set with no zero in it negates exactly, as before.
+        assert exact_unop(SetFormat(frozenset((Fraction(2),))), operator.neg) \
+            == SetFormat(frozenset((Fraction(-2),)))
+
+    def test_abs_of_a_zero_set_stays_a_set(self):
+        """``abs`` can never produce a negative zero, so it keeps its
+        precision -- the widening is targeted, not blanket."""
+        from fpy2.analysis.format_infer.analysis import exact_unop
+        zero = SetFormat(frozenset((Fraction(0),)))
+        assert exact_unop(zero, abs) == zero
+
+    def test_mul_to_zero_follows_the_ieee_sign_rule(self):
+        """IEEE 754 §6.3: a product's zero sign is the XOR of the operand
+        signs, in every rounding mode.  So the set path can keep ``{0}`` when
+        neither operand is negative, and must widen when one is."""
+        from fpy2.analysis.format_infer.analysis import exact_binop
+        import operator
+        zero = SetFormat(frozenset((Fraction(0),)))
+        pos = SetFormat(frozenset((Fraction(2),)))
+        neg = SetFormat(frozenset((Fraction(-2),)))
+        assert exact_binop(zero, pos, operator.mul) == zero
+        assert exact_binop(zero, neg, operator.mul) is None   # -0.0
+        assert exact_binop(neg, zero, operator.mul) is None   # -0.0
+
+    def test_add_and_sub_to_zero_follow_the_ieee_sign_rule(self):
+        """An exactly-zero sum of *opposite-signed* operands is ``+0.0`` in
+        every rounding mode except ``roundTowardNegative``.  ``exact_binop``
+        does not know the mode, so it can only keep ``{0}`` where both addends
+        are themselves ``+0.0``.  A difference always has opposite-signed
+        addends (``a - b`` is ``a + (-b)``), so a zero difference always
+        widens -- including ``0 - 0``."""
+        from fpy2.analysis.format_infer.analysis import exact_binop
+        import operator
+        zero = SetFormat(frozenset((Fraction(0),)))
+        one = SetFormat(frozenset((Fraction(1),)))
+        neg_one = SetFormat(frozenset((Fraction(-1),)))
+        assert exact_binop(zero, zero, operator.add) == zero
+        assert exact_binop(one, neg_one, operator.add) is None
+        assert exact_binop(one, one, operator.sub) is None
+        assert exact_binop(zero, zero, operator.sub) is None
+        # A non-zero result is unaffected either way.
+        assert exact_binop(one, one, operator.add) \
+            == SetFormat(frozenset((Fraction(2),)))
+
+    def test_an_accumulator_starting_at_zero_keeps_its_set(self):
+        """Regression against over-widening.
+
+        ``acc = 0`` then ``acc += i`` puts a zero in every intermediate set, so
+        a rule keyed on "the result contains zero" widens the whole
+        accumulation.  The rule is keyed on the *operands* that produced each
+        zero instead: here the only zero comes from ``0 + 0``, which IEEE makes
+        ``+0.0`` in every mode.
+        """
+        @fp.fpy
+        def f():
+            with fp.REAL:
+                acc = 0
+                for i in range(10):
+                    acc += i
+                return acc
+
+        info = FormatInfer.analyze(f.ast, set_format_threshold=256)
+        acc = self._last_acc(info)
+        assert isinstance(acc, SetFormat), acc
+        assert Fraction(0) in acc.values, acc
+
+    def test_a_negative_zero_free_variable_gets_no_set_bound(self):
+        """A captured ``-0.0`` is finite, so the old code gave it
+        ``SetFormat({0})`` via ``as_rational`` -- same lie as the literal."""
+        from fpy2.analysis.format_infer.analysis import _free_var_format
+        from fpy2.number import Float
+        assert _free_var_format(Float(s=True, exp=0, c=0)) is None
+        # A `+0.0` capture is exactly the integer 0 and keeps its singleton.
+        assert _free_var_format(Float(s=False, exp=0, c=0)) \
+            == SetFormat(frozenset((Fraction(0),)))
+
+    def test_exact_binop_mul_by_zero_format_widens(self):
+        """``Mul(loose_format, SetFormat({0}))`` must not answer ``{0}``.
+
+        IEEE 754 makes ``0 * x`` a NaN for an infinite or NaN *x* and ``-0.0``
+        for a negative *x*.  An ``FP32`` bound admits all three, so none can be
+        ruled out -- and a ``Fraction`` set can state none of them.  ``{0}`` was
+        the old answer, and it is what made ``0.0 * inf`` compile to
+        ``static_cast<uint8_t>(NaN)``.
+
+        ``None`` specifically, rather than falling through to the abstract path:
+        ``{0}`` lifts to an ``AbstractFormat`` bounded by zero on both sides,
+        whose product drives a later ``add``/``sub``'s ``prec`` to 0.  ``None``
+        makes the caller use the scope format, which is well-formed.
         """
         from fpy2.analysis.format_infer.analysis import exact_binop
         import operator
         fp32_fmt = fp.FP32.format()
         zero = SetFormat(frozenset((Fraction(0),)))
-        assert exact_binop(fp32_fmt, zero, operator.mul) == zero
-        assert exact_binop(zero, fp32_fmt, operator.mul) == zero
+        assert exact_binop(fp32_fmt, zero, operator.mul) is None
+        assert exact_binop(zero, fp32_fmt, operator.mul) is None
 
     def test_exact_binop_add_zero_set_is_identity(self):
         """``Add(F, SetFormat({0}))`` and ``Sub(F, SetFormat({0}))``

--- a/tests/unit/analysis/test_format_infer.py
+++ b/tests/unit/analysis/test_format_infer.py
@@ -1392,24 +1392,21 @@ class TestFormatInfer:
             f'expected REAL_FORMAT among s bounds with widening, got {s_bounds}'
         )
 
-    def test_literal_bound_reports_a_format_only_for_a_signed_zero(self):
-        """``_literal_bound`` may only answer ``FP32`` for a value ``FP32``
-        contains.
+    def test_literal_bound_states_a_signed_zero_exactly(self):
+        """A ``-0.0`` literal gets ``SetFormat({NEG_ZERO})`` -- an exact bound.
 
-        A signed zero is the one literal value ``SetFormat`` cannot state, so it
-        gets a format bound instead.  ``as_real`` returns a ``Float`` for
-        exactly that case today -- but that invariant lives in
-        ``fpy2.ast.fpyast``, and answering ``FP32`` on the strength of the
-        *type* would be a false bound the moment some other ``Float`` came
-        back: ``1e-400`` is a ``Float`` and is not in ``FP32``, and no consumer
-        of the bound could detect the lie.  So the discriminator has to be the
-        value.
+        The discriminator is the literal's **value**, not the type ``as_real``
+        returns.  ``as_real`` returns a ``Float`` only for a signed zero today,
+        but that invariant lives in ``fpy2.ast.fpyast`` and ``_literal_bound``
+        cannot enforce it: ``1e-400`` is a ``Float`` and is not a zero, so
+        answering ``NEG_ZERO`` for it would be a false bound no consumer could
+        detect.
         """
-        from fpy2.analysis.format_infer.analysis import _literal_bound
+        from fpy2.analysis.format_infer.analysis import NEG_ZERO, _literal_bound
         from fpy2.number import Float
 
         class _FakeLiteral:
-            """A literal whose ``as_real`` hands back the ``Float`` given."""
+            """A literal whose ``as_real`` hands back the value given."""
             def __init__(self, real, rational):
                 self._real, self._rational = real, rational
 
@@ -1419,28 +1416,27 @@ class TestFormatInfer:
             def as_rational(self):
                 return self._rational
 
-        from fpy2.analysis.format_infer.analysis import _SIGNED_ZERO_FORMAT
         neg_zero = _FakeLiteral(Float(s=True, exp=0, c=0), Fraction(0))
-        assert _literal_bound(neg_zero) == _SIGNED_ZERO_FORMAT
-
-        # Not a zero, so the two-zeros format does not contain it.  A `Float` is
-        # an exact rational whenever it is finite, so the set states it exactly.
+        assert _literal_bound(neg_zero) == SetFormat.from_value(NEG_ZERO)
+        # `+0.0` is exactly the integer 0 and keeps its `Fraction`.
+        pos_zero = _FakeLiteral(Float(s=False, exp=0, c=0), Fraction(0))
+        assert _literal_bound(pos_zero) == SetFormat.from_value(Fraction(0))
+        # A finite non-zero `Float` is an exact rational, so it takes that path.
         tiny = Float(s=False, exp=-400, c=1)
-        assert _literal_bound(_FakeLiteral(tiny, tiny.as_rational())) != _SIGNED_ZERO_FORMAT
         assert _literal_bound(_FakeLiteral(tiny, tiny.as_rational())) == \
             SetFormat.from_value(tiny.as_rational())
-
         # No rational value at all: the honest bound is the scalar top.
         assert _literal_bound(_FakeLiteral(Float(isinf=True), None)) == REAL_FORMAT
         assert _literal_bound(_FakeLiteral(Float(isnan=True), None)) == REAL_FORMAT
 
-    def test_a_negative_zero_literal_gets_a_float_bound(self):
-        """The end-to-end direction, through the real AST rather than a fake.
+    def test_a_negative_zero_literal_keeps_its_sign_end_to_end(self):
+        """Through the real AST: the two zeros get *different* bounds.
 
-        ``SetFormat`` holds ``Fraction``s and a ``Fraction`` has no signed zero,
-        so ``SetFormat({0})`` would claim ``-0.0`` and ``+0.0`` are one value.
-        They are distinguishable by ``copysign`` and by division.
+        This is what a `Fraction`-only set could not do, and why `-0.0` used to
+        report a whole format instead.
         """
+        from fpy2.analysis.format_infer.analysis import NEG_ZERO
+
         @fp.fpy
         def neg() -> fp.Real:
             with fp.FP64:
@@ -1451,36 +1447,24 @@ class TestFormatInfer:
             with fp.FP64:
                 return 0.0
 
-        neg_info = FormatInfer.analyze(neg.ast)
-        pos_info = FormatInfer.analyze(pos.ast)
-        # `-0.0` reports a format; `+0.0` is exactly the integer 0, so it keeps
-        # the precise singleton set and nothing about it regresses.
-        from fpy2.analysis.format_infer.analysis import _SIGNED_ZERO_FORMAT
-        assert neg_info.fn_fmt.ret_fmt == _SIGNED_ZERO_FORMAT, neg_info.fn_fmt.ret_fmt
-        assert pos_info.fn_fmt.ret_fmt == SetFormat.from_value(Fraction(0)), \
-            pos_info.fn_fmt.ret_fmt
+        assert FormatInfer.analyze(neg.ast).fn_fmt.ret_fmt == \
+            SetFormat.from_value(NEG_ZERO)
+        assert FormatInfer.analyze(pos.ast).fn_fmt.ret_fmt == \
+            SetFormat.from_value(Fraction(0))
 
-    # ``Fraction(0)`` in a ``SetFormat`` means exactly ``+0.0`` -- a ``Fraction``
-    # has no signed zero, and consumers read the set literally (the C++ backend
-    # picks ``uint8_t`` for ``{0}``, which holds neither sign).  So every
-    # operation that may have produced a ``-0.0`` must answer with a format
-    # instead.  See ``format_infer._zero_result_is_positive``.
+    def test_neg_of_a_zero_set_is_exactly_the_other_zero(self):
+        """``-(+0.0)`` is ``-0.0``, stated exactly.
 
-    def test_neg_of_a_zero_set_does_not_stay_a_set(self):
-        """``-(+0.0)`` is ``-0.0``, but ``-Fraction(0) == Fraction(0)``.
-
-        This was a live wrong answer: `z = 0.0; return -z` inferred ``{0}``,
-        stored as ``uint8_t``, and the emitted C++ returned ``+0.0`` where the
-        interpreter returns ``-0.0``.
+        This was the original wrong answer: `z = 0.0; return -z` inferred
+        ``{0}``, stored as ``uint8_t``, and the emitted C++ returned ``+0.0``
+        where the interpreter returns ``-0.0``.
         """
-        from fpy2.analysis.format_infer.analysis import exact_unop
+        from fpy2.analysis.format_infer.analysis import NEG_ZERO, exact_unop
         import operator
         zero = SetFormat(frozenset((Fraction(0),)))
-        # Not a set -- and, since Phase 4, a *tight* bound rather than a
-        # give-up: the values are kept and only the zero's sign is surrendered.
-        got = exact_unop(zero, operator.neg)
-        assert not isinstance(got, SetFormat)
-        assert got is not None and got.has_neg_zero
+        assert exact_unop(zero, operator.neg) == SetFormat.from_value(NEG_ZERO)
+        # ...and back again.
+        assert exact_unop(SetFormat.from_value(NEG_ZERO), operator.neg) == zero
         # A set with no zero in it negates exactly, as before.
         assert exact_unop(SetFormat(frozenset((Fraction(2),))), operator.neg) \
             == SetFormat(frozenset((Fraction(-2),)))
@@ -1493,39 +1477,39 @@ class TestFormatInfer:
         assert exact_unop(zero, abs) == zero
 
     def test_mul_to_zero_follows_the_ieee_sign_rule(self):
-        """IEEE 754 §6.3: a product's zero sign is the XOR of the operand
-        signs, in every rounding mode.  So the set path can keep ``{0}`` when
-        neither operand is negative, and must widen when one is."""
-        from fpy2.analysis.format_infer.analysis import exact_binop
+        """IEEE 754 §6.3: a product's zero sign is the XOR of the operand signs,
+        in every rounding mode -- so a negative operand and a ``+0.0`` give
+        ``-0.0`` even though neither operand is a signed zero."""
+        from fpy2.analysis.format_infer.analysis import NEG_ZERO, exact_binop
         import operator
         zero = SetFormat(frozenset((Fraction(0),)))
+        nzero = SetFormat.from_value(NEG_ZERO)
         pos = SetFormat(frozenset((Fraction(2),)))
         neg = SetFormat(frozenset((Fraction(-2),)))
         assert exact_binop(zero, pos, operator.mul) == zero
-        for got in (exact_binop(zero, neg, operator.mul),
-                    exact_binop(neg, zero, operator.mul)):
-            assert not isinstance(got, SetFormat)      # may be -0.0
-            assert got is not None and got.has_neg_zero
+        assert exact_binop(zero, neg, operator.mul) == nzero
+        assert exact_binop(neg, zero, operator.mul) == nzero
+        assert exact_binop(nzero, pos, operator.mul) == nzero
+        assert exact_binop(nzero, neg, operator.mul) == zero      # signs agree
 
     def test_add_and_sub_to_zero_follow_the_ieee_sign_rule(self):
-        """An exactly-zero sum of *opposite-signed* operands is ``+0.0`` in
-        every rounding mode except ``roundTowardNegative``.  ``exact_binop``
-        does not know the mode, so it can only keep ``{0}`` where both addends
-        are themselves ``+0.0``.  A difference always has opposite-signed
-        addends (``a - b`` is ``a + (-b)``), so a zero difference always
-        widens -- including ``0 - 0``."""
-        from fpy2.analysis.format_infer.analysis import exact_binop
+        """A sum is ``-0.0`` only when both addends are; ``a - b`` is
+        ``a + (-b)``, which derives every subtraction case without a special
+        rule."""
+        from fpy2.analysis.format_infer.analysis import NEG_ZERO, exact_binop
         import operator
         zero = SetFormat(frozenset((Fraction(0),)))
+        nzero = SetFormat.from_value(NEG_ZERO)
         one = SetFormat(frozenset((Fraction(1),)))
         neg_one = SetFormat(frozenset((Fraction(-1),)))
         assert exact_binop(zero, zero, operator.add) == zero
-        for got in (exact_binop(one, neg_one, operator.add),
-                    exact_binop(one, one, operator.sub),
-                    exact_binop(zero, zero, operator.sub)):
-            assert not isinstance(got, SetFormat)
-            assert got is not None and got.has_neg_zero
-        # A non-zero result is unaffected either way.
+        assert exact_binop(nzero, nzero, operator.add) == nzero
+        assert exact_binop(nzero, zero, operator.add) == zero
+        assert exact_binop(one, neg_one, operator.add) == zero
+        assert exact_binop(nzero, zero, operator.sub) == nzero
+        assert exact_binop(zero, zero, operator.sub) == zero
+        assert exact_binop(nzero, nzero, operator.sub) == zero
+        assert exact_binop(one, one, operator.sub) == zero
         assert exact_binop(one, one, operator.add) \
             == SetFormat(frozenset((Fraction(2),)))
 
@@ -1551,13 +1535,16 @@ class TestFormatInfer:
         assert isinstance(acc, SetFormat), acc
         assert Fraction(0) in acc.values, acc
 
-    def test_a_negative_zero_free_variable_gets_no_set_bound(self):
-        """A captured ``-0.0`` is finite, so the old code gave it
-        ``SetFormat({0})`` via ``as_rational`` -- same lie as the literal."""
-        from fpy2.analysis.format_infer.analysis import _free_var_format
+    def test_a_negative_zero_free_variable_keeps_its_sign(self):
+        """A captured ``-0.0`` is statable, so it gets a set like any capture.
+
+        The old code handed it ``SetFormat({0})`` via ``as_rational``, which said
+        it was ``+0.0``."""
+        from fpy2.analysis.format_infer.analysis import NEG_ZERO, _free_var_format
         from fpy2.number import Float
-        assert _free_var_format(Float(s=True, exp=0, c=0)) is None
-        # A `+0.0` capture is exactly the integer 0 and keeps its singleton.
+        assert _free_var_format(Float(s=True, exp=0, c=0)) \
+            == SetFormat.from_value(NEG_ZERO)
+        # A `+0.0` capture is exactly the integer 0 and keeps its `Fraction`.
         assert _free_var_format(Float(s=False, exp=0, c=0)) \
             == SetFormat(frozenset((Fraction(0),)))
 

--- a/tests/unit/backend/cpp/test_emit_context.py
+++ b/tests/unit/backend/cpp/test_emit_context.py
@@ -315,27 +315,28 @@ class TestRealScopeLosslessWidening:
     def test_mixed_storage_widens_through_wider_ctx(self):
         """``with fp.REAL:`` over mixed-storage operands.
 
-        ``round(0.01)`` infers to an ``FP32`` bound (storage
-        ``float``) and ``round(0.0)`` infers to ``SetFormat({0})``
-        (storage ``uint8_t``).  The exact product is ``{0}`` so the
-        result also stores as ``uint8_t``, but the multiplication
-        itself can't run at ``uint8_t`` width (``float`` doesn't
-        losslessly downcast to ``uint8_t``).  The widening picks the
-        ``(float, float) → float under FP32`` sig, upcasts the
-        ``uint8_t`` operand to ``float``, then downcasts the product
-        back to ``uint8_t`` — sound because ``{0}`` fits losslessly.
+        ``round(0.01)`` infers to an ``FP32`` bound (storage ``float``);
+        ``round(0.0)`` infers to ``SetFormat({0})`` (storage ``uint8_t``).  The
+        multiplication cannot run at ``uint8_t`` width, so the widening picks
+        the ``(float, float) → float under FP32`` sig and upcasts the zero
+        operand.
+
+        The *result* is ``float``, not ``uint8_t``: ``F * {0}`` no longer infers
+        ``{0}``, because IEEE 754 makes that product ``-0.0`` for a negative
+        multiplicand and NaN for an infinite one, and neither is a value a
+        ``Fraction`` set can state.  See ``format_infer._zero_result_is_positive``.  A
+        ``uint8_t`` result was the old, unsound answer -- it is what made
+        ``0.0 * inf`` compile to ``static_cast<uint8_t>(NaN)``.
         """
         @fp.fpy(ctx=fp.FP32)
         def f() -> fp.Real:
             return fp.round(0.01) * fp.round(0.0) + fp.round(0.0)
 
         out = CppCompiler().compile(f, ctx=fp.FP32)
-        # Result format is ``SetFormat({0})`` → ``uint8_t`` storage.
-        assert 'uint8_t f(' in out
-        # The widening upcasts the zero operand to ``float`` for the
-        # multiplication, then casts the product back to ``uint8_t``.
+        assert 'float f(' in out
+        assert 'uint8_t' not in out, out
+        # The widening still upcasts the narrow zero operand for the product.
         assert 'static_cast<float>(' in out
-        assert 'static_cast<uint8_t>(' in out
 
     def test_sint8_mul_widens_to_int16(self):
         """Exact product of two ``SINT8`` operands fits in

--- a/tests/unit/backend/cpp/test_emit_context.py
+++ b/tests/unit/backend/cpp/test_emit_context.py
@@ -323,10 +323,10 @@ class TestRealScopeLosslessWidening:
 
         The *result* is ``float``, not ``uint8_t``: ``F * {0}`` no longer infers
         ``{0}``, because IEEE 754 makes that product ``-0.0`` for a negative
-        multiplicand and NaN for an infinite one, and neither is a value a
-        ``Fraction`` set can state.  See ``format_infer._zero_result_is_positive``.  A
-        ``uint8_t`` result was the old, unsound answer -- it is what made
-        ``0.0 * inf`` compile to ``static_cast<uint8_t>(NaN)``.
+        multiplicand and NaN for an infinite one -- and a ``Format`` operand
+        cannot rule either out.  A ``uint8_t`` result was the old, unsound
+        answer: it is what made ``0.0 * inf`` compile to
+        ``static_cast<uint8_t>(NaN)``.
         """
         @fp.fpy(ctx=fp.FP32)
         def f() -> fp.Real:

--- a/tests/unit/backend/cpp/test_storage.py
+++ b/tests/unit/backend/cpp/test_storage.py
@@ -68,6 +68,40 @@ class TestStorageScalar:
         unbounded_int = MPFixedFormat(nmin=-1)
         assert choose_storage_scalar(unbounded_int) == CppScalar.S64
 
+    def test_unbounded_integer_fallback_still_checks_special_values(self):
+        """The ``S64`` fallback ignores the *magnitude* bound, not the rest.
+
+        Regression: it ran after the ladder search and re-checked nothing, so a
+        bound the ladder had just rejected could still land in ``int64_t``.
+        ``int64_t`` holds no NaN, no infinity and no signed zero, and an
+        ``MPFixedFormat`` can carry any of the three.
+        """
+        from fpy2.number.context.mp_fixed import MPFixedFormat
+        for kwargs in ({'enable_nan': True}, {'enable_inf': True}):
+            fmt = MPFixedFormat(nmin=-1, **kwargs)
+            with pytest.raises(StorageSelectionError):
+                choose_storage_scalar(fmt)
+        # ...while a plain unbounded integer still takes the fallback.
+        assert choose_storage_scalar(MPFixedFormat(nmin=-1)) == CppScalar.S64
+
+    def test_an_unbounded_integers_signed_zero_is_not_seen_here(self):
+        """``enable_neg_zero`` is the one flag this guard cannot act on.
+
+        Not because the guard is wrong, but because
+        ``AbstractFormat.from_format`` declines to believe an ``MPFixedFormat``
+        about its signed zero -- so the flag is already gone by the time storage
+        selection runs.  See the ``TODO`` there and
+        ``docs/todos/reals-in-integer-storage.md``: this is what lets ``-x`` on an
+        ``INTEGER`` parameter return ``0`` where the interpreter returns ``-0.0``.
+
+        Pinned so that lifting the carve-out shows up here as a change in
+        behaviour rather than passing unnoticed.
+        """
+        from fpy2.number.context.mp_fixed import MPFixedFormat
+        fmt = MPFixedFormat(nmin=-1, enable_neg_zero=True)
+        assert fmt.representable_in(fp.RealFloat(s=True, exp=0, c=0))
+        assert choose_storage_scalar(fmt) == CppScalar.S64
+
     def test_a_signed_zero_bound_does_not_narrow_to_an_integer(self):
         """A bound carrying a ``-0.0`` selects a float, not an integer.
 

--- a/tests/unit/backend/cpp/test_storage.py
+++ b/tests/unit/backend/cpp/test_storage.py
@@ -68,6 +68,41 @@ class TestStorageScalar:
         unbounded_int = MPFixedFormat(nmin=-1)
         assert choose_storage_scalar(unbounded_int) == CppScalar.S64
 
+    def test_a_signed_zero_bound_does_not_narrow_to_an_integer(self):
+        """A bound carrying a ``-0.0`` selects a float, not an integer.
+
+        The ladder is built by abstracting each C++ type's own ``Format``, so
+        the integer rungs report ``has_neg_zero=False`` and containment rejects
+        them.  Without that, the narrowest type containing "a zero" is
+        ``uint8_t``, which holds the integer 0 and neither sign — the mechanism
+        behind every signed-zero wrong answer in
+        ``docs/todos/reals-in-integer-storage.md``.
+        """
+        from fpy2.analysis.format_infer.format import AbstractFormat
+        pz = fp.RealFloat(s=False, exp=0, c=0)
+        nz = fp.RealFloat(s=True, exp=0, c=0)
+        neg = AbstractFormat(1, 0, pz, neg_bound=nz, has_neg_zero=True)
+        assert choose_storage_scalar(neg.format()) == CppScalar.F32
+
+    def test_a_range_counter_keeps_an_integer_storage(self):
+        """The shape ``_range_counter_scalar`` builds, via ``.format()``.
+
+        A counter is an integer and never a ``-0.0``, but it reaches the ladder
+        as a materialized fixed-point format — and no ``Format`` can say "no
+        negative zero".  Only the carve-out in ``AbstractFormat.from_format``
+        keeps this an integer; without it every loop counter becomes ``float``.
+        """
+        from fpy2.analysis.format_infer.format import AbstractFormat
+        counter = AbstractFormat(float('inf'), 0, fp.RealFloat.from_int(10))
+        assert choose_storage_scalar(counter.format()) == CppScalar.S8
+
+    def test_a_positive_zero_bound_still_narrows(self):
+        """The counterweight: ``+0.0`` is exactly the integer 0, so the
+        value-narrowing this backend relies on is untouched.  A blanket "no
+        zero narrows" rule would cost the ~20% of corpus list element types
+        that are value-narrowed."""
+        assert choose_storage(SetFormat(frozenset((Fraction(0),)))) == CppScalar.U8
+
 
 class TestStorageStructural:
     """``choose_storage`` recurses through TupleFormat / ListFormat."""

--- a/tests/unit/backend/cpp/test_storage.py
+++ b/tests/unit/backend/cpp/test_storage.py
@@ -85,16 +85,27 @@ class TestStorageScalar:
         assert choose_storage_scalar(neg.format()) == CppScalar.F32
 
     def test_a_range_counter_keeps_an_integer_storage(self):
-        """The shape ``_range_counter_scalar`` builds, via ``.format()``.
+        """The shape ``_range_counter_scalar`` builds, reaching the ladder via
+        ``.format()``.
 
-        A counter is an integer and never a ``-0.0``, but it reaches the ladder
-        as a materialized fixed-point format — and no ``Format`` can say "no
-        negative zero".  Only the carve-out in ``AbstractFormat.from_format``
-        keeps this an integer; without it every loop counter becomes ``float``.
+        A counter is an integer and never a ``-0.0``.  It only stays an integer
+        because ``enable_neg_zero`` lets the materialized format say so; without
+        it every loop counter becomes ``float``.
         """
         from fpy2.analysis.format_infer.format import AbstractFormat
         counter = AbstractFormat(float('inf'), 0, fp.RealFloat.from_int(10))
         assert choose_storage_scalar(counter.format()) == CppScalar.S8
+
+    def test_integer_arithmetic_keeps_an_integer_storage(self):
+        """``int8 + int8`` is ``int16_t``, not ``float``.
+
+        The sum has a finite precision, so it materializes as a *float*-shaped
+        format on the way to the ladder — and a float format admits a negative
+        zero unless ``enable_neg_zero`` says otherwise.
+        """
+        from fpy2.analysis.format_infer.format import AbstractFormat
+        a = AbstractFormat.from_format(fp.SINT8.format())
+        assert choose_storage_scalar((a + a).format()) == CppScalar.S16
 
     def test_a_positive_zero_bound_still_narrows(self):
         """The counterweight: ``+0.0`` is exactly the integer 0, so the


### PR DESCRIPTION
Updates the format inference algorithm.
- encode negative zero in formats
- join on `IndexedAssign` since that may require widening